### PR TITLE
Install cert_bundles into the OpenShell system CA store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ webhook
 
 # Code intelligence disk cache (may contain source snippets)
 .codeintel/
+
+.opencode/
+graphify-out/

--- a/deploy/helm/astonish/templates/configmap.yaml
+++ b/deploy/helm/astonish/templates/configmap.yaml
@@ -136,6 +136,9 @@ data:
             {{- if .subPath }}
             sub_path: {{ .subPath | quote }}
             {{- end }}
+            {{- if hasKey . "installSystemTrust" }}
+            install_system_trust: {{ .installSystemTrust }}
+            {{- end }}
             {{- with .trustEnv }}
             trust_env:
               {{- range . }}

--- a/deploy/helm/astonish/values.yaml
+++ b/deploy/helm/astonish/values.yaml
@@ -332,8 +332,12 @@ sandbox:
     # driver_config (Kubernetes PVC mounts). Empty = no mounts (default).
     # Each entry's PVC holds a *combined* PEM (system CAs + corporate roots).
     # Mount paths must not be under /sandbox or /etc/openshell{,-tls}.
-    # Trust env vars default to SSL_CERT_FILE, CURL_CA_BUNDLE,
-    # REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS, GIT_SSL_CAINFO.
+    #
+    # installSystemTrust (default true): also bind-mounts the bundle over
+    # /etc/ssl/certs/ca-certificates.crt so the OpenShell MITM proxy trusts
+    # corporate upstream TLS. Trust env vars alone are insufficient — the
+    # supervisor overwrites SSL_CERT_FILE to /etc/openshell-tls/.... At most
+    # one certBundles entry may install into the system store.
     #
     # Optional per-entry bootstrap: chart creates the PVC and a post-install
     # Job that downloads bootstrap.url, appends it to the system CA bundle,
@@ -349,6 +353,7 @@ sandbox:
     #     claimName: astonish-corp-ca
     #     mountPath: /etc/astonish-ca/ca-bundle.crt
     #     subPath: ca-bundle.crt
+    #     # installSystemTrust: true  # default; dual-mount onto system CA path
     #     # trustEnv: []  # use defaults, or override
     #     bootstrap:
     #       enabled: true

--- a/docs/architecture/openshell-sandbox-backend.md
+++ b/docs/architecture/openshell-sandbox-backend.md
@@ -516,7 +516,7 @@ type SandboxOpenShellConfig struct {
     CACertPath     string             `yaml:"ca_cert_path,omitempty"`
     AuthToken      string             `yaml:"auth_token,omitempty"`
     SandboxImage   string             `yaml:"sandbox_image,omitempty"`
-    CertBundles    []CertBundleConfig `yaml:"cert_bundles,omitempty"` // PVC mounts via driver_config
+    CertBundles    []CertBundleConfig `yaml:"cert_bundles,omitempty"` // PVC mounts + system CA install
 }
 ```
 
@@ -639,7 +639,11 @@ domain types to the protobuf `SandboxPolicy` message before sending
 to the gateway. When `DriverConfig` is set, it is encoded as
 `SandboxTemplate.driver_config` (`google.protobuf.Struct`). Platform
 `cert_bundles` config renders into the Kubernetes driver's PVC mount
-schema and trust env vars — see `pkg/sandbox/openshell/driver_config.go`.
+schema, trust env vars, and (by default) a bind-mount over
+`/etc/ssl/certs/ca-certificates.crt` so the supervisor’s MITM upstream
+TLS trusts corporate roots — see `pkg/sandbox/openshell/driver_config.go`.
+Agent `SSL_CERT_FILE` alone is insufficient: OpenShell overwrites it to
+`/etc/openshell-tls/ca-bundle.pem`.
 
 ---
 
@@ -652,7 +656,7 @@ schema and trust env vars — see `pkg/sandbox/openshell/driver_config.go`.
 | `pkg/sandbox/openshell/exec.go` | Exec with `wrapCommand()` for WorkDir/Env |
 | `pkg/sandbox/openshell/fleet.go` | Fleet/pool management, CreateSandbox with policy |
 | `pkg/sandbox/openshell/policy.go` | `defaultSandboxPolicy()` — Landlock filesystem rules |
-| `pkg/sandbox/openshell/driver_config.go` | CertBundles → K8s `driver_config` PVC mounts + trust env |
+| `pkg/sandbox/openshell/driver_config.go` | CertBundles → K8s `driver_config` PVC mounts, system CA install, trust env |
 | `pkg/sandbox/openshell/gateway_client.go` | GatewayClient interface, domain types (SandboxPolicySpec, etc.) |
 | `pkg/sandbox/openshell/client_grpc.go` | Real gRPC implementation, `mapPolicyToProto()` |
 | `pkg/sandbox/openshell/client_grpc_test.go` | Policy mapping tests |

--- a/docs/website/docs/deployment/openshell.md
+++ b/docs/website/docs/deployment/openshell.md
@@ -433,10 +433,19 @@ sandbox:
 Requires the OpenShell gateway **≥ 0.0.81** (Astonish chart pins **0.0.86**).
 Older gateways reject `containers.agent.volume_mounts` in `driver_config`.
 
-To trust internal HTTPS endpoints without rebuilding the sandbox image,
-mount a combined CA bundle (system CAs + corporate roots) via OpenShell
-`driver_config` PVC mounts. Configure only through Helm values — leave
-`certBundles` empty (default) for no mounts.
+OpenShell’s egress proxy **MITMs** HTTPS (`CONNECT`), then opens a second
+TLS session to the real upstream. Upstream verification uses Mozilla roots
+plus the container system store at `/etc/ssl/certs/ca-certificates.crt` —
+not the agent’s `SSL_CERT_FILE` (the supervisor overwrites that to
+`/etc/openshell-tls/ca-bundle.pem`). Mounting a corp CA only under
+`/etc/astonish-ca/...` is therefore **not enough** for internal HTTPS.
+
+To trust corporate endpoints without rebuilding the sandbox image, mount a
+**combined** PEM (system CAs + corporate roots) via `certBundles`. By
+default (`installSystemTrust: true`) Astonish dual-mounts that file at the
+operator path **and** over `/etc/ssl/certs/ca-certificates.crt` so the
+supervisor loads corp roots before PID 1 starts. At most one entry may
+install into the system store.
 
 **Chart-managed bootstrap** (recommended): Helm creates the PVC and a
 post-install/upgrade Job that downloads your org CA URL, appends it to
@@ -450,6 +459,7 @@ sandbox:
         claimName: astonish-corp-ca
         mountPath: /etc/astonish-ca/ca-bundle.crt
         subPath: ca-bundle.crt
+        # installSystemTrust: true  # default — required for MITM upstream
         bootstrap:
           enabled: true
           url: "https://pki.example.com/corp-root-ca.crt"
@@ -457,18 +467,21 @@ sandbox:
 
 Or pre-provision the PVC yourself and omit `bootstrap`.
 
-Astonish mounts the PVC read-only into every sandbox, sets trust env vars
-(`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`,
-`NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`) to the mount path, and adds the
-path to the Landlock read-only set.
+Astonish also sets trust env vars (`SSL_CERT_FILE`, etc.) to the operator
+mount path for tools that honor them before OpenShell rewrites env, and
+adds mount paths to the Landlock read-only set. Browser sessions still
+inject the OpenShell MITM CA into the NSS DB via the browser launch script.
 
 Mount paths must not be under `/sandbox` (workspace) or
 `/etc/openshell` / `/etc/openshell-tls` (OpenShell-managed). Use a
-*combined* bundle — `SSL_CERT_FILE` replaces the system store, so a
-corp-only PEM would break public HTTPS.
+*combined* bundle — replacing the system store with a corp-only PEM would
+break public HTTPS.
 
 On RWO StorageClasses (e.g. Cinder), the cert PVC can attach to only one
 node; use RWX/ROX or pin sandboxes when scheduling across multiple nodes.
+
+Recycle existing sandboxes after enabling or changing `certBundles`
+(idle eviction or new chat) so pods pick up the new mounts.
 
 **Landlock enforcement mode:**
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -138,10 +138,11 @@ type SandboxOpenShellConfig struct {
 	FilesystemPolicy FilesystemPolicyConfig `yaml:"filesystem_policy,omitempty" json:"filesystem_policy,omitempty"`
 
 	// CertBundles mounts operator-provided CA trust material into every
-	// OpenShell sandbox via driver_config PVC mounts, and sets standard
-	// trust env vars (SSL_CERT_FILE, etc.) to the mounted bundle path.
-	// Each bundle must already exist as a PVC in the sandbox namespace and
-	// should contain a combined PEM (system CAs + corporate roots).
+	// OpenShell sandbox via driver_config PVC mounts. Each PVC should hold a
+	// combined PEM (system CAs + corporate roots). By default the bundle is
+	// also installed over the system CA path so the OpenShell MITM proxy can
+	// verify corporate upstream TLS (trust env alone is insufficient — the
+	// supervisor overwrites SSL_CERT_FILE to /etc/openshell-tls/...).
 	CertBundles []CertBundleConfig `yaml:"cert_bundles,omitempty" json:"cert_bundles,omitempty"`
 
 	// IdleTimeoutMinutes evicts sandbox pods that have had no exec activity
@@ -169,8 +170,16 @@ type CertBundleConfig struct {
 
 	// TrustEnv lists env var names set to MountPath. When empty, defaults to
 	// SSL_CERT_FILE, CURL_CA_BUNDLE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS,
-	// and GIT_SSL_CAINFO.
+	// and GIT_SSL_CAINFO. OpenShell typically overwrites these to its
+	// openshell-tls bundle; InstallSystemTrust is what makes corporate
+	// upstream TLS work under MITM.
 	TrustEnv []string `yaml:"trust_env,omitempty" json:"trust_env,omitempty"`
+
+	// InstallSystemTrust, when true (default if nil), also bind-mounts this
+	// bundle over /etc/ssl/certs/ca-certificates.crt so the OpenShell
+	// supervisor loads corporate roots for upstream TLS verification.
+	// At most one cert_bundle may enable this.
+	InstallSystemTrust *bool `yaml:"install_system_trust,omitempty" json:"install_system_trust,omitempty"`
 }
 
 // RegistryConfig holds OCI registry connection details for pushing

--- a/pkg/sandbox/AGENTS.md
+++ b/pkg/sandbox/AGENTS.md
@@ -50,7 +50,7 @@ If you add a backend, run the contract suite against it in CI. If you change the
 
 ## Session provisioning (per backend)
 - **Incus**: `EnsureOrgSessionContainer` composes overlay layers, ensures a `@base` snapshot, creates a per-session container. `WaitForSessionReady` polls `IsRunning`. Templates are content-addressed via `hashSnapshotRootfs`.
-- **OpenShell**: `Gateway.CreateSandbox` provisions a pod; the in-pod supervisor opens `ConnectSupervisor`; exec/push/pull go through `ExecSandbox` / `ExecSandboxInteractive`. Evicted sandboxes are auto-resumed by `ensureSessionRunning`. Platform `cert_bundles` render into `SandboxTemplate.driver_config` (K8s PVC mounts) plus trust env vars — see `pkg/sandbox/openshell/driver_config.go`.
+- **OpenShell**: `Gateway.CreateSandbox` provisions a pod; the in-pod supervisor opens `ConnectSupervisor`; exec/push/pull go through `ExecSandbox` / `ExecSandboxInteractive`. Evicted sandboxes are auto-resumed by `ensureSessionRunning`. Platform `cert_bundles` render into `SandboxTemplate.driver_config` (K8s PVC mounts, default install over `/etc/ssl/certs/ca-certificates.crt` for MITM upstream trust, plus trust env) — see `pkg/sandbox/openshell/driver_config.go`.
 - **K8s (direct, without OpenShell)**: `pkg/sandbox/k8s` — image pull policy is `Always` for mutable tags (`latest`, `dev`) and `IfNotPresent` for pinned digests. Enforces per-org/team labels and `NetworkPolicy`.
 - **Mock**: in-memory, used by unit tests; supports injection hooks.
 

--- a/pkg/sandbox/openshell/driver_config.go
+++ b/pkg/sandbox/openshell/driver_config.go
@@ -8,9 +8,16 @@ import (
 	"github.com/SAP/astonish/pkg/config"
 )
 
+// systemCABundlePath is where OpenShell's supervisor loads system CA roots
+// for upstream TLS after MITM CONNECT. Corporate CAs must appear here
+// (volume mount before PID 1); agent SSL_CERT_FILE alone is not enough.
+const systemCABundlePath = "/etc/ssl/certs/ca-certificates.crt"
+
 // defaultTrustEnvVars are set to each cert bundle MountPath when TrustEnv
-// is empty. SSL_CERT_FILE (and peers) replace the system store — operators
-// must place a *combined* PEM (system CAs + corporate roots) in the PVC.
+// is empty. OpenShell typically overwrites these to /etc/openshell-tls/...;
+// InstallSystemTrust is the contract that makes corporate upstream TLS work.
+// Operators must place a *combined* PEM (system CAs + corporate roots) in
+// the PVC so replacing the system store does not break public HTTPS.
 var defaultTrustEnvVars = []string{
 	"SSL_CERT_FILE",
 	"CURL_CA_BUNDLE",
@@ -46,10 +53,11 @@ func renderDriverConfig(bundles []config.CertBundleConfig) (driverConfigResult, 
 	}
 
 	volumes := make([]any, 0, len(bundles))
-	mounts := make([]any, 0, len(bundles))
+	mounts := make([]any, 0, len(bundles)*2)
 	trustEnv := make(map[string]string)
-	extraRO := make([]string, 0, len(bundles))
+	extraRO := make([]string, 0, len(bundles)*2)
 	seenNames := make(map[string]struct{}, len(bundles))
+	systemTrustCount := 0
 
 	for i, b := range bundles {
 		if err := validateCertBundle(b, i); err != nil {
@@ -68,28 +76,49 @@ func renderDriverConfig(bundles []config.CertBundleConfig) (driverConfigResult, 
 			},
 		})
 
-		mount := map[string]any{
-			"name":       b.Name,
-			"mount_path": b.MountPath,
-			"read_only":  true,
-		}
-		if b.SubPath != "" {
-			mount["sub_path"] = b.SubPath
-		}
-		mounts = append(mounts, mount)
+		cleanedMount := path.Clean(b.MountPath)
+		mountsAtSystemPath := cleanedMount == systemCABundlePath
+		installSystem := certBundleInstallSystemTrust(b)
+		// Mounting at the system path counts as a system-trust install even
+		// when install_system_trust is false — only one such mount is allowed.
+		usesSystemPath := installSystem || mountsAtSystemPath
 
-		extraRO = append(extraRO, b.MountPath)
+		if usesSystemPath {
+			systemTrustCount++
+			if systemTrustCount > 1 {
+				return driverConfigResult{}, fmt.Errorf(
+					"cert_bundles[%d]: at most one cert_bundle may install into %s",
+					i, systemCABundlePath)
+			}
+		}
+
+		// Primary operator mount (skipped when it would duplicate the system mount).
+		if !mountsAtSystemPath {
+			mounts = append(mounts, certBundleVolumeMount(b.Name, b.MountPath, b.SubPath))
+			extraRO = append(extraRO, b.MountPath)
+		}
+
+		// System-store install for OpenShell upstream MITM trust.
+		// If MountPath is already the system path, a single mount covers both.
+		if usesSystemPath {
+			mounts = append(mounts, certBundleVolumeMount(b.Name, systemCABundlePath, b.SubPath))
+			extraRO = append(extraRO, systemCABundlePath)
+		}
 
 		envKeys := b.TrustEnv
 		if len(envKeys) == 0 {
 			envKeys = defaultTrustEnvVars
+		}
+		trustPath := b.MountPath
+		if mountsAtSystemPath {
+			trustPath = systemCABundlePath
 		}
 		for _, k := range envKeys {
 			k = strings.TrimSpace(k)
 			if k == "" {
 				continue
 			}
-			trustEnv[k] = b.MountPath
+			trustEnv[k] = trustPath
 		}
 	}
 
@@ -107,6 +136,27 @@ func renderDriverConfig(bundles []config.CertBundleConfig) (driverConfigResult, 
 		TrustEnv:      trustEnv,
 		ExtraReadOnly: extraRO,
 	}, nil
+}
+
+func certBundleVolumeMount(name, mountPath, subPath string) map[string]any {
+	mount := map[string]any{
+		"name":       name,
+		"mount_path": mountPath,
+		"read_only":  true,
+	}
+	if subPath != "" {
+		mount["sub_path"] = subPath
+	}
+	return mount
+}
+
+// certBundleInstallSystemTrust returns whether the bundle should be installed
+// over the system CA path. Nil means default true.
+func certBundleInstallSystemTrust(b config.CertBundleConfig) bool {
+	if b.InstallSystemTrust == nil {
+		return true
+	}
+	return *b.InstallSystemTrust
 }
 
 func validateCertBundle(b config.CertBundleConfig, idx int) error {

--- a/pkg/sandbox/openshell/driver_config_test.go
+++ b/pkg/sandbox/openshell/driver_config_test.go
@@ -55,18 +55,28 @@ func TestRenderDriverConfig_PVCShape(t *testing.T) {
 	containers := k8s["containers"].(map[string]any)
 	agent := containers["agent"].(map[string]any)
 	mounts := agent["volume_mounts"].([]any)
-	if len(mounts) != 1 {
-		t.Fatalf("volume_mounts len = %d", len(mounts))
+	if len(mounts) != 2 {
+		t.Fatalf("volume_mounts len = %d, want 2 (operator + system)", len(mounts))
 	}
-	m := mounts[0].(map[string]any)
-	if m["mount_path"] != "/etc/astonish-ca/ca-bundle.crt" {
-		t.Errorf("mount_path = %v", m["mount_path"])
+	m0 := mounts[0].(map[string]any)
+	if m0["mount_path"] != "/etc/astonish-ca/ca-bundle.crt" {
+		t.Errorf("mount_path[0] = %v", m0["mount_path"])
 	}
-	if m["sub_path"] != "ca-bundle.crt" {
-		t.Errorf("sub_path = %v", m["sub_path"])
+	if m0["sub_path"] != "ca-bundle.crt" {
+		t.Errorf("sub_path[0] = %v", m0["sub_path"])
 	}
-	if m["read_only"] != true {
-		t.Errorf("mount read_only = %v", m["read_only"])
+	if m0["read_only"] != true {
+		t.Errorf("mount[0] read_only = %v", m0["read_only"])
+	}
+	m1 := mounts[1].(map[string]any)
+	if m1["mount_path"] != systemCABundlePath {
+		t.Errorf("mount_path[1] = %v, want %s", m1["mount_path"], systemCABundlePath)
+	}
+	if m1["sub_path"] != "ca-bundle.crt" {
+		t.Errorf("sub_path[1] = %v", m1["sub_path"])
+	}
+	if m1["name"] != "corp-root-ca" {
+		t.Errorf("system mount volume name = %v", m1["name"])
 	}
 
 	for _, k := range defaultTrustEnvVars {
@@ -74,7 +84,10 @@ func TestRenderDriverConfig_PVCShape(t *testing.T) {
 			t.Errorf("TrustEnv[%s] = %q", k, result.TrustEnv[k])
 		}
 	}
-	if len(result.ExtraReadOnly) != 1 || result.ExtraReadOnly[0] != "/etc/astonish-ca/ca-bundle.crt" {
+	if len(result.ExtraReadOnly) != 2 {
+		t.Fatalf("ExtraReadOnly = %v, want 2 paths", result.ExtraReadOnly)
+	}
+	if result.ExtraReadOnly[0] != "/etc/astonish-ca/ca-bundle.crt" || result.ExtraReadOnly[1] != systemCABundlePath {
 		t.Errorf("ExtraReadOnly = %v", result.ExtraReadOnly)
 	}
 }
@@ -137,6 +150,87 @@ func TestRenderDriverConfig_RejectDuplicateName(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected duplicate name error")
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestRenderDriverConfig_InstallSystemTrustFalse(t *testing.T) {
+	result, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:               "corp",
+		ClaimName:          "pvc-ca",
+		MountPath:          "/etc/astonish-ca/ca.pem",
+		InstallSystemTrust: boolPtr(false),
+	}})
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	mounts := result.DriverConfig["kubernetes"].(map[string]any)["containers"].(map[string]any)["agent"].(map[string]any)["volume_mounts"].([]any)
+	if len(mounts) != 1 {
+		t.Fatalf("volume_mounts len = %d, want 1", len(mounts))
+	}
+	if mounts[0].(map[string]any)["mount_path"] != "/etc/astonish-ca/ca.pem" {
+		t.Errorf("unexpected mounts: %#v", mounts)
+	}
+}
+
+func TestRenderDriverConfig_RejectTwoSystemTrustInstalls(t *testing.T) {
+	_, err := renderDriverConfig([]config.CertBundleConfig{
+		{Name: "a", ClaimName: "pvc-a", MountPath: "/etc/astonish-ca/a.crt"},
+		{Name: "b", ClaimName: "pvc-b", MountPath: "/etc/astonish-ca/b.crt"},
+	})
+	if err == nil {
+		t.Fatal("expected error for two default install_system_trust bundles")
+	}
+}
+
+func TestRenderDriverConfig_SecondBundleWithoutSystemTrust(t *testing.T) {
+	result, err := renderDriverConfig([]config.CertBundleConfig{
+		{Name: "a", ClaimName: "pvc-a", MountPath: "/etc/astonish-ca/a.crt"},
+		{Name: "b", ClaimName: "pvc-b", MountPath: "/etc/astonish-ca/b.crt", InstallSystemTrust: boolPtr(false)},
+	})
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	mounts := result.DriverConfig["kubernetes"].(map[string]any)["containers"].(map[string]any)["agent"].(map[string]any)["volume_mounts"].([]any)
+	// a: operator + system; b: operator only
+	if len(mounts) != 3 {
+		t.Fatalf("volume_mounts len = %d, want 3", len(mounts))
+	}
+	systemCount := 0
+	for _, m := range mounts {
+		if m.(map[string]any)["mount_path"] == systemCABundlePath {
+			systemCount++
+		}
+	}
+	if systemCount != 1 {
+		t.Errorf("system CA mounts = %d, want 1", systemCount)
+	}
+}
+
+func TestRenderDriverConfig_MountPathIsSystemCA(t *testing.T) {
+	result, err := renderDriverConfig([]config.CertBundleConfig{{
+		Name:      "corp",
+		ClaimName: "pvc-ca",
+		MountPath: systemCABundlePath,
+		SubPath:   "ca-bundle.crt",
+	}})
+	if err != nil {
+		t.Fatalf("renderDriverConfig: %v", err)
+	}
+	mounts := result.DriverConfig["kubernetes"].(map[string]any)["containers"].(map[string]any)["agent"].(map[string]any)["volume_mounts"].([]any)
+	if len(mounts) != 1 {
+		t.Fatalf("volume_mounts len = %d, want 1 (no duplicate)", len(mounts))
+	}
+	m := mounts[0].(map[string]any)
+	if m["mount_path"] != systemCABundlePath {
+		t.Errorf("mount_path = %v", m["mount_path"])
+	}
+	if m["sub_path"] != "ca-bundle.crt" {
+		t.Errorf("sub_path = %v", m["sub_path"])
+	}
+	if result.TrustEnv["SSL_CERT_FILE"] != systemCABundlePath {
+		t.Errorf("SSL_CERT_FILE = %q", result.TrustEnv["SSL_CERT_FILE"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Dual-mount `cert_bundles` PEMs over `/etc/ssl/certs/ca-certificates.crt` (default `installSystemTrust`) so the OpenShell MITM proxy can verify corporate upstream TLS.
- Document that agent `SSL_CERT_FILE` alone is insufficient because OpenShell overwrites it to `/etc/openshell-tls/...`.
- Ignore `.opencode/` and `graphify-out/` local artifacts.

## Test plan
- [ ] `go test ./pkg/sandbox/openshell/ -count=1 -run 'TestRenderDriverConfig|TestApplyCertBundles'`
- [ ] Deploy with existing `certBundles` bootstrap; recycle sandbox pods
- [ ] Confirm system CA path is bind-mounted and corp HTTPS via proxy returns real HTTP status (not CONNECT reset)
- [ ] Confirm public HTTPS (e.g. github.com) still works through the same proxy
- [ ] Confirm client trust still uses OpenShell MITM CA (`/etc/openshell-tls/ca-bundle.pem`)