### PR TITLE
Fix CrashLoop: run astonish image on glibc Debian

### DIFF
--- a/docker/astonish/Dockerfile
+++ b/docker/astonish/Dockerfile
@@ -4,23 +4,39 @@
 # This avoids Go 1.26 segfaults when running `go mod download` under QEMU
 # user-mode emulation on Apple Silicon Macs.
 #
+# Base must be glibc (Debian), not Alpine/musl: pkg/codeintel uses purego.Dlopen,
+# which produces a dynamically linked binary needing /lib64/ld-linux-*.so.2.
+#
 # Build (multi-arch, from Makefile):
 #   make push-dev   # cross-compiles both arch binaries, then buildx pushes
 #
 # Build (single-arch, local dev):
 #   make push-dev-fast
 
-FROM alpine:3.19
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install certificates, Node.js (includes npx), Python3, uv (includes uvx), and git
-RUN apk add --no-cache ca-certificates nodejs npm python3 py3-pip git && \
-    pip3 install uv --break-system-packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        nodejs \
+        npm \
+        python3 \
+        python3-pip \
+        git \
+    && pip3 install uv --break-system-packages \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 # Copy the pre-built Linux astonish binary for the target architecture.
 # TARGETARCH is set automatically by docker buildx (amd64 or arm64).
-ARG TARGETARCH=amd64
+# Do not give TARGETARCH a default — BuildKit overrides are ignored when a
+# default is set, which previously shipped an amd64 binary in the arm64 image.
+ARG TARGETARCH
 COPY astonish-linux-${TARGETARCH} /usr/local/bin/astonish
 RUN chmod +x /usr/local/bin/astonish
 

--- a/docker/incus/Dockerfile
+++ b/docker/incus/Dockerfile
@@ -73,8 +73,9 @@ RUN test -x /opt/incus/bin/incusd || { echo "ERROR: incusd not found"; exit 1; }
 
 # Copy the pre-built Linux astonish binary for the target architecture.
 # TARGETARCH is set automatically by docker buildx (amd64 or arm64).
-# For local single-arch builds, default to amd64.
-ARG TARGETARCH=amd64
+# Do not give TARGETARCH a default — BuildKit ignores platform injection when
+# a default is set, which ships the wrong-arch binary in multi-arch images.
+ARG TARGETARCH
 COPY astonish-linux-${TARGETARCH} /usr/local/bin/astonish
 RUN chmod +x /usr/local/bin/astonish
 

--- a/docker/sandbox-openshell/Dockerfile
+++ b/docker/sandbox-openshell/Dockerfile
@@ -56,7 +56,9 @@ LABEL org.opencontainers.image.title="astonish-sandbox-openshell" \
 USER root
 
 # --- Astonish agent binary (cross-compiled on host, see Makefile build-linux) ---
-ARG TARGETARCH=amd64
+# Do not give TARGETARCH a default — BuildKit ignores platform injection when
+# a default is set, which ships the wrong-arch binary in multi-arch images.
+ARG TARGETARCH
 COPY astonish-linux-${TARGETARCH} /usr/local/bin/astonish
 RUN chmod +x /usr/local/bin/astonish
 


### PR DESCRIPTION
## Summary
- Switch `ghcr.io/sap/astonish` from Alpine/musl to `debian:bookworm-slim` so the purego-linked binary can resolve `/lib64/ld-linux-*.so.2` (fixes v3.1.5 api/worker CrashLoop: `exec …: no such file or directory`).
- Remove `ARG TARGETARCH=amd64` defaults in astonish, incus, and OpenShell Dockerfiles so multi-arch builds COPY the correct arch binary.

## Test plan
- [x] Local image build: `astonish -v` runs on the Debian-based image
- [x] Same binary fails on Alpine (missing ld-linux), confirming the root cause
- [x] Multi-arch build shows `COPY astonish-linux-arm64` for `linux/arm64`
- [ ] After merge, retag `v3.1.5` (or cut `v3.1.6`), wait for Docker Images, roll cluster off the v3.1.3 pin