### PR TITLE
Wire OpenShell driver_config for corporate CA trust bundles

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -195,6 +195,25 @@ jobs:
           npm ci
           npm run build
 
+      # Dockerfile COPYs pre-built astonish-linux-${TARGETARCH}; compile on the
+      # runner (same as docker-images.yml) to avoid QEMU Go builds.
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Cross-compile Linux binaries
+        env:
+          VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          touch web/embed.go
+          LDFLAGS="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=${VERSION_TAG}"
+          echo "Building linux/amd64..."
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-amd64 .
+          echo "Building linux/arm64..."
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-arm64 .
+          ls -la astonish-linux-*
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -417,6 +436,23 @@ jobs:
           cd web
           npm ci
           npm run build
+
+      # Dockerfile COPYs astonish-linux-${TARGETARCH}; compile on the runner
+      # (same as docker-images.yml build-sandbox-openshell).
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Cross-compile Linux binaries
+        env:
+          VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          touch web/embed.go
+          LDFLAGS="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=${VERSION_TAG}"
+          echo "Building linux/amd64..."
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-amd64 .
+          ls -la astonish-linux-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/deploy/helm/astonish/Chart.lock
+++ b/deploy/helm/astonish/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: helm-chart
   repository: oci://ghcr.io/nvidia/openshell
-  version: 0.0.63
-digest: sha256:809060cc93e6a529ece1831f78bf228bc51aad8715e76fc7159e15a59c9614cd
-generated: "2026-06-16T20:08:55.379128684-04:00"
+  version: 0.0.86
+digest: sha256:298c34e2d6d116f4d7e9433fd113a63159beff64f87e6e519ccb1dbf031ff618
+generated: "2026-07-19T18:06:33.004657-04:00"

--- a/deploy/helm/astonish/Chart.yaml
+++ b/deploy/helm/astonish/Chart.yaml
@@ -21,8 +21,8 @@ maintainers:
 dependencies:
   - name: helm-chart
     alias: openshell
-    # TODO: Upgrade to 0.0.70 for Landlock ABI v5 PTY fix on kernel 6.10+.
+    # 0.0.86: PVC mounts via driver_config (≥0.0.81) + Landlock ABI v5 PTY (≥0.0.70).
     # Run `helm dependency update` after bumping.
-    version: "0.0.63"
+    version: "0.0.86"
     repository: "oci://ghcr.io/nvidia/openshell"
     condition: sandbox.openshell.enabled

--- a/deploy/helm/astonish/templates/configmap.yaml
+++ b/deploy/helm/astonish/templates/configmap.yaml
@@ -127,6 +127,23 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{- with .Values.sandbox.openshell.certBundles }}
+        cert_bundles:
+          {{- range . }}
+          - name: {{ .name | quote }}
+            claim_name: {{ .claimName | quote }}
+            mount_path: {{ .mountPath | quote }}
+            {{- if .subPath }}
+            sub_path: {{ .subPath | quote }}
+            {{- end }}
+            {{- with .trustEnv }}
+            trust_env:
+              {{- range . }}
+              - {{ . | quote }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.sandbox.openshell.idleTimeoutMinutes }}
         idle_timeout_minutes: {{ .Values.sandbox.openshell.idleTimeoutMinutes }}
         {{- end }}

--- a/deploy/helm/astonish/templates/openshell/cert-bundle-bootstrap-job.yaml
+++ b/deploy/helm/astonish/templates/openshell/cert-bundle-bootstrap-job.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.openshell.enabled .Values.sandbox.openshell.certBundles }}
+{{- range $i, $bundle := .Values.sandbox.openshell.certBundles }}
+{{- if and $bundle.bootstrap $bundle.bootstrap.enabled $bundle.bootstrap.url $bundle.claimName }}
+{{- $subPath := default "ca-bundle.crt" $bundle.subPath }}
+{{- $image := default "debian:bookworm-slim" $bundle.bootstrap.image }}
+---
+# One-shot Helm hook: download a corporate CA and write a combined PEM
+# (system CAs + downloaded cert) onto the cert-bundle PVC.
+#
+# hook-delete-policy matches sandbox seed-job: replace on each upgrade,
+# clean up after success.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "astonish.fullname" $ }}-cert-bundle-{{ $bundle.name }}
+  namespace: {{ include "astonish.namespace.sandbox" $ }}
+  labels:
+    {{- include "astonish.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: cert-bundle-bootstrap
+    astonish.io/cert-bundle: {{ $bundle.name | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "astonish.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: cert-bundle-bootstrap
+        astonish.io/cert-bundle: {{ $bundle.name | quote }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: {{ $image | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends ca-certificates curl
+              DEST="/bundle/{{ $subPath }}"
+              echo "astonish-cert-bundle: downloading CA from configured URL"
+              curl -fsSL -o /tmp/org-ca.crt "{{ $bundle.bootstrap.url }}"
+              # Combined bundle: system trust store + org CA (SSL_CERT_FILE replaces
+              # the system store — a corp-only PEM would break public HTTPS).
+              cat /etc/ssl/certs/ca-certificates.crt /tmp/org-ca.crt > "$DEST"
+              chmod 644 "$DEST"
+              echo "astonish-cert-bundle: wrote $DEST ($(wc -c < "$DEST") bytes)"
+          volumeMounts:
+            - name: bundle
+              mountPath: /bundle
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: bundle
+          persistentVolumeClaim:
+            claimName: {{ $bundle.claimName | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/astonish/templates/openshell/cert-bundle-pvc.yaml
+++ b/deploy/helm/astonish/templates/openshell/cert-bundle-pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.openshell.enabled .Values.sandbox.openshell.certBundles }}
+{{- range .Values.sandbox.openshell.certBundles }}
+{{- if and .bootstrap .bootstrap.enabled .claimName }}
+---
+# Cert-bundle PVC for OpenShell sandbox trust mounts (driver_config).
+# Populated by the matching cert-bundle-bootstrap Job when bootstrap.enabled.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .claimName | quote }}
+  namespace: {{ include "astonish.namespace.sandbox" $ }}
+  labels:
+    {{- include "astonish.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: cert-bundle
+    astonish.io/cert-bundle: {{ .name | quote }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ default $.Values.sandbox.storage.storageClassName .bootstrap.storageClassName | quote }}
+  resources:
+    requests:
+      storage: {{ default "64Mi" .bootstrap.size | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/astonish/values.yaml
+++ b/deploy/helm/astonish/values.yaml
@@ -329,22 +329,33 @@ sandbox:
       #   - /dev/fuse
 
     # Corporate CA / trust bundles mounted into every sandbox via OpenShell
-    # driver_config (Kubernetes PVC mounts). Each entry references an existing
-    # PVC in the sandbox namespace that holds a *combined* PEM (system CAs +
-    # corporate roots). Mount paths must not be under /sandbox or
-    # /etc/openshell{,-tls}. Trust env vars default to SSL_CERT_FILE,
-    # CURL_CA_BUNDLE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS, GIT_SSL_CAINFO.
+    # driver_config (Kubernetes PVC mounts). Empty = no mounts (default).
+    # Each entry's PVC holds a *combined* PEM (system CAs + corporate roots).
+    # Mount paths must not be under /sandbox or /etc/openshell{,-tls}.
+    # Trust env vars default to SSL_CERT_FILE, CURL_CA_BUNDLE,
+    # REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS, GIT_SSL_CAINFO.
+    #
+    # Optional per-entry bootstrap: chart creates the PVC and a post-install
+    # Job that downloads bootstrap.url, appends it to the system CA bundle,
+    # and writes subPath (default ca-bundle.crt) onto the PVC. Orgs can also
+    # pre-provision the PVC and omit bootstrap.
+    #
+    # NOTE: RWO PVCs can only attach to one node. Prefer RWX/ROX when sandboxes
+    # schedule across multiple nodes, or pin sandboxes to a single node.
     certBundles: []
-    # Example:
+    # Example (chart-managed bootstrap):
     # certBundles:
     #   - name: corp-root-ca
     #     claimName: astonish-corp-ca
     #     mountPath: /etc/astonish-ca/ca-bundle.crt
     #     subPath: ca-bundle.crt
-    #     # trustEnv: []  # use defaults, or override:
-    #     # trustEnv:
-    #     #   - SSL_CERT_FILE
-    #     #   - NODE_EXTRA_CA_CERTS
+    #     # trustEnv: []  # use defaults, or override
+    #     bootstrap:
+    #       enabled: true
+    #       url: "https://pki.example.com/corp-root-ca.crt"
+    #       size: 64Mi
+    #       storageClassName: ""  # empty = sandbox.storage.storageClassName
+    #       image: "debian:bookworm-slim"
 
     # Idle timeout (minutes) before the watchdog evicts an unused sandbox pod.
     # 0 = disable idle eviction (pods run indefinitely).

--- a/deploy/helm/astonish/values.yaml
+++ b/deploy/helm/astonish/values.yaml
@@ -328,6 +328,24 @@ sandbox:
       #   - /mnt/scratch
       #   - /dev/fuse
 
+    # Corporate CA / trust bundles mounted into every sandbox via OpenShell
+    # driver_config (Kubernetes PVC mounts). Each entry references an existing
+    # PVC in the sandbox namespace that holds a *combined* PEM (system CAs +
+    # corporate roots). Mount paths must not be under /sandbox or
+    # /etc/openshell{,-tls}. Trust env vars default to SSL_CERT_FILE,
+    # CURL_CA_BUNDLE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS, GIT_SSL_CAINFO.
+    certBundles: []
+    # Example:
+    # certBundles:
+    #   - name: corp-root-ca
+    #     claimName: astonish-corp-ca
+    #     mountPath: /etc/astonish-ca/ca-bundle.crt
+    #     subPath: ca-bundle.crt
+    #     # trustEnv: []  # use defaults, or override:
+    #     # trustEnv:
+    #     #   - SSL_CERT_FILE
+    #     #   - NODE_EXTRA_CA_CERTS
+
     # Idle timeout (minutes) before the watchdog evicts an unused sandbox pod.
     # 0 = disable idle eviction (pods run indefinitely).
     # Evicted sessions are transparently recreated on next tool call (~5-10s).

--- a/docs/architecture/openshell-sandbox-backend.md
+++ b/docs/architecture/openshell-sandbox-backend.md
@@ -509,13 +509,14 @@ openshell:
 
 ```go
 type SandboxOpenShellConfig struct {
-    GatewayAddr    string `yaml:"gateway_addr" json:"gateway_addr"`
-    GatewayTLS     bool   `yaml:"gateway_tls" json:"gateway_tls"`
-    ClientCertPath string `yaml:"client_cert_path,omitempty" json:"client_cert_path,omitempty"`
-    ClientKeyPath  string `yaml:"client_key_path,omitempty" json:"client_key_path,omitempty"`
-    CACertPath     string `yaml:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"`
-    AuthToken      string `yaml:"auth_token,omitempty" json:"auth_token,omitempty"`
-    SandboxImage   string `yaml:"sandbox_image,omitempty" json:"sandbox_image,omitempty"`
+    GatewayAddr    string             `yaml:"gateway_addr" json:"gateway_addr"`
+    GatewayTLS     bool               `yaml:"gateway_tls" json:"gateway_tls"`
+    ClientCertPath string             `yaml:"client_cert_path,omitempty"`
+    ClientKeyPath  string             `yaml:"client_key_path,omitempty"`
+    CACertPath     string             `yaml:"ca_cert_path,omitempty"`
+    AuthToken      string             `yaml:"auth_token,omitempty"`
+    SandboxImage   string             `yaml:"sandbox_image,omitempty"`
+    CertBundles    []CertBundleConfig `yaml:"cert_bundles,omitempty"` // PVC mounts via driver_config
 }
 ```
 
@@ -624,17 +625,21 @@ type FilesystemSpec struct {
 }
 
 type CreateSandboxRequest struct {
-    Name   string
-    Image  string
-    Env    map[string]string
-    Labels map[string]string
-    Policy *SandboxPolicySpec
+    Name         string
+    Image        string
+    Env          map[string]string
+    Labels       map[string]string
+    Policy       *SandboxPolicySpec
+    DriverConfig map[string]any // OpenShell driver-keyed envelope
 }
 ```
 
 The `mapPolicyToProto()` helper in `client_grpc.go` converts these
 domain types to the protobuf `SandboxPolicy` message before sending
-to the gateway.
+to the gateway. When `DriverConfig` is set, it is encoded as
+`SandboxTemplate.driver_config` (`google.protobuf.Struct`). Platform
+`cert_bundles` config renders into the Kubernetes driver's PVC mount
+schema and trust env vars — see `pkg/sandbox/openshell/driver_config.go`.
 
 ---
 
@@ -647,6 +652,7 @@ to the gateway.
 | `pkg/sandbox/openshell/exec.go` | Exec with `wrapCommand()` for WorkDir/Env |
 | `pkg/sandbox/openshell/fleet.go` | Fleet/pool management, CreateSandbox with policy |
 | `pkg/sandbox/openshell/policy.go` | `defaultSandboxPolicy()` — Landlock filesystem rules |
+| `pkg/sandbox/openshell/driver_config.go` | CertBundles → K8s `driver_config` PVC mounts + trust env |
 | `pkg/sandbox/openshell/gateway_client.go` | GatewayClient interface, domain types (SandboxPolicySpec, etc.) |
 | `pkg/sandbox/openshell/client_grpc.go` | Real gRPC implementation, `mapPolicyToProto()` |
 | `pkg/sandbox/openshell/client_grpc_test.go` | Policy mapping tests |

--- a/docs/architecture/openshell-sandbox-backend.md
+++ b/docs/architecture/openshell-sandbox-backend.md
@@ -69,9 +69,9 @@ graph TB
 
 | Component | Image / Artifact | Purpose |
 |-----------|-----------------|---------|
-| **Gateway** | `ghcr.io/nvidia/openshell/gateway:0.0.63` | Sandbox lifecycle, exec relay, policy distribution |
-| **Supervisor** | `ghcr.io/nvidia/openshell/supervisor:0.0.63` | PID 1 inside sandboxes, Landlock/seccomp enforcement (≥0.0.70 recommended for kernel 6.10+ PTY fix) |
-| **Helm Chart** | `oci://ghcr.io/nvidia/openshell/helm-chart:0.0.63` | Deploys gateway + RBAC (subchart of Astonish) |
+| **Gateway** | `ghcr.io/nvidia/openshell/gateway:0.0.86` | Sandbox lifecycle, exec relay, policy distribution |
+| **Supervisor** | `ghcr.io/nvidia/openshell/supervisor:0.0.86` | PID 1 inside sandboxes, Landlock/seccomp enforcement |
+| **Helm Chart** | `oci://ghcr.io/nvidia/openshell/helm-chart:0.0.86` | Deploys gateway + RBAC (subchart of Astonish); ≥0.0.81 required for cert-bundle PVC mounts via `driver_config` |
 
 #### Astonish Provides
 

--- a/docs/website/docs/deployment/openshell.md
+++ b/docs/website/docs/deployment/openshell.md
@@ -428,6 +428,36 @@ sandbox:
         - /mnt/scratch
 ```
 
+### Corporate CA / Trust Bundles (`driver_config`)
+
+To trust internal HTTPS endpoints without rebuilding the sandbox image,
+mount a combined CA bundle (system CAs + corporate roots) via OpenShell
+`driver_config` PVC mounts:
+
+1. Create a PVC in the **sandbox** namespace that contains the combined PEM
+   (for example at path `ca-bundle.crt` inside the volume).
+2. Reference it from Helm values:
+
+```yaml
+sandbox:
+  openshell:
+    certBundles:
+      - name: corp-root-ca
+        claimName: astonish-corp-ca
+        mountPath: /etc/astonish-ca/ca-bundle.crt
+        subPath: ca-bundle.crt
+```
+
+Astonish mounts the PVC read-only into every sandbox, sets trust env vars
+(`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`,
+`NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`) to the mount path, and adds the
+path to the Landlock read-only set.
+
+Mount paths must not be under `/sandbox` (workspace) or
+`/etc/openshell` / `/etc/openshell-tls` (OpenShell-managed). Use a
+*combined* bundle — `SSL_CERT_FILE` replaces the system store, so a
+corp-only PEM would break public HTTPS.
+
 **Landlock enforcement mode:**
 
 ```yaml

--- a/docs/website/docs/deployment/openshell.md
+++ b/docs/website/docs/deployment/openshell.md
@@ -430,13 +430,17 @@ sandbox:
 
 ### Corporate CA / Trust Bundles (`driver_config`)
 
+Requires the OpenShell gateway **≥ 0.0.81** (Astonish chart pins **0.0.86**).
+Older gateways reject `containers.agent.volume_mounts` in `driver_config`.
+
 To trust internal HTTPS endpoints without rebuilding the sandbox image,
 mount a combined CA bundle (system CAs + corporate roots) via OpenShell
-`driver_config` PVC mounts:
+`driver_config` PVC mounts. Configure only through Helm values — leave
+`certBundles` empty (default) for no mounts.
 
-1. Create a PVC in the **sandbox** namespace that contains the combined PEM
-   (for example at path `ca-bundle.crt` inside the volume).
-2. Reference it from Helm values:
+**Chart-managed bootstrap** (recommended): Helm creates the PVC and a
+post-install/upgrade Job that downloads your org CA URL, appends it to
+the Debian system trust store, and writes the combined PEM onto the PVC.
 
 ```yaml
 sandbox:
@@ -446,7 +450,12 @@ sandbox:
         claimName: astonish-corp-ca
         mountPath: /etc/astonish-ca/ca-bundle.crt
         subPath: ca-bundle.crt
+        bootstrap:
+          enabled: true
+          url: "https://pki.example.com/corp-root-ca.crt"
 ```
+
+Or pre-provision the PVC yourself and omit `bootstrap`.
 
 Astonish mounts the PVC read-only into every sandbox, sets trust env vars
 (`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`,
@@ -457,6 +466,9 @@ Mount paths must not be under `/sandbox` (workspace) or
 `/etc/openshell` / `/etc/openshell-tls` (OpenShell-managed). Use a
 *combined* bundle — `SSL_CERT_FILE` replaces the system store, so a
 corp-only PEM would break public HTTPS.
+
+On RWO StorageClasses (e.g. Cinder), the cert PVC can attach to only one
+node; use RWX/ROX or pin sandboxes when scheduling across multiple nodes.
 
 **Landlock enforcement mode:**
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -137,11 +137,40 @@ type SandboxOpenShellConfig struct {
 	// nodes or operator-specific mount points without modifying code.
 	FilesystemPolicy FilesystemPolicyConfig `yaml:"filesystem_policy,omitempty" json:"filesystem_policy,omitempty"`
 
+	// CertBundles mounts operator-provided CA trust material into every
+	// OpenShell sandbox via driver_config PVC mounts, and sets standard
+	// trust env vars (SSL_CERT_FILE, etc.) to the mounted bundle path.
+	// Each bundle must already exist as a PVC in the sandbox namespace and
+	// should contain a combined PEM (system CAs + corporate roots).
+	CertBundles []CertBundleConfig `yaml:"cert_bundles,omitempty" json:"cert_bundles,omitempty"`
+
 	// IdleTimeoutMinutes evicts sandbox pods that have had no exec activity
 	// for this duration. The pod is deleted (state → evicted) and recreated
 	// transparently on the next tool call. Default: 240 (4 hours). Set to
 	// -1 to disable idle eviction entirely.
 	IdleTimeoutMinutes *int `yaml:"idle_timeout_minutes,omitempty" json:"idle_timeout_minutes,omitempty"`
+}
+
+// CertBundleConfig describes a read-only CA bundle mounted into OpenShell
+// sandboxes via the Kubernetes driver's driver_config PVC mount schema.
+type CertBundleConfig struct {
+	// Name is the Kubernetes volume name (DNS-1123 label), e.g. "corp-root-ca".
+	Name string `yaml:"name" json:"name"`
+
+	// ClaimName is the existing PVC name in the sandbox namespace.
+	ClaimName string `yaml:"claim_name" json:"claim_name"`
+
+	// MountPath is the absolute path inside the sandbox where the bundle
+	// is mounted, e.g. "/etc/astonish-ca/ca-bundle.crt".
+	MountPath string `yaml:"mount_path" json:"mount_path"`
+
+	// SubPath is an optional PVC subpath (relative file within the claim).
+	SubPath string `yaml:"sub_path,omitempty" json:"sub_path,omitempty"`
+
+	// TrustEnv lists env var names set to MountPath. When empty, defaults to
+	// SSL_CERT_FILE, CURL_CA_BUNDLE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS,
+	// and GIT_SSL_CAINFO.
+	TrustEnv []string `yaml:"trust_env,omitempty" json:"trust_env,omitempty"`
 }
 
 // RegistryConfig holds OCI registry connection details for pushing

--- a/pkg/sandbox/AGENTS.md
+++ b/pkg/sandbox/AGENTS.md
@@ -50,7 +50,7 @@ If you add a backend, run the contract suite against it in CI. If you change the
 
 ## Session provisioning (per backend)
 - **Incus**: `EnsureOrgSessionContainer` composes overlay layers, ensures a `@base` snapshot, creates a per-session container. `WaitForSessionReady` polls `IsRunning`. Templates are content-addressed via `hashSnapshotRootfs`.
-- **OpenShell**: `Gateway.CreateSandbox` provisions a pod; the in-pod supervisor opens `ConnectSupervisor`; exec/push/pull go through `ExecSandbox` / `ExecSandboxInteractive`. Evicted sandboxes are auto-resumed by `ensureSessionRunning`.
+- **OpenShell**: `Gateway.CreateSandbox` provisions a pod; the in-pod supervisor opens `ConnectSupervisor`; exec/push/pull go through `ExecSandbox` / `ExecSandboxInteractive`. Evicted sandboxes are auto-resumed by `ensureSessionRunning`. Platform `cert_bundles` render into `SandboxTemplate.driver_config` (K8s PVC mounts) plus trust env vars — see `pkg/sandbox/openshell/driver_config.go`.
 - **K8s (direct, without OpenShell)**: `pkg/sandbox/k8s` — image pull policy is `Always` for mutable tags (`latest`, `dev`) and `IfNotPresent` for pinned digests. Enforces per-org/team labels and `NetworkPolicy`.
 - **Mock**: in-memory, used by unit tests; supports injection hooks.
 

--- a/pkg/sandbox/openshell/client_grpc.go
+++ b/pkg/sandbox/openshell/client_grpc.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // GRPCClientConfig configures the gRPC gateway client connection.
@@ -162,6 +163,13 @@ func (c *grpcGatewayClient) CreateSandbox(ctx context.Context, req CreateSandbox
 		Image:       req.Image,
 		Environment: req.Env,
 		Labels:      req.Labels,
+	}
+	if len(req.DriverConfig) > 0 {
+		ds, err := structpb.NewStruct(req.DriverConfig)
+		if err != nil {
+			return nil, fmt.Errorf("gateway CreateSandbox: encode driver_config: %w", err)
+		}
+		template.DriverConfig = ds
 	}
 
 	pbReq := &pb.CreateSandboxRequest{

--- a/pkg/sandbox/openshell/client_grpc_test.go
+++ b/pkg/sandbox/openshell/client_grpc_test.go
@@ -253,6 +253,81 @@ func TestGRPCClient_CreateSandbox_NilPolicy(t *testing.T) {
 	}
 }
 
+func TestGRPCClient_CreateSandbox_WithDriverConfig(t *testing.T) {
+	var capturedReq *pb.CreateSandboxRequest
+	srv := &fakeOpenShellServer{
+		createSandboxFn: func(req *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
+			capturedReq = req
+			return &pb.SandboxResponse{
+				Sandbox: &pb.Sandbox{
+					Metadata: &pb.ObjectMeta{Id: "sb-dc", Name: req.GetName()},
+					Status:   &pb.SandboxStatus{Phase: pb.SandboxPhase_SANDBOX_PHASE_PROVISIONING, AgentPod: "pod-dc"},
+				},
+			}, nil
+		},
+	}
+	client, cleanup := startFakeServer(t, srv)
+	defer cleanup()
+
+	_, err := client.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Name:  "driver-config-sandbox",
+		Image: "ubuntu:24.04",
+		DriverConfig: map[string]any{
+			"kubernetes": map[string]any{
+				"volumes": []any{
+					map[string]any{
+						"name": "corp-root-ca",
+						"persistent_volume_claim": map[string]any{
+							"claim_name": "astonish-corp-ca",
+							"read_only":  true,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox error: %v", err)
+	}
+	dc := capturedReq.GetSpec().GetTemplate().GetDriverConfig()
+	if dc == nil {
+		t.Fatal("expected DriverConfig on SandboxTemplate")
+	}
+	fields := dc.GetFields()
+	k8s, ok := fields["kubernetes"]
+	if !ok || k8s.GetStructValue() == nil {
+		t.Fatalf("kubernetes block missing: %#v", fields)
+	}
+}
+
+func TestGRPCClient_CreateSandbox_EmptyDriverConfigUnset(t *testing.T) {
+	var capturedReq *pb.CreateSandboxRequest
+	srv := &fakeOpenShellServer{
+		createSandboxFn: func(req *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
+			capturedReq = req
+			return &pb.SandboxResponse{
+				Sandbox: &pb.Sandbox{
+					Metadata: &pb.ObjectMeta{Id: "sb-nodc", Name: req.GetName()},
+					Status:   &pb.SandboxStatus{Phase: pb.SandboxPhase_SANDBOX_PHASE_PROVISIONING, AgentPod: "pod-nodc"},
+				},
+			}, nil
+		},
+	}
+	client, cleanup := startFakeServer(t, srv)
+	defer cleanup()
+
+	_, err := client.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Name:  "no-driver-config",
+		Image: "ubuntu:24.04",
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox error: %v", err)
+	}
+	if capturedReq.GetSpec().GetTemplate().GetDriverConfig() != nil {
+		t.Error("expected DriverConfig unset when empty")
+	}
+}
+
 func TestGRPCClient_CreateSandbox_WithNetworkPolicy(t *testing.T) {
 	var capturedReq *pb.CreateSandboxRequest
 	srv := &fakeOpenShellServer{

--- a/pkg/sandbox/openshell/driver_config.go
+++ b/pkg/sandbox/openshell/driver_config.go
@@ -1,0 +1,154 @@
+package openshell
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/SAP/astonish/pkg/config"
+)
+
+// defaultTrustEnvVars are set to each cert bundle MountPath when TrustEnv
+// is empty. SSL_CERT_FILE (and peers) replace the system store — operators
+// must place a *combined* PEM (system CAs + corporate roots) in the PVC.
+var defaultTrustEnvVars = []string{
+	"SSL_CERT_FILE",
+	"CURL_CA_BUNDLE",
+	"REQUESTS_CA_BUNDLE",
+	"NODE_EXTRA_CA_CERTS",
+	"GIT_SSL_CAINFO",
+}
+
+// protectedMountPrefixes must not be used as CertBundle mount paths —
+// they collide with OpenShell-managed material or the workspace root.
+var protectedMountPrefixes = []string{
+	"/sandbox",
+	"/etc/openshell",
+	"/etc/openshell-tls",
+}
+
+// driverConfigResult is the rendered OpenShell driver_config envelope plus
+// trust env vars derived from CertBundles.
+type driverConfigResult struct {
+	// DriverConfig is nil when there are no cert bundles.
+	DriverConfig map[string]any
+	// TrustEnv maps env var name → MountPath.
+	TrustEnv map[string]string
+	// ExtraReadOnly are mount paths to append to the Landlock RO set.
+	ExtraReadOnly []string
+}
+
+// renderDriverConfig builds the Kubernetes driver_config envelope and trust
+// env vars from CertBundles. Returns a zero result when bundles is empty.
+func renderDriverConfig(bundles []config.CertBundleConfig) (driverConfigResult, error) {
+	if len(bundles) == 0 {
+		return driverConfigResult{}, nil
+	}
+
+	volumes := make([]any, 0, len(bundles))
+	mounts := make([]any, 0, len(bundles))
+	trustEnv := make(map[string]string)
+	extraRO := make([]string, 0, len(bundles))
+	seenNames := make(map[string]struct{}, len(bundles))
+
+	for i, b := range bundles {
+		if err := validateCertBundle(b, i); err != nil {
+			return driverConfigResult{}, err
+		}
+		if _, dup := seenNames[b.Name]; dup {
+			return driverConfigResult{}, fmt.Errorf("cert_bundles[%d]: duplicate name %q", i, b.Name)
+		}
+		seenNames[b.Name] = struct{}{}
+
+		volumes = append(volumes, map[string]any{
+			"name": b.Name,
+			"persistent_volume_claim": map[string]any{
+				"claim_name": b.ClaimName,
+				"read_only":  true,
+			},
+		})
+
+		mount := map[string]any{
+			"name":       b.Name,
+			"mount_path": b.MountPath,
+			"read_only":  true,
+		}
+		if b.SubPath != "" {
+			mount["sub_path"] = b.SubPath
+		}
+		mounts = append(mounts, mount)
+
+		extraRO = append(extraRO, b.MountPath)
+
+		envKeys := b.TrustEnv
+		if len(envKeys) == 0 {
+			envKeys = defaultTrustEnvVars
+		}
+		for _, k := range envKeys {
+			k = strings.TrimSpace(k)
+			if k == "" {
+				continue
+			}
+			trustEnv[k] = b.MountPath
+		}
+	}
+
+	return driverConfigResult{
+		DriverConfig: map[string]any{
+			"kubernetes": map[string]any{
+				"volumes": volumes,
+				"containers": map[string]any{
+					"agent": map[string]any{
+						"volume_mounts": mounts,
+					},
+				},
+			},
+		},
+		TrustEnv:      trustEnv,
+		ExtraReadOnly: extraRO,
+	}, nil
+}
+
+func validateCertBundle(b config.CertBundleConfig, idx int) error {
+	if strings.TrimSpace(b.Name) == "" {
+		return fmt.Errorf("cert_bundles[%d]: name is required", idx)
+	}
+	if strings.TrimSpace(b.ClaimName) == "" {
+		return fmt.Errorf("cert_bundles[%d]: claim_name is required", idx)
+	}
+	if strings.TrimSpace(b.MountPath) == "" {
+		return fmt.Errorf("cert_bundles[%d]: mount_path is required", idx)
+	}
+	if !path.IsAbs(b.MountPath) {
+		return fmt.Errorf("cert_bundles[%d]: mount_path %q must be absolute", idx, b.MountPath)
+	}
+	cleaned := path.Clean(b.MountPath)
+	for _, prefix := range protectedMountPrefixes {
+		if cleaned == prefix || strings.HasPrefix(cleaned, prefix+"/") {
+			return fmt.Errorf("cert_bundles[%d]: mount_path %q collides with protected prefix %q", idx, b.MountPath, prefix)
+		}
+	}
+	if b.SubPath != "" {
+		if path.IsAbs(b.SubPath) || strings.Contains(b.SubPath, "..") {
+			return fmt.Errorf("cert_bundles[%d]: sub_path %q must be a relative path without '..'", idx, b.SubPath)
+		}
+	}
+	return nil
+}
+
+// applyCertBundles merges rendered cert-bundle trust env into create-time
+// env and returns the driver_config envelope (nil when no bundles). Landlock
+// ExtraReadOnly for mount paths is handled by defaultSandboxPolicy.
+func applyCertBundles(cfg config.SandboxOpenShellConfig, env map[string]string) (map[string]any, error) {
+	result, err := renderDriverConfig(cfg.CertBundles)
+	if err != nil {
+		return nil, err
+	}
+	if result.DriverConfig == nil {
+		return nil, nil
+	}
+	for k, v := range result.TrustEnv {
+		env[k] = v
+	}
+	return result.DriverConfig, nil
+}

--- a/pkg/sandbox/openshell/driver_config_test.go
+++ b/pkg/sandbox/openshell/driver_config_test.go
@@ -1,0 +1,186 @@
+package openshell
+
+import (
+	"testing"
+
+	"github.com/SAP/astonish/pkg/config"
+)
+
+func TestRenderDriverConfig_Empty(t *testing.T) {
+	result, err := renderDriverConfig(nil)
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	if result.DriverConfig != nil {
+		t.Errorf("DriverConfig = %v, want nil", result.DriverConfig)
+	}
+	if len(result.TrustEnv) != 0 {
+		t.Errorf("TrustEnv = %v, want empty", result.TrustEnv)
+	}
+}
+
+func TestRenderDriverConfig_PVCShape(t *testing.T) {
+	result, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "corp-root-ca",
+		ClaimName: "astonish-corp-ca",
+		MountPath: "/etc/astonish-ca/ca-bundle.crt",
+		SubPath:   "ca-bundle.crt",
+	}})
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	if result.DriverConfig == nil {
+		t.Fatal("expected DriverConfig")
+	}
+	k8s, ok := result.DriverConfig["kubernetes"].(map[string]any)
+	if !ok {
+		t.Fatalf("kubernetes block missing: %#v", result.DriverConfig)
+	}
+	vols, ok := k8s["volumes"].([]any)
+	if !ok || len(vols) != 1 {
+		t.Fatalf("volumes = %#v", k8s["volumes"])
+	}
+	vol := vols[0].(map[string]any)
+	if vol["name"] != "corp-root-ca" {
+		t.Errorf("volume name = %v", vol["name"])
+	}
+	pvc := vol["persistent_volume_claim"].(map[string]any)
+	if pvc["claim_name"] != "astonish-corp-ca" {
+		t.Errorf("claim_name = %v", pvc["claim_name"])
+	}
+	if pvc["read_only"] != true {
+		t.Errorf("read_only = %v, want true", pvc["read_only"])
+	}
+
+	containers := k8s["containers"].(map[string]any)
+	agent := containers["agent"].(map[string]any)
+	mounts := agent["volume_mounts"].([]any)
+	if len(mounts) != 1 {
+		t.Fatalf("volume_mounts len = %d", len(mounts))
+	}
+	m := mounts[0].(map[string]any)
+	if m["mount_path"] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("mount_path = %v", m["mount_path"])
+	}
+	if m["sub_path"] != "ca-bundle.crt" {
+		t.Errorf("sub_path = %v", m["sub_path"])
+	}
+	if m["read_only"] != true {
+		t.Errorf("mount read_only = %v", m["read_only"])
+	}
+
+	for _, k := range defaultTrustEnvVars {
+		if result.TrustEnv[k] != "/etc/astonish-ca/ca-bundle.crt" {
+			t.Errorf("TrustEnv[%s] = %q", k, result.TrustEnv[k])
+		}
+	}
+	if len(result.ExtraReadOnly) != 1 || result.ExtraReadOnly[0] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("ExtraReadOnly = %v", result.ExtraReadOnly)
+	}
+}
+
+func TestRenderDriverConfig_CustomTrustEnv(t *testing.T) {
+	result, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "corp",
+		ClaimName: "pvc-ca",
+		MountPath: "/etc/astonish-ca/ca.pem",
+		TrustEnv:  []string{"SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"},
+	}})
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	if len(result.TrustEnv) != 2 {
+		t.Fatalf("TrustEnv = %v, want 2 keys", result.TrustEnv)
+	}
+	if result.TrustEnv["SSL_CERT_FILE"] != "/etc/astonish-ca/ca.pem" {
+		t.Errorf("SSL_CERT_FILE = %q", result.TrustEnv["SSL_CERT_FILE"])
+	}
+}
+
+func TestRenderDriverConfig_RejectSandboxMount(t *testing.T) {
+	_, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "bad",
+		ClaimName: "pvc",
+		MountPath: "/sandbox/certs/ca.pem",
+	}})
+	if err == nil {
+		t.Fatal("expected error for /sandbox mount")
+	}
+}
+
+func TestRenderDriverConfig_RejectOpenshellMount(t *testing.T) {
+	_, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "bad",
+		ClaimName: "pvc",
+		MountPath: "/etc/openshell-tls/ca.pem",
+	}})
+	if err == nil {
+		t.Fatal("expected error for /etc/openshell-tls mount")
+	}
+}
+
+func TestRenderDriverConfig_RejectRelativeMount(t *testing.T) {
+	_, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "bad",
+		ClaimName: "pvc",
+		MountPath: "etc/astonish-ca/ca.pem",
+	}})
+	if err == nil {
+		t.Fatal("expected error for relative mount_path")
+	}
+}
+
+func TestRenderDriverConfig_RejectDuplicateName(t *testing.T) {
+	_, err := renderDriverConfig([]config.CertBundleConfig{
+		{Name: "corp", ClaimName: "pvc-a", MountPath: "/etc/astonish-ca/a.crt"},
+		{Name: "corp", ClaimName: "pvc-b", MountPath: "/etc/astonish-ca/b.crt"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+}
+
+func TestApplyCertBundles_MergesTrustEnv(t *testing.T) {
+	cfg := config.SandboxOpenShellConfig{
+		CertBundles: []config.CertBundleConfig{{
+			Name:      "corp",
+			ClaimName: "astonish-corp-ca",
+			MountPath: "/etc/astonish-ca/ca-bundle.crt",
+		}},
+	}
+	env := map[string]string{"ASTONISH_SESSION_ID": "s1"}
+	dc, err := applyCertBundles(cfg, env)
+	if err != nil {
+		t.Fatalf("applyCertBundles: %v", err)
+	}
+	if dc == nil {
+		t.Fatal("expected driver_config")
+	}
+	if env["SSL_CERT_FILE"] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("SSL_CERT_FILE = %q", env["SSL_CERT_FILE"])
+	}
+	if env["ASTONISH_SESSION_ID"] != "s1" {
+		t.Error("session id env overwritten")
+	}
+}
+
+func TestDefaultSandboxPolicy_CertBundleExtraReadOnly(t *testing.T) {
+	cfg := config.SandboxOpenShellConfig{
+		CertBundles: []config.CertBundleConfig{{
+			Name:      "corp",
+			ClaimName: "pvc",
+			MountPath: "/etc/astonish-ca/ca-bundle.crt",
+		}},
+	}
+	policy := defaultSandboxPolicy(cfg)
+	found := false
+	for _, p := range policy.Filesystem.ReadOnly {
+		if p == "/etc/astonish-ca/ca-bundle.crt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected cert mount path in Landlock read-only set")
+	}
+}

--- a/pkg/sandbox/openshell/fleet.go
+++ b/pkg/sandbox/openshell/fleet.go
@@ -53,6 +53,10 @@ func (b *OpenShellBackend) EnsureFleetContainer(ctx context.Context, spec sandbo
 	env := map[string]string{
 		"ASTONISH_SESSION_ID": spec.FleetKey,
 	}
+	driverCfg, err := applyCertBundles(b.cfg.AppConfig, env)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox/openshell: EnsureFleetContainer(%s): cert_bundles: %w", spec.FleetKey, err)
+	}
 
 	labels := map[string]string{
 		"astonish.io/type":       "fleet",
@@ -80,11 +84,12 @@ func (b *OpenShellBackend) EnsureFleetContainer(ctx context.Context, spec sandbo
 	}
 
 	resp, err := b.gateway.CreateSandbox(ctx, CreateSandboxRequest{
-		Name:   name,
-		Image:  image,
-		Env:    env,
-		Labels: labels,
-		Policy: defaultSandboxPolicy(b.cfg.AppConfig),
+		Name:         name,
+		Image:        image,
+		Env:          env,
+		Labels:       labels,
+		Policy:       defaultSandboxPolicy(b.cfg.AppConfig),
+		DriverConfig: driverCfg,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("sandbox/openshell: EnsureFleetContainer(%s): create: %w", spec.FleetKey, err)

--- a/pkg/sandbox/openshell/gateway_client.go
+++ b/pkg/sandbox/openshell/gateway_client.go
@@ -224,6 +224,12 @@ type CreateSandboxRequest struct {
 	// When nil, the gateway applies its default policy.
 	Policy *SandboxPolicySpec
 
+	// DriverConfig is the OpenShell driver-keyed config envelope (top-level
+	// keys are compute-driver names such as "kubernetes"). The gateway
+	// forwards only the block matching the active driver. Used for PVC
+	// mounts (cert bundles) and other driver-owned create-time knobs.
+	DriverConfig map[string]any
+
 	// NodeSelector constrains where the pod is scheduled.
 	NodeSelector map[string]string
 

--- a/pkg/sandbox/openshell/network_test.go
+++ b/pkg/sandbox/openshell/network_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/store"
 )
@@ -199,6 +200,49 @@ func TestEnsureFleetContainer_Success(t *testing.T) {
 	}
 	if sess.OrgSlug != "acme" {
 		t.Errorf("OrgSlug = %q, want %q", sess.OrgSlug, "acme")
+	}
+}
+
+func TestEnsureFleetContainer_WithCertBundles(t *testing.T) {
+	var captured CreateSandboxRequest
+	gw := &mockGateway{
+		createFn: func(ctx context.Context, req CreateSandboxRequest) (*CreateSandboxResponse, error) {
+			captured = req
+			return &CreateSandboxResponse{SandboxID: "sb-fleet-ca", GatewayID: "gw-fleet-ca", PodName: "pod-fleet-ca"}, nil
+		},
+	}
+	sr, err := sandbox.NewSessionRegistry()
+	if err != nil {
+		t.Fatalf("NewSessionRegistry: %v", err)
+	}
+	b, err := New(Config{
+		Sessions: sr,
+		Gateway:  gw,
+		AppConfig: config.SandboxOpenShellConfig{
+			CertBundles: []config.CertBundleConfig{{
+				Name:      "corp-root-ca",
+				ClaimName: "astonish-corp-ca",
+				MountPath: "/etc/astonish-ca/ca-bundle.crt",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	key := fmt.Sprintf("fleet-certs-%d", time.Now().UnixNano())
+	_, err = b.EnsureFleetContainer(context.Background(), sandbox.FleetSpec{
+		FleetKey:   key,
+		TemplateID: "@base",
+	})
+	if err != nil {
+		t.Fatalf("EnsureFleetContainer: %v", err)
+	}
+	if captured.DriverConfig == nil {
+		t.Fatal("expected DriverConfig")
+	}
+	if captured.Env["SSL_CERT_FILE"] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("SSL_CERT_FILE = %q", captured.Env["SSL_CERT_FILE"])
 	}
 }
 

--- a/pkg/sandbox/openshell/policy.go
+++ b/pkg/sandbox/openshell/policy.go
@@ -1,6 +1,10 @@
 package openshell
 
-import "github.com/SAP/astonish/pkg/config"
+import (
+	"strings"
+
+	"github.com/SAP/astonish/pkg/config"
+)
 
 // defaultSandboxPolicy returns the SandboxPolicySpec applied to every sandbox
 // created by the Astonish backend.
@@ -80,6 +84,14 @@ func defaultSandboxPolicy(cfg config.SandboxOpenShellConfig) *SandboxPolicySpec 
 	}
 	if len(cfg.FilesystemPolicy.ExtraReadWrite) > 0 {
 		policy.Filesystem.ReadWrite = append(policy.Filesystem.ReadWrite, cfg.FilesystemPolicy.ExtraReadWrite...)
+	}
+	// Cert-bundle mount paths are also added in applyCertBundles at create
+	// time; listing them here keeps defaultSandboxPolicy self-contained for
+	// callers that only use the policy helper.
+	for _, b := range cfg.CertBundles {
+		if p := strings.TrimSpace(b.MountPath); p != "" {
+			policy.Filesystem.ReadOnly = append(policy.Filesystem.ReadOnly, p)
+		}
 	}
 
 	// Always populate NetworkPolicies — empty = deny-all in OpenShell.

--- a/pkg/sandbox/openshell/session.go
+++ b/pkg/sandbox/openshell/session.go
@@ -91,6 +91,10 @@ func (b *OpenShellBackend) CreateSession(ctx context.Context, spec sandbox.Sessi
 	for k, v := range spec.Env {
 		env[k] = v
 	}
+	driverCfg, err := applyCertBundles(b.cfg.AppConfig, env)
+	if err != nil {
+		return nil, fmt.Errorf("openshell: cert_bundles: %w", err)
+	}
 
 	// Build labels. Sanitize session ID for K8s label compliance (values
 	// allow only [a-zA-Z0-9._-]). The primary fix is at session-key creation
@@ -118,11 +122,12 @@ func (b *OpenShellBackend) CreateSession(ctx context.Context, spec sandbox.Sessi
 
 	// Create the sandbox via the gateway.
 	resp, err := b.gateway.CreateSandbox(ctx, CreateSandboxRequest{
-		Name:   name,
-		Image:  image,
-		Env:    env,
-		Labels: labels,
-		Policy: defaultSandboxPolicy(b.cfg.AppConfig),
+		Name:         name,
+		Image:        image,
+		Env:          env,
+		Labels:       labels,
+		Policy:       defaultSandboxPolicy(b.cfg.AppConfig),
+		DriverConfig: driverCfg,
 	})
 	if err != nil {
 		if !isAlreadyExists(err) {
@@ -190,6 +195,10 @@ func (b *OpenShellBackend) StartSession(ctx context.Context, sessionID string) e
 	env := map[string]string{
 		"ASTONISH_SESSION_ID": sessionID,
 	}
+	driverCfg, err := applyCertBundles(b.cfg.AppConfig, env)
+	if err != nil {
+		return fmt.Errorf("openshell: cert_bundles: %w", err)
+	}
 
 	labels := map[string]string{
 		"astonish.io/type":       "session",
@@ -204,11 +213,12 @@ func (b *OpenShellBackend) StartSession(ctx context.Context, sessionID string) e
 	}
 
 	resp, err := b.gateway.CreateSandbox(ctx, CreateSandboxRequest{
-		Name:   sandboxName(sessionID),
-		Image:  image,
-		Env:    env,
-		Labels: labels,
-		Policy: defaultSandboxPolicy(b.cfg.AppConfig),
+		Name:         sandboxName(sessionID),
+		Image:        image,
+		Env:          env,
+		Labels:       labels,
+		Policy:       defaultSandboxPolicy(b.cfg.AppConfig),
+		DriverConfig: driverCfg,
 	})
 	if err != nil {
 		if !isAlreadyExists(err) {

--- a/pkg/sandbox/openshell/session_test.go
+++ b/pkg/sandbox/openshell/session_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/store"
 	"google.golang.org/grpc/codes"
@@ -148,6 +149,67 @@ func TestCreateSession_Success(t *testing.T) {
 	// BackendRef stores the sandbox ID (via ContainerName).
 	if sess.BackendRef == "" {
 		t.Error("BackendRef should not be empty")
+	}
+}
+
+func TestCreateSession_WithCertBundles(t *testing.T) {
+	var captured CreateSandboxRequest
+	gw := &mockGateway{
+		createFn: func(ctx context.Context, req CreateSandboxRequest) (*CreateSandboxResponse, error) {
+			captured = req
+			return &CreateSandboxResponse{SandboxID: "sb-certs", GatewayID: "gw-certs", PodName: "pod-certs"}, nil
+		},
+	}
+	sr, err := sandbox.NewSessionRegistry()
+	if err != nil {
+		t.Fatalf("NewSessionRegistry: %v", err)
+	}
+	b, err := New(Config{
+		Sessions: sr,
+		Gateway:  gw,
+		AppConfig: config.SandboxOpenShellConfig{
+			CertBundles: []config.CertBundleConfig{{
+				Name:      "corp-root-ca",
+				ClaimName: "astonish-corp-ca",
+				MountPath: "/etc/astonish-ca/ca-bundle.crt",
+				SubPath:   "ca-bundle.crt",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	id := fmt.Sprintf("sess-certs-%d", time.Now().UnixNano())
+	_, err = b.CreateSession(context.Background(), sandbox.SessionSpec{
+		SessionID:  id,
+		TemplateID: "@base",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if captured.DriverConfig == nil {
+		t.Fatal("expected DriverConfig on CreateSandboxRequest")
+	}
+	k8s, ok := captured.DriverConfig["kubernetes"].(map[string]any)
+	if !ok {
+		t.Fatalf("kubernetes block missing: %#v", captured.DriverConfig)
+	}
+	if _, ok := k8s["volumes"].([]any); !ok {
+		t.Errorf("volumes missing: %#v", k8s)
+	}
+	if captured.Env["SSL_CERT_FILE"] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("SSL_CERT_FILE = %q", captured.Env["SSL_CERT_FILE"])
+	}
+	foundRO := false
+	for _, p := range captured.Policy.Filesystem.ReadOnly {
+		if p == "/etc/astonish-ca/ca-bundle.crt" {
+			foundRO = true
+			break
+		}
+	}
+	if !foundRO {
+		t.Error("expected cert mount path in policy ReadOnly")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wire OpenShell `SandboxTemplate.driver_config` so `certBundles` can mount PVC CA material and set TLS trust env vars without rebuilding sandbox images.
- Add Helm optional cert-bundle PVC + bootstrap Job, bump the OpenShell chart dependency to 0.0.86 (PVC `volume_mounts` need ≥ 0.0.81), and document the flow.
- Fix beta Docker builds to precompile Linux binaries before image build so glibc-based images stay reliable.

## Test plan
- [ ] Unit: `go test ./pkg/sandbox/openshell/ -count=1`
- [ ] Deploy with `certBundles` configured; confirm bootstrap Job populates the PVC and sandboxes mount the combined PEM
- [ ] Verify TLS to corporate endpoints works with `SSL_CERT_FILE` / related trust env (no image rebuild)
- [ ] Confirm OpenShell gateway is ≥ 0.0.81 (chart 0.0.86) so `volume_mounts` in driver_config are accepted
- [ ] Spot-check beta-release workflow still builds astonish / sandbox-openshell images