### PR TITLE
Fix treesitter image builds missing libc headers

### DIFF
--- a/docker/sandbox-base/Dockerfile
+++ b/docker/sandbox-base/Dockerfile
@@ -129,6 +129,7 @@ RUN apt-get update && \
         ca-certificates \
         git \
         gcc \
+        libc6-dev \
         make \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/sandbox-openshell/Dockerfile
+++ b/docker/sandbox-openshell/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
         ca-certificates \
         git \
         gcc \
+        libc6-dev \
         make \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/pkg/sandbox/k8s/treesitter_path_contract_test.go
+++ b/pkg/sandbox/k8s/treesitter_path_contract_test.go
@@ -28,6 +28,10 @@ func TestTreeSitterLibraryPathContract(t *testing.T) {
 	if !strings.Contains(dockerfile, wantCopy) {
 		t.Fatalf("sandbox-base Dockerfile must COPY library to %s; missing:\n%s", treeSitterLibPath, wantCopy)
 	}
+	// treesitter-builder needs libc headers; gcc alone on Debian slim is insufficient.
+	if !strings.Contains(dockerfile, "libc6-dev") {
+		t.Fatal("sandbox-base Dockerfile treesitter-builder must apt-install libc6-dev")
+	}
 	// Guard against accidental apt install of ripgrep in the pod image
 	// (invisible after overlay chroot; belongs in @base / OpenShell).
 	if strings.Contains(dockerfile, "\tripgrep") || strings.Contains(dockerfile, " ripgrep \\\n") || strings.Contains(dockerfile, " ripgrep\n") {

--- a/pkg/sandbox/openshell/dockerfile_contract_test.go
+++ b/pkg/sandbox/openshell/dockerfile_contract_test.go
@@ -27,4 +27,8 @@ func TestOpenShellDockerfileIncludesRipgrep(t *testing.T) {
 	if !strings.Contains(content, "ripgrep") {
 		t.Fatalf("%s must install ripgrep for grep_search/find_files", dockerfile)
 	}
+	// treesitter-builder needs libc headers; gcc alone on Debian slim is insufficient.
+	if !strings.Contains(content, "libc6-dev") {
+		t.Fatalf("%s treesitter-builder must apt-install libc6-dev", dockerfile)
+	}
 }


### PR DESCRIPTION
## Summary
- Install `libc6-dev` in the sandbox-base and OpenShell `treesitter-builder` stages so `libastonish-treesitter.so` can compile on Debian slim (gcc alone lacks `stdio.h` / `stdint.h`).
- Lock the dependency with Dockerfile contract tests so it cannot regress.
- Unblocks the failing Docker Images jobs for `v3.1.5` (sandbox-base and OpenShell); Incus already used `build-essential`.

## Test plan
- [x] `go test ./pkg/sandbox/k8s -run TestTreeSitterLibraryPathContract`
- [x] `go test ./pkg/sandbox/openshell -run TestOpenShellDockerfile`
- [x] Local `docker build -f docker/sandbox-base/Dockerfile --target treesitter-builder .`
- [ ] After merge, move `v3.1.5` to the merge commit and confirm sandbox-base + OpenShell image builds succeed