### PR TITLE
Stop shipping Windows release binaries

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -65,10 +65,6 @@ jobs:
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
-          - os: windows-latest
-            goos: windows
-            goarch: amd64
-            suffix: windows-amd64.exe
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,6 @@ jobs:
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
-          - os: windows-latest
-            goos: windows
-            goarch: amd64
-            suffix: windows-amd64.exe
 
     steps:
       - name: Checkout code

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -66,10 +66,6 @@ const platforms = [
     darkLogo: '/platforms/macos-dark.svg'
   },
   {
-    name: 'Windows',
-    logo: '/platforms/windows.svg'
-  },
-  {
     name: 'Kubernetes',
     logo: '/platforms/kubernetes.svg'
   },


### PR DESCRIPTION
## Summary
- Remove the `windows-latest` matrix arm from release and beta-release workflows so we no longer build or publish `astonish-windows-amd64.exe`.
- Drop Windows from the website platforms list so it is not advertised as a supported host OS.
- Unblocks tagged releases that currently fail on Windows because `purego.Dlopen` is Unix-only (codeintel treesitter bindings).

## Test plan
- [ ] Confirm the PR CI is green
- [ ] After merge, re-run or re-tag a release and verify jobs are only linux-amd64, linux-arm64, darwin-amd64, darwin-arm64
- [ ] Confirm the GitHub release assets no longer include a Windows `.exe`