### PR TITLE
Add lean Cursor-style tool activity UI for Studio Chat

### DIFF
--- a/docs/architecture/chat-rendering-pipeline.md
+++ b/docs/architecture/chat-rendering-pipeline.md
@@ -94,10 +94,17 @@ The backend emits **27 distinct event types** across `chat_runner.go` and `chat_
 
 | Event | Data Shape | Frontend Action |
 |-------|-----------|----------------|
-| `tool_call` | `{name, args, id}` | Add tool call card (collapsible) |
-| `tool_result` | `{name, result, id}` | Add tool result card (collapsible) |
+| `tool_call` | `{name, args, id}` | Append `tool_call` message; render via grouped `ToolActivityBlock` |
+| `tool_result` | `{name, result, id}` | Append `tool_result` message; paired into the same `ToolActivityBlock` |
 | `approval` | `{name, args, options}` | Show approval card with Approve/Deny buttons |
 | `auto_approved` | `{name}` | Show auto-approved badge |
+
+Tool messages stay separate in React state (and on the wire). At render time, `groupToolActivity` / `buildActivityRenderIndex` (`web/src/components/chat/toolActivity.ts`) fold **contiguous** `tool_call` / `tool_result` runs into one compact `ToolActivityBlock` (`web/src/components/chat/ToolActivityBlock.tsx`):
+
+- **Collapsed by default** — a discrete muted line with **categorized human language** (not a raw tool-name list), e.g. `Edited 2 files, explored 3 files, 2 searches, ran 1 command`. While streaming: a short verb hint (`Searching…`, `Fetching…`). Errors append after the categories (`… · http_request failed`).
+- **Expand the block** to see paired steps; expand a step for full args/result JSON.
+- Agent text, approvals, artifacts, handoffs, etc. split groups so narration between tool batches still reads naturally.
+- Source citation chips (`collectSourceUrls`) still walk raw `tool_result` messages — grouping is display-only.
 
 ### Artifact & File Events
 
@@ -165,7 +172,7 @@ graph TD
 
     subgraph "Message Types (React State)"
         M1 --> C1["ReactMarkdown bubble<br/>(+ report/video HarnessPlaceholder)"]
-        M2 --> C2[renderToolCard]
+        M2 --> C2[ToolActivityBlock]
         M3 --> C2
         M4 --> C3[ArtifactCard]
         M5 --> C4["HarnessPlaceholder → HarnessPanel(AppPreviewCard)"]
@@ -181,8 +188,8 @@ graph TD
 |-------------|-----------|-------|
 | `user` | Inline chat bubble | "You" label, plain text |
 | `agent` | `ReactMarkdown` bubble + report/video `HarnessPlaceholder` | Last agent message: gated reports and last-turn videos open in `HarnessPanel` |
-| `tool_call` | `renderToolCard()` | Collapsible tool invocation card |
-| `tool_result` | `renderToolCard()` | Collapsible tool response card |
+| `tool_call` | `ToolActivityBlock` | Grouped with contiguous results; categorized collapsed summary |
+| `tool_result` | `ToolActivityBlock` | Paired into the same activity block as its call |
 | `browser_handoff` | `HarnessPlaceholder` → `HarnessPanel`/`BrowserView` | VNC proxy fills the right panel |
 | `image` | Inline `<img>` | Base64 data URI |
 | `error` | Red error `<div>` | Plain text |

--- a/web/src/components/StudioChat.tsx
+++ b/web/src/components/StudioChat.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { Send, Plus, Trash2, MessageSquare, ChevronRight, ChevronDown, Loader, Square, Copy, Check, Code, RotateCcw, Wrench, Clock, Search, Users, Info, FileText, Globe, ListChecks, AppWindow, Brain, Paperclip, X } from 'lucide-react'
+import { Send, Plus, Trash2, MessageSquare, ChevronRight, ChevronDown, Loader, Square, Copy, Check, Code, RotateCcw, Clock, Search, Users, Info, FileText, Globe, ListChecks, AppWindow, Brain, Paperclip, X } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { markdownComponents } from './chat/markdownComponents'
@@ -8,7 +8,9 @@ import type { ChatSession, AttachmentPayload, SessionModelStatus } from '../api/
 import { startFleetSession, connectFleetStream, sendFleetMessage, stopFleetSession, fetchFleetSessions } from '../api/fleetChat'
 import type { FleetSession } from '../api/fleetChat'
 import HomePage from './HomePage'
-import type { FleetMessageItem, ChatMsg, FleetInfo, FleetStateInfo, DeferredPrompt, FleetExecutionMessage, FleetEvent, AgentMessage, ToolCallMessage, ToolResultMessage, BrowserHandoffMessage, SubTaskExecutionMessage, SubTaskEvent, SubTaskInfo, PlanMessage, PlanStepInfo, SessionArtifact, ArtifactMessage, AppPreviewMessage, AppSavedMessage, DistillPreviewMessage, DistillSavedMessage, TutorialBlueprintPreviewMessage, TutorialBlueprintApprovedMessage, TutorialSceneSlideshowMessage, UserMessage, AttachmentInfo, NetworkDenialMessage, ImageMessage } from './chat/chatTypes'
+import type { FleetMessageItem, ChatMsg, FleetInfo, FleetStateInfo, DeferredPrompt, FleetExecutionMessage, FleetEvent, AgentMessage, ToolResultMessage, BrowserHandoffMessage, SubTaskExecutionMessage, SubTaskEvent, SubTaskInfo, PlanMessage, PlanStepInfo, SessionArtifact, ArtifactMessage, AppPreviewMessage, AppSavedMessage, DistillPreviewMessage, DistillSavedMessage, TutorialBlueprintPreviewMessage, TutorialBlueprintApprovedMessage, TutorialSceneSlideshowMessage, UserMessage, AttachmentInfo, NetworkDenialMessage, ImageMessage } from './chat/chatTypes'
+import { buildActivityRenderIndex, deriveLiveStreamStatus } from './chat/toolActivity'
+import ToolActivityBlock from './chat/ToolActivityBlock'
 import { getAgentColor } from './chat/chatTypes'
 import FleetStartDialog from './chat/FleetStartDialog'
 import FleetTemplatePicker from './chat/FleetTemplatePicker'
@@ -274,7 +276,6 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
   const [slashIndex, setSlashIndex] = useState(0)
 
   // UI state
-  const [expandedTools, setExpandedTools] = useState<Set<number>>(new Set())
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
   const [rawViewIndices, setRawViewIndices] = useState<Set<number>>(new Set())
   const [expandedCodeIndices, setExpandedCodeIndices] = useState<Set<number>>(new Set())
@@ -2547,15 +2548,6 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     return slashCommands.filter(c => c.cmd.slice(1).startsWith(slashFilter))
   }, [slashFilter, slashCommands])
 
-  const toggleToolExpand = (index: number) => {
-    setExpandedTools(prev => {
-      const next = new Set(prev)
-      if (next.has(index)) next.delete(index)
-      else next.add(index)
-      return next
-    })
-  }
-
   const toggleRawView = (index: number) => {
     setRawViewIndices(prev => {
       const next = new Set(prev)
@@ -2577,51 +2569,15 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     return sessions.filter(s => (s.title || s.id).toLowerCase().includes(q))
   }, [sessions, sessionFilter])
 
-  // Render a single tool call as a collapsible card
-  const renderToolCard = (msg: ChatMsg, index: number) => {
-    const toolMsg = msg as ToolCallMessage | ToolResultMessage
-    const isExpanded = expandedTools.has(index)
-    const isCall = msg.type === 'tool_call'
-    const name = (toolMsg as any).toolName || 'unknown'
-    const data = isCall ? (toolMsg as ToolCallMessage).toolArgs : (toolMsg as ToolResultMessage).toolResult
+  const { activityByStart, skipIndices: toolActivitySkipIndices } = useMemo(
+    () => buildActivityRenderIndex(messages),
+    [messages],
+  )
 
-    return (
-      <div
-        key={index}
-        className="my-2 rounded-lg overflow-hidden"
-        style={{
-          border: '1px solid var(--border-color)',
-          background: theme === 'dark' ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
-        }}
-      >
-        <button
-          onClick={() => toggleToolExpand(index)}
-          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-purple-500/5 transition-colors"
-        >
-          {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          <Wrench size={14} className="text-purple-400" />
-          <span className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
-            {isCall ? 'Tool Call' : 'Tool Result'}: <code className="bg-purple-500/15 px-1.5 py-0.5 rounded text-purple-300">{name}</code>
-          </span>
-        </button>
-        {isExpanded && !!data && (
-          <div className="px-3 pb-3">
-            <pre
-              className="text-xs whitespace-pre-wrap break-words font-mono p-2 rounded"
-              style={{
-                background: theme === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.05)',
-                color: 'var(--text-secondary)',
-                maxHeight: '300px',
-                overflowY: 'auto',
-              }}
-            >
-              {typeof data === 'string' ? data : JSON.stringify(data, null, 2)}
-            </pre>
-          </div>
-        ) as React.ReactNode}
-      </div>
-    )
-  }
+  const liveStreamStatus = useMemo(
+    () => (isStreaming ? deriveLiveStreamStatus(messages) : null),
+    [isStreaming, messages],
+  )
 
   return (
     <>
@@ -3013,7 +2969,18 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
               }
 
               if (msg.type === 'tool_call' || msg.type === 'tool_result') {
-                return renderToolCard(msg, index)
+                if (toolActivitySkipIndices.has(index)) return null
+                const activity = activityByStart.get(index)
+                if (!activity) return null
+                const streamingActivity = isStreaming && activity.end === messages.length - 1
+                return (
+                  <ToolActivityBlock
+                    key={`activity-${activity.start}`}
+                    blockId={`activity-${activity.start}`}
+                    steps={activity.steps}
+                    streaming={streamingActivity}
+                  />
+                )
               }
 
               if (msg.type === 'browser_handoff') {
@@ -3403,9 +3370,9 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
           {/* Streaming indicator */}
           {isStreaming && !isFleetMode && messages.length > 0 && messages[messages.length - 1]?.type !== 'fleet_execution' && (
-            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-purple-500/10 border border-purple-500/20 w-fit">
-              <Loader size={14} className="text-purple-400 animate-spin" />
-              <span className="text-xs text-purple-300">Processing...</span>
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-purple-500/10 border border-purple-500/20 w-fit max-w-full">
+              <Loader size={14} className="text-purple-400 animate-spin shrink-0" />
+              <span className="text-xs text-purple-300 truncate">{liveStreamStatus || 'Thinking…'}</span>
             </div>
           )}
         </div>

--- a/web/src/components/chat/ToolActivityBlock.tsx
+++ b/web/src/components/chat/ToolActivityBlock.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react'
+import { AlertCircle, Check, ChevronDown, ChevronRight, Loader } from 'lucide-react'
+import {
+  activityStats,
+  activitySummary,
+  formatToolPayload,
+  previewValue,
+  type ActivityStats,
+  type ToolActivityStep,
+} from './toolActivity'
+
+interface ToolActivityBlockProps {
+  steps: ToolActivityStep[]
+  /** True when this block is the trailing activity during an active stream. */
+  streaming?: boolean
+  /** Stable key prefix for the block (e.g. activity start index). */
+  blockId: string
+}
+
+function StepStatusIcon({ status }: { status: ToolActivityStep['status'] }) {
+  if (status === 'running') {
+    return <Loader size={12} className="animate-spin shrink-0" style={{ color: 'var(--text-muted)' }} />
+  }
+  if (status === 'error') {
+    return <AlertCircle size={12} className="shrink-0" style={{ color: 'var(--danger)' }} />
+  }
+  return <Check size={12} className="shrink-0" style={{ color: 'var(--text-muted)' }} />
+}
+
+function TrailingMetric({ stats }: { stats: ActivityStats }) {
+  if (stats.kind === 'diff') {
+    return (
+      <span className="flex items-center gap-1.5 shrink-0 text-xs font-medium tabular-nums" data-testid="activity-diff">
+        {stats.added > 0 && (
+          <span style={{ color: 'var(--success)' }}>+{stats.added}</span>
+        )}
+        {stats.removed > 0 && (
+          <span style={{ color: 'var(--danger)' }}>-{stats.removed}</span>
+        )}
+      </span>
+    )
+  }
+  return (
+    <span
+      className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded tabular-nums"
+      data-testid="activity-badge"
+      style={{
+        color: 'var(--accent)',
+        background: 'var(--accent-soft)',
+      }}
+    >
+      {stats.count}
+    </span>
+  )
+}
+
+/**
+ * Cursor-style tool activity line with accent lead, muted rest, and trailing metric.
+ * Collapsed by default; expands to paired call/result steps.
+ */
+export default function ToolActivityBlock({ steps, streaming = false, blockId }: ToolActivityBlockProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set())
+
+  const summary = activitySummary(steps, { streaming })
+  const stats = activityStats(steps)
+  const showSpinner = summary.variant === 'running'
+
+  const toggleStep = (stepIndex: number) => {
+    setExpandedSteps(prev => {
+      const next = new Set(prev)
+      if (next.has(stepIndex)) next.delete(stepIndex)
+      else next.add(stepIndex)
+      return next
+    })
+  }
+
+  return (
+    <div
+      className="my-0.5 text-sm"
+      data-testid="tool-activity-block"
+      data-block-id={blockId}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="group inline-flex max-w-full items-center gap-1.5 py-0.5 text-left"
+        style={{
+          cursor: 'pointer',
+          background: 'transparent',
+          border: 'none',
+        }}
+        aria-expanded={expanded}
+        aria-label={summary.text}
+      >
+        {showSpinner && (
+          <Loader size={12} className="animate-spin shrink-0" style={{ color: 'var(--accent)' }} />
+        )}
+        {summary.variant === 'error' && !showSpinner && (
+          <AlertCircle size={12} className="shrink-0" style={{ color: 'var(--danger)' }} />
+        )}
+        <span className="text-xs truncate min-w-0">
+          <span style={{ color: 'var(--accent)', fontWeight: 500 }}>
+            {summary.lead}
+          </span>
+          {summary.rest && (
+            <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>
+              {summary.rest}
+            </span>
+          )}
+          {summary.errorSuffix && (
+            <span style={{ color: 'var(--danger)', fontWeight: 400 }}>
+              {summary.errorSuffix}
+            </span>
+          )}
+        </span>
+        {!showSpinner && <TrailingMetric stats={stats} />}
+        <span
+          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          data-testid="activity-chevron"
+          aria-hidden
+        >
+          {expanded ? (
+            <ChevronDown size={14} style={{ color: 'var(--text-secondary)' }} />
+          ) : (
+            <ChevronRight size={14} style={{ color: 'var(--text-secondary)' }} />
+          )}
+        </span>
+      </button>
+
+      {expanded && (
+        <div
+          className="mt-1 rounded-lg overflow-hidden"
+          style={{
+            border: '1px solid var(--border-color)',
+            background: 'var(--bg-secondary)',
+          }}
+        >
+          {steps.map((step, stepIndex) => {
+            const stepOpen = expandedSteps.has(stepIndex)
+            const preview = step.status === 'running'
+              ? previewValue(step.args)
+              : previewValue(step.result ?? step.args)
+            return (
+              <div key={`${blockId}-step-${stepIndex}`}>
+                {stepIndex > 0 && (
+                  <div style={{ borderTop: '1px solid var(--border-color)' }} />
+                )}
+                <button
+                  type="button"
+                  onClick={() => toggleStep(stepIndex)}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-black/5 dark:hover:bg-white/5"
+                  style={{ color: 'var(--text-secondary)' }}
+                  aria-expanded={stepOpen}
+                >
+                  {stepOpen ? (
+                    <ChevronDown size={12} className="shrink-0" style={{ color: 'var(--text-muted)' }} />
+                  ) : (
+                    <ChevronRight size={12} className="shrink-0" style={{ color: 'var(--text-muted)' }} />
+                  )}
+                  <StepStatusIcon status={step.status} />
+                  <code
+                    className="text-xs px-1 py-0.5 rounded shrink-0"
+                    style={{
+                      background: 'var(--bg-tertiary, rgba(0,0,0,0.06))',
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    {step.toolName}
+                  </code>
+                  {preview && (
+                    <span className="text-xs truncate flex-1" style={{ color: 'var(--text-muted)' }}>
+                      {preview}
+                    </span>
+                  )}
+                </button>
+                {stepOpen && (
+                  <div className="px-3 pb-2 space-y-2">
+                    {step.args !== undefined && (
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>
+                          Arguments
+                        </div>
+                        <pre
+                          className="text-xs whitespace-pre-wrap break-words font-mono p-2 rounded"
+                          style={{
+                            background: 'var(--bg-primary, rgba(0,0,0,0.2))',
+                            color: 'var(--text-secondary)',
+                            maxHeight: 240,
+                            overflowY: 'auto',
+                          }}
+                        >
+                          {formatToolPayload(step.args)}
+                        </pre>
+                      </div>
+                    )}
+                    {step.result !== undefined && (
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>
+                          Result
+                        </div>
+                        <pre
+                          className="text-xs whitespace-pre-wrap break-words font-mono p-2 rounded"
+                          style={{
+                            background: 'var(--bg-primary, rgba(0,0,0,0.2))',
+                            color: 'var(--text-secondary)',
+                            maxHeight: 240,
+                            overflowY: 'auto',
+                          }}
+                        >
+                          {formatToolPayload(step.result)}
+                        </pre>
+                      </div>
+                    )}
+                    {step.status === 'running' && step.result === undefined && (
+                      <div className="text-xs flex items-center gap-1.5 py-1" style={{ color: 'var(--text-muted)' }}>
+                        <Loader size={12} className="animate-spin" />
+                        Waiting for result…
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/chat/__tests__/ToolActivityBlock.test.tsx
+++ b/web/src/components/chat/__tests__/ToolActivityBlock.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ToolActivityBlock from '../ToolActivityBlock'
+import type { ToolActivityStep } from '../toolActivity'
+
+const completeSteps: ToolActivityStep[] = [
+  {
+    toolName: 'search_tools',
+    args: { query: 'http' },
+    result: { tools: ['http_request'] },
+    status: 'complete',
+    callIndex: 0,
+    resultIndex: 1,
+  },
+  {
+    toolName: 'http_request',
+    args: { url: 'https://example.com' },
+    result: { status: 200 },
+    status: 'complete',
+    callIndex: 2,
+    resultIndex: 3,
+  },
+]
+
+describe('ToolActivityBlock', () => {
+  it('renders a two-tone collapsed summary with step badge', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-0"
+        steps={completeSteps}
+      />,
+    )
+    expect(screen.getByTestId('tool-activity-block')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /1 search, 1 request/ })).toBeInTheDocument()
+    expect(screen.getByTestId('activity-badge')).toHaveTextContent('2')
+    expect(screen.queryByText('Arguments')).not.toBeInTheDocument()
+  })
+
+  it('expands to show step rows and nested payloads', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-0"
+        steps={completeSteps}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /1 search, 1 request/ }))
+    expect(screen.getByText('search_tools')).toBeInTheDocument()
+    expect(screen.getByText('http_request')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('http_request'))
+    expect(screen.getByText('Arguments')).toBeInTheDocument()
+    expect(screen.getByText('Result')).toBeInTheDocument()
+    expect(screen.getByText(/example\.com/)).toBeInTheDocument()
+  })
+
+  it('shows a live running hint while streaming', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-1"
+        streaming
+        steps={[
+          {
+            toolName: 'http_request',
+            args: { url: 'https://example.com' },
+            status: 'running',
+            callIndex: 0,
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /Fetching https:\/\/example\.com with http_request/ })).toBeInTheDocument()
+  })
+
+  it('surfaces failed tools and keeps expand affordance', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-2"
+        steps={[
+          {
+            toolName: 'http_request',
+            args: {},
+            result: { error: 'timeout' },
+            status: 'error',
+            callIndex: 0,
+            resultIndex: 1,
+          },
+        ]}
+      />,
+    )
+    const header = screen.getByRole('button', { name: /1 request · http_request failed/ })
+    expect(header).toBeInTheDocument()
+    expect(screen.getByTestId('activity-badge')).toHaveTextContent('1')
+  })
+
+  it('shows green/red diff stats for edit_file content', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-3"
+        steps={[
+          {
+            toolName: 'edit_file',
+            status: 'complete',
+            callIndex: 0,
+            args: {
+              path: 'a.ts',
+              old_string: 'a\nb',
+              new_string: 'a\nb\nc\nd',
+            },
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /Edited 1 file/ })).toBeInTheDocument()
+    const diff = screen.getByTestId('activity-diff')
+    expect(diff).toHaveTextContent('+4')
+    expect(diff).toHaveTextContent('-2')
+  })
+
+  it('keeps badge beside the summary and hides the chevron until hover', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-0"
+        steps={completeSteps}
+      />,
+    )
+    const header = screen.getByRole('button', { name: /1 search, 1 request/ })
+    expect(header).toHaveClass('inline-flex')
+    expect(screen.getByTestId('activity-badge')).toHaveTextContent('2')
+    const chevron = screen.getByTestId('activity-chevron')
+    expect(chevron).toHaveClass('opacity-0')
+    expect(chevron).toHaveClass('group-hover:opacity-100')
+  })
+})

--- a/web/src/components/chat/__tests__/toolActivity.test.ts
+++ b/web/src/components/chat/__tests__/toolActivity.test.ts
@@ -80,6 +80,29 @@ describe('groupToolActivity', () => {
     expect(segs[0].steps[0].status).toBe('running')
   })
 
+  it('pairs parallel call/call/result/result by tool name FIFO', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'web_search', toolArgs: { query: 'a' } },
+      { type: 'tool_call', toolName: 'read_file', toolArgs: { path: '/x' } },
+      { type: 'tool_result', toolName: 'web_search', toolResult: 'hits' },
+      { type: 'tool_result', toolName: 'read_file', toolResult: 'body' },
+    ]
+    const segs = groupToolActivity(messages)
+    expect(segs).toHaveLength(1)
+    if (segs[0].kind !== 'activity') throw new Error('expected activity')
+    expect(segs[0].steps).toHaveLength(2)
+    expect(segs[0].steps[0]).toMatchObject({
+      toolName: 'web_search',
+      status: 'complete',
+      result: 'hits',
+    })
+    expect(segs[0].steps[1]).toMatchObject({
+      toolName: 'read_file',
+      status: 'complete',
+      result: 'body',
+    })
+  })
+
   it('marks error results', () => {
     const messages: ChatMsg[] = [
       { type: 'tool_call', toolName: 'http_request', toolArgs: {} },
@@ -96,6 +119,7 @@ describe('categorizeTool', () => {
     expect(categorizeTool('write_file')).toBe('edit')
     expect(categorizeTool('read_file')).toBe('explore')
     expect(categorizeTool('grep_search')).toBe('search')
+    expect(categorizeTool('web_search')).toBe('search')
     expect(categorizeTool('http_request')).toBe('request')
     expect(categorizeTool('shell_command')).toBe('command')
     expect(categorizeTool('browser_navigate')).toBe('browser')

--- a/web/src/components/chat/__tests__/toolActivity.test.ts
+++ b/web/src/components/chat/__tests__/toolActivity.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatMsg } from '../chatTypes'
+import {
+  activityStats,
+  activitySummary,
+  buildActivityRenderIndex,
+  categorizeTool,
+  deriveLiveStreamStatus,
+  extractPathHint,
+  groupToolActivity,
+  isToolResultError,
+  liveActivityHint,
+  previewValue,
+  splitActivitySummary,
+} from '../toolActivity'
+
+describe('isToolResultError', () => {
+  it('detects success: false and error fields', () => {
+    expect(isToolResultError({ success: false })).toBe(true)
+    expect(isToolResultError({ error: 'boom' })).toBe(true)
+    expect(isToolResultError({ ok: false })).toBe(true)
+    expect(isToolResultError({ status: 'failed' })).toBe(true)
+  })
+
+  it('does not flag successful results', () => {
+    expect(isToolResultError({ success: true, data: 1 })).toBe(false)
+    expect(isToolResultError('ok')).toBe(false)
+    expect(isToolResultError(null)).toBe(false)
+  })
+})
+
+describe('previewValue', () => {
+  it('stringifies and truncates', () => {
+    expect(previewValue({ url: 'https://example.com' })).toContain('example.com')
+    expect(previewValue('a'.repeat(100), 20).endsWith('…')).toBe(true)
+  })
+})
+
+describe('groupToolActivity', () => {
+  it('pairs contiguous call/result and splits on agent text', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'hi' },
+      { type: 'tool_call', toolName: 'search_tools', toolArgs: { q: 'x' } },
+      { type: 'tool_result', toolName: 'search_tools', toolResult: { ok: true } },
+      { type: 'tool_call', toolName: 'http_request', toolArgs: { url: 'https://a' } },
+      { type: 'tool_result', toolName: 'http_request', toolResult: 'body' },
+      { type: 'agent', content: 'done' },
+      { type: 'tool_call', toolName: 'write_file', toolArgs: { path: 'a.md' } },
+      { type: 'tool_result', toolName: 'write_file', toolResult: { path: 'a.md' } },
+    ]
+
+    const segs = groupToolActivity(messages)
+    expect(segs.map(s => s.kind)).toEqual([
+      'passthrough',
+      'activity',
+      'passthrough',
+      'activity',
+    ])
+
+    const first = segs[1]
+    expect(first.kind).toBe('activity')
+    if (first.kind !== 'activity') return
+    expect(first.start).toBe(1)
+    expect(first.end).toBe(4)
+    expect(first.steps).toHaveLength(2)
+    expect(first.steps[0].toolName).toBe('search_tools')
+    expect(first.steps[0].status).toBe('complete')
+    expect(first.steps[1].toolName).toBe('http_request')
+    expect(first.steps[1].result).toBe('body')
+  })
+
+  it('marks unpaired call as running', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'http_request', toolArgs: { url: 'https://a' } },
+    ]
+    const segs = groupToolActivity(messages)
+    expect(segs).toHaveLength(1)
+    expect(segs[0].kind).toBe('activity')
+    if (segs[0].kind !== 'activity') return
+    expect(segs[0].steps[0].status).toBe('running')
+  })
+
+  it('marks error results', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'http_request', toolArgs: {} },
+      { type: 'tool_result', toolName: 'http_request', toolResult: { error: 'timeout' } },
+    ]
+    const segs = groupToolActivity(messages)
+    if (segs[0].kind !== 'activity') throw new Error('expected activity')
+    expect(segs[0].steps[0].status).toBe('error')
+  })
+})
+
+describe('categorizeTool', () => {
+  it('maps built-ins and prefixes', () => {
+    expect(categorizeTool('write_file')).toBe('edit')
+    expect(categorizeTool('read_file')).toBe('explore')
+    expect(categorizeTool('grep_search')).toBe('search')
+    expect(categorizeTool('http_request')).toBe('request')
+    expect(categorizeTool('shell_command')).toBe('command')
+    expect(categorizeTool('browser_navigate')).toBe('browser')
+    expect(categorizeTool('memory_get')).toBe('memory')
+    expect(categorizeTool('custom_mcp_tool')).toBe('other')
+  })
+})
+
+describe('extractPathHint', () => {
+  it('reads common path-like args', () => {
+    expect(extractPathHint({ path: 'a.md' })).toBe('a.md')
+    expect(extractPathHint({ url: 'https://x' })).toBe('https://x')
+    expect(extractPathHint({ query: 'x' })).toBeUndefined()
+  })
+})
+
+describe('activitySummary', () => {
+  it('shows rich running hint while streaming', () => {
+    const summary = activitySummary(
+      [{ toolName: 'http_request', status: 'running', callIndex: 0, args: { url: 'https://example.com/api' } }],
+      { streaming: true },
+    )
+    expect(summary.variant).toBe('running')
+    expect(summary.text).toBe('Fetching https://example.com/api with http_request')
+    expect(summary.lead).toBe('Fetching')
+  })
+
+  it('summarizes completed tools with human categories', () => {
+    const summary = activitySummary([
+      { toolName: 'search_tools', status: 'complete', callIndex: 0 },
+      { toolName: 'http_request', status: 'complete', callIndex: 1 },
+      { toolName: 'write_file', status: 'complete', callIndex: 2, args: { path: 'a.md' } },
+      { toolName: 'write_file', status: 'complete', callIndex: 3, args: { path: 'b.md' } },
+      { toolName: 'read_file', status: 'complete', callIndex: 4, args: { path: 'a.md' } },
+      { toolName: 'read_file', status: 'complete', callIndex: 5, args: { path: 'c.md' } },
+      { toolName: 'grep_search', status: 'complete', callIndex: 6 },
+    ])
+    expect(summary.variant).toBe('complete')
+    expect(summary.text).toBe('Edited 2 files, explored 2 files, 2 searches, 1 request')
+  })
+
+  it('folds unknown tools into other', () => {
+    const summary = activitySummary([
+      { toolName: 'a', status: 'complete', callIndex: 0 },
+      { toolName: 'b', status: 'complete', callIndex: 1 },
+      { toolName: 'c', status: 'complete', callIndex: 2 },
+      { toolName: 'd', status: 'complete', callIndex: 3 },
+    ])
+    expect(summary.text).toBe('Used 4 other tools')
+  })
+
+  it('highlights failures after categorized body', () => {
+    const summary = activitySummary([
+      { toolName: 'write_file', status: 'complete', callIndex: 0, args: { path: 'a.md' } },
+      { toolName: 'http_request', status: 'error', callIndex: 1 },
+    ])
+    expect(summary.variant).toBe('error')
+    expect(summary.text).toBe('Edited 1 file, 1 request · http_request failed')
+    expect(summary.lead).toBe('Edited')
+    expect(summary.rest).toBe(' 1 file, 1 request')
+    expect(summary.errorSuffix).toBe(' · http_request failed')
+  })
+
+  it('splits lead/rest for mixed categories', () => {
+    const summary = activitySummary([
+      { toolName: 'write_file', status: 'complete', callIndex: 0, args: { path: 'a.md' } },
+      { toolName: 'grep_search', status: 'complete', callIndex: 1 },
+    ])
+    expect(summary.lead).toBe('Edited')
+    expect(summary.rest).toBe(' 1 file, 1 search')
+  })
+
+  it('splits live hints into accent lead + muted rest', () => {
+    const parts = splitActivitySummary(
+      'Running `ls -lah` with shell_command',
+      'running',
+    )
+    expect(parts.lead).toBe('Running')
+    expect(parts.rest).toBe(' `ls -lah` with shell_command')
+  })
+})
+
+describe('liveActivityHint', () => {
+  it('includes shell command text', () => {
+    expect(liveActivityHint({
+      toolName: 'shell_command',
+      status: 'running',
+      callIndex: 0,
+      args: { command: 'ls -lah' },
+    })).toBe('Running `ls -lah` with shell_command')
+  })
+
+  it('includes edit path', () => {
+    expect(liveActivityHint({
+      toolName: 'edit_file',
+      status: 'running',
+      callIndex: 0,
+      args: { path: 'web/src/App.tsx' },
+    })).toBe('Editing web/src/App.tsx with edit_file')
+  })
+
+  it('describes credential tools', () => {
+    expect(liveActivityHint({
+      toolName: 'list_credentials',
+      status: 'running',
+      callIndex: 0,
+      args: {},
+    })).toBe('Listing credentials with list_credentials')
+  })
+
+  it('truncates long commands', () => {
+    const long = 'echo ' + 'x'.repeat(80)
+    const hint = liveActivityHint({
+      toolName: 'shell_command',
+      status: 'running',
+      callIndex: 0,
+      args: { command: long },
+    })
+    expect(hint.startsWith('Running `')).toBe(true)
+    expect(hint.includes('…')).toBe(true)
+    expect(hint.endsWith('with shell_command')).toBe(true)
+    expect(hint.length).toBeLessThan(long.length + 40)
+  })
+
+  it('falls back to tool name', () => {
+    expect(liveActivityHint({
+      toolName: 'custom_mcp_tool',
+      status: 'running',
+      callIndex: 0,
+    })).toBe('Running custom_mcp_tool')
+  })
+})
+
+describe('deriveLiveStreamStatus', () => {
+  it('returns live hint when last message is a running tool', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'hi' },
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: { command: 'pwd' } },
+    ]
+    expect(deriveLiveStreamStatus(messages)).toBe('Running `pwd` with shell_command')
+  })
+
+  it('returns Thinking… when streaming without an open tool', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'hi' },
+      { type: 'agent', content: 'working', _streaming: true },
+    ]
+    expect(deriveLiveStreamStatus(messages)).toBe('Thinking…')
+  })
+})
+
+describe('activityStats', () => {
+  it('infers +/- lines from edit_file args', () => {
+    const stats = activityStats([
+      {
+        toolName: 'edit_file',
+        status: 'complete',
+        callIndex: 0,
+        args: {
+          path: 'a.ts',
+          old_string: 'a\nb\nc',
+          new_string: 'a\nb\nc\nd\ne',
+        },
+      },
+    ])
+    expect(stats).toEqual({ kind: 'diff', added: 5, removed: 3 })
+  })
+
+  it('falls back to a step badge when no edit content', () => {
+    const stats = activityStats([
+      { toolName: 'shell_command', status: 'complete', callIndex: 0 },
+      { toolName: 'http_request', status: 'complete', callIndex: 1 },
+    ])
+    expect(stats).toEqual({ kind: 'badge', count: 2 })
+  })
+})
+
+describe('buildActivityRenderIndex', () => {
+  it('maps start indices and skips covered ones', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'a', toolArgs: {} },
+      { type: 'tool_result', toolName: 'a', toolResult: {} },
+      { type: 'agent', content: 'x' },
+    ]
+    const { activityByStart, skipIndices } = buildActivityRenderIndex(messages)
+    expect(activityByStart.has(0)).toBe(true)
+    expect(skipIndices.has(1)).toBe(true)
+    expect(skipIndices.has(0)).toBe(false)
+  })
+})

--- a/web/src/components/chat/toolActivity.ts
+++ b/web/src/components/chat/toolActivity.ts
@@ -99,45 +99,45 @@ export function formatToolPayload(data: unknown): string {
 
 function pairSteps(messages: ChatMsg[], start: number, end: number): ToolActivityStep[] {
   const steps: ToolActivityStep[] = []
-  let i = start
-  while (i <= end) {
+  // FIFO queues of step indices awaiting a result, keyed by tool name.
+  // Handles parallel call/call/result/result ordering.
+  const pendingByName = new Map<string, number[]>()
+
+  for (let i = start; i <= end; i++) {
     const msg = messages[i]
     if (!isToolMessage(msg)) break
 
     if (msg.type === 'tool_call') {
       const name = toolNameOf(msg)
-      const next = i + 1 <= end ? messages[i + 1] : null
-      if (next && next.type === 'tool_result' && toolNameOf(next) === name) {
-        const result = next.toolResult
-        steps.push({
-          toolName: name,
-          args: msg.toolArgs,
-          result,
-          status: isToolResultError(result) ? 'error' : 'complete',
-          callIndex: i,
-          resultIndex: i + 1,
-        })
-        i += 2
-      } else {
-        steps.push({
-          toolName: name,
-          args: msg.toolArgs,
-          status: 'running',
-          callIndex: i,
-        })
-        i += 1
-      }
+      const stepIndex = steps.length
+      steps.push({
+        toolName: name,
+        args: msg.toolArgs,
+        status: 'running',
+        callIndex: i,
+      })
+      const queue = pendingByName.get(name) || []
+      queue.push(stepIndex)
+      pendingByName.set(name, queue)
     } else {
       const name = toolNameOf(msg)
       const result = msg.toolResult
-      steps.push({
-        toolName: name,
-        result,
-        status: isToolResultError(result) ? 'error' : 'complete',
-        callIndex: i,
-        resultIndex: i,
-      })
-      i += 1
+      const queue = pendingByName.get(name)
+      const pendingIdx = queue?.shift()
+      if (pendingIdx !== undefined) {
+        const step = steps[pendingIdx]
+        step.result = result
+        step.resultIndex = i
+        step.status = isToolResultError(result) ? 'error' : 'complete'
+      } else {
+        steps.push({
+          toolName: name,
+          result,
+          status: isToolResultError(result) ? 'error' : 'complete',
+          callIndex: i,
+          resultIndex: i,
+        })
+      }
     }
   }
   return steps
@@ -206,6 +206,7 @@ const EXACT_CATEGORY: Record<string, ToolActivityCategory> = {
   search_tools: 'search',
   search_flows: 'search',
   email_search: 'search',
+  web_search: 'search',
   http_request: 'request',
   web_fetch: 'request',
   shell_command: 'command',

--- a/web/src/components/chat/toolActivity.ts
+++ b/web/src/components/chat/toolActivity.ts
@@ -1,0 +1,567 @@
+import type { ChatMsg, ToolCallMessage, ToolResultMessage } from './chatTypes'
+
+export type ToolStepStatus = 'running' | 'complete' | 'error'
+
+export interface ToolActivityStep {
+  toolName: string
+  args?: unknown
+  result?: unknown
+  status: ToolStepStatus
+  callIndex: number
+  resultIndex?: number
+}
+
+export type MessageSegment =
+  | { kind: 'passthrough'; index: number }
+  | { kind: 'activity'; start: number; end: number; steps: ToolActivityStep[] }
+
+export type ActivitySummaryVariant = 'running' | 'complete' | 'error'
+
+export interface ActivitySummary {
+  text: string
+  variant: ActivitySummaryVariant
+  /** Accent-colored lead (verb or first clause). */
+  lead: string
+  /** Muted remainder of the categorized phrase. */
+  rest: string
+  /** Error fragment including leading " · ", rendered in danger color. */
+  errorSuffix?: string
+}
+
+export type ActivityStats =
+  | { kind: 'diff'; added: number; removed: number }
+  | { kind: 'badge'; count: number }
+
+function isToolMessage(msg: ChatMsg): msg is ToolCallMessage | ToolResultMessage {
+  return msg.type === 'tool_call' || msg.type === 'tool_result'
+}
+
+function toolNameOf(msg: ToolCallMessage | ToolResultMessage): string {
+  const name = msg.toolName
+  if (typeof name === 'string' && name) return name
+  return 'unknown'
+}
+
+/** Detect common error shapes in tool results. */
+export function isToolResultError(result: unknown): boolean {
+  if (result == null) return false
+  if (typeof result === 'string') {
+    const head = result.slice(0, 300).toLowerCase()
+    return (
+      head.startsWith('error:') ||
+      head.startsWith('error ') ||
+      head.includes('\nerror:') ||
+      /^failed\b/i.test(result.slice(0, 80))
+    )
+  }
+  if (typeof result === 'object') {
+    const r = result as Record<string, unknown>
+    if (r.success === false) return true
+    if (r.ok === false) return true
+    if (r.status === 'error' || r.status === 'failed') return true
+    if (typeof r.error === 'string' && r.error.trim() !== '') return true
+    if (r.error && typeof r.error === 'object') return true
+  }
+  return false
+}
+
+/** One-line preview of args/result for collapsed step rows. */
+export function previewValue(data: unknown, maxLen = 80): string {
+  if (data == null) return ''
+  let text: string
+  if (typeof data === 'string') {
+    text = data
+  } else {
+    try {
+      text = JSON.stringify(data)
+    } catch {
+      text = String(data)
+    }
+  }
+  text = text.replace(/\s+/g, ' ').trim()
+  if (text.length <= maxLen) return text
+  return text.slice(0, maxLen - 1) + '…'
+}
+
+function formatToolResult(data: unknown): string {
+  if (typeof data === 'string') return data
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch {
+    return String(data)
+  }
+}
+
+/** Full pretty-printed payload for expanded step detail. */
+export function formatToolPayload(data: unknown): string {
+  return formatToolResult(data)
+}
+
+function pairSteps(messages: ChatMsg[], start: number, end: number): ToolActivityStep[] {
+  const steps: ToolActivityStep[] = []
+  let i = start
+  while (i <= end) {
+    const msg = messages[i]
+    if (!isToolMessage(msg)) break
+
+    if (msg.type === 'tool_call') {
+      const name = toolNameOf(msg)
+      const next = i + 1 <= end ? messages[i + 1] : null
+      if (next && next.type === 'tool_result' && toolNameOf(next) === name) {
+        const result = next.toolResult
+        steps.push({
+          toolName: name,
+          args: msg.toolArgs,
+          result,
+          status: isToolResultError(result) ? 'error' : 'complete',
+          callIndex: i,
+          resultIndex: i + 1,
+        })
+        i += 2
+      } else {
+        steps.push({
+          toolName: name,
+          args: msg.toolArgs,
+          status: 'running',
+          callIndex: i,
+        })
+        i += 1
+      }
+    } else {
+      const name = toolNameOf(msg)
+      const result = msg.toolResult
+      steps.push({
+        toolName: name,
+        result,
+        status: isToolResultError(result) ? 'error' : 'complete',
+        callIndex: i,
+        resultIndex: i,
+      })
+      i += 1
+    }
+  }
+  return steps
+}
+
+/**
+ * Fold contiguous tool_call / tool_result messages into activity segments.
+ * Non-tool messages remain passthrough by index.
+ */
+export function groupToolActivity(messages: ChatMsg[]): MessageSegment[] {
+  const segments: MessageSegment[] = []
+  let i = 0
+  while (i < messages.length) {
+    if (!isToolMessage(messages[i])) {
+      segments.push({ kind: 'passthrough', index: i })
+      i += 1
+      continue
+    }
+    const start = i
+    while (i < messages.length && isToolMessage(messages[i])) {
+      i += 1
+    }
+    const end = i - 1
+    segments.push({
+      kind: 'activity',
+      start,
+      end,
+      steps: pairSteps(messages, start, end),
+    })
+  }
+  return segments
+}
+
+export type ToolActivityCategory =
+  | 'edit'
+  | 'explore'
+  | 'search'
+  | 'request'
+  | 'command'
+  | 'browser'
+  | 'memory'
+  | 'other'
+
+const CATEGORY_ORDER: ToolActivityCategory[] = [
+  'edit',
+  'explore',
+  'search',
+  'request',
+  'command',
+  'browser',
+  'memory',
+  'other',
+]
+
+const EXACT_CATEGORY: Record<string, ToolActivityCategory> = {
+  write_file: 'edit',
+  edit_file: 'edit',
+  read_file: 'explore',
+  file_tree: 'explore',
+  find_files: 'explore',
+  repo_map: 'explore',
+  code_definition: 'explore',
+  code_references: 'explore',
+  read_pdf: 'explore',
+  grep_search: 'search',
+  search_tools: 'search',
+  search_flows: 'search',
+  email_search: 'search',
+  http_request: 'request',
+  web_fetch: 'request',
+  shell_command: 'command',
+  process_read: 'command',
+  process_write: 'command',
+  process_list: 'command',
+  process_kill: 'command',
+}
+
+/** Map a tool name to a human activity category. */
+export function categorizeTool(name: string): ToolActivityCategory {
+  const key = (name || '').toLowerCase()
+  if (EXACT_CATEGORY[key]) return EXACT_CATEGORY[key]
+  if (key.startsWith('browser_')) return 'browser'
+  if (key.startsWith('memory_')) return 'memory'
+  if (key.startsWith('process_')) return 'command'
+  return 'other'
+}
+
+/** Pull a path/url hint from common tool arg shapes. */
+export function extractPathHint(args: unknown): string | undefined {
+  if (!args || typeof args !== 'object') return undefined
+  const a = args as Record<string, unknown>
+  for (const key of ['path', 'file', 'filename', 'glob', 'url']) {
+    const v = a[key]
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return undefined
+}
+
+function plural(n: number, singular: string, pluralForm?: string): string {
+  return n === 1 ? singular : (pluralForm ?? `${singular}s`)
+}
+
+function countForCategory(steps: ToolActivityStep[], category: ToolActivityCategory): number {
+  const inCat = steps.filter(s => categorizeTool(s.toolName) === category)
+  if (inCat.length === 0) return 0
+
+  if (category === 'edit' || category === 'explore') {
+    const paths = new Set<string>()
+    let missing = 0
+    for (const s of inCat) {
+      const hint = extractPathHint(s.args)
+      if (hint) paths.add(hint)
+      else missing += 1
+    }
+    return paths.size + missing
+  }
+
+  return inCat.length
+}
+
+function phraseForCategory(category: ToolActivityCategory, count: number, otherNames: string[]): string | null {
+  if (count <= 0) return null
+  switch (category) {
+    case 'edit':
+      return `Edited ${count} ${plural(count, 'file')}`
+    case 'explore':
+      return `explored ${count} ${plural(count, 'file')}`
+    case 'search':
+      return `${count} ${plural(count, 'search', 'searches')}`
+    case 'request':
+      return `${count} ${plural(count, 'request')}`
+    case 'command':
+      return `ran ${count} ${plural(count, 'command')}`
+    case 'browser':
+      return `${count} browser ${plural(count, 'action')}`
+    case 'memory':
+      return `${count} memory ${plural(count, 'lookup')}`
+    case 'other':
+      if (count === 1 && otherNames[0]) return `used ${otherNames[0]}`
+      return `used ${count} other ${plural(count, 'tool')}`
+  }
+}
+
+function buildCategorizedBody(steps: ToolActivityStep[]): string {
+  const otherNames: string[] = []
+  for (const s of steps) {
+    if (categorizeTool(s.toolName) === 'other') otherNames.push(s.toolName)
+  }
+
+  const parts: string[] = []
+  for (const cat of CATEGORY_ORDER) {
+    const count = countForCategory(steps, cat)
+    const phrase = phraseForCategory(cat, count, otherNames)
+    if (phrase) parts.push(phrase)
+  }
+
+  if (parts.length === 0) return 'Done'
+  // Capitalize first phrase only (Cursor style: "Edited 2 files, explored 3 files")
+  const [first, ...rest] = parts
+  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(', ')
+}
+
+function truncateDetail(s: string, maxLen = 60): string {
+  const t = s.replace(/\s+/g, ' ').trim()
+  if (t.length <= maxLen) return t
+  return t.slice(0, maxLen - 1) + '…'
+}
+
+function argString(args: unknown, ...keys: string[]): string | undefined {
+  if (!args || typeof args !== 'object') return undefined
+  const a = args as Record<string, unknown>
+  for (const key of keys) {
+    const v = a[key]
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return undefined
+}
+
+/**
+ * Informative in-flight status for a running tool step.
+ * e.g. `Running \`ls -lah\` with shell_command`
+ */
+export function liveActivityHint(step: ToolActivityStep): string {
+  const name = step.toolName || 'tool'
+  const key = name.toLowerCase()
+  const args = step.args
+  const path = extractPathHint(args)
+  const command = argString(args, 'command', 'cmd')
+  const query = argString(args, 'query', 'pattern', 'regex', 'search')
+  const credName = argString(args, 'name', 'credential', 'credential_name')
+
+  const withTool = (action: string, detail?: string) => {
+    if (detail) return `${action} ${detail} with ${name}`
+    return `${action} with ${name}`
+  }
+
+  if (key === 'shell_command' || key === 'process_write') {
+    if (command) return withTool('Running', `\`${truncateDetail(command)}\``)
+    return withTool('Running command')
+  }
+  if (key.startsWith('process_')) {
+    return withTool('Running process')
+  }
+  if (key === 'write_file' || key === 'edit_file') {
+    if (path) return withTool('Editing', truncateDetail(path))
+    return withTool('Editing')
+  }
+  if (key === 'read_file' || key === 'read_pdf') {
+    if (path) return withTool('Reading', truncateDetail(path))
+    return withTool('Reading')
+  }
+  if (key === 'file_tree' || key === 'find_files' || key === 'repo_map' || key === 'code_definition' || key === 'code_references') {
+    if (path) return withTool('Exploring', truncateDetail(path))
+    return withTool('Exploring')
+  }
+  if (key === 'grep_search' || key === 'search_tools' || key === 'search_flows' || key === 'email_search') {
+    if (query) return withTool('Searching for', `"${truncateDetail(query, 40)}"`)
+    return withTool('Searching')
+  }
+  if (key === 'http_request' || key === 'web_fetch') {
+    if (path) return withTool('Fetching', truncateDetail(path))
+    return withTool('Fetching')
+  }
+  if (key === 'list_credentials') {
+    return withTool('Listing credentials')
+  }
+  if (key === 'save_credential') {
+    if (credName) return withTool('Saving credential', truncateDetail(credName))
+    return withTool('Saving credential')
+  }
+  if (key === 'remove_credential') {
+    if (credName) return withTool('Removing credential', truncateDetail(credName))
+    return withTool('Removing credential')
+  }
+  if (key === 'test_credential' || key === 'resolve_credential') {
+    if (credName) return withTool('Using credential', truncateDetail(credName))
+    return withTool('Using credentials')
+  }
+  if (key.startsWith('credential') || key.includes('credential')) {
+    return withTool('Working with credentials')
+  }
+  if (key === 'browser_navigate') {
+    if (path) return withTool('Navigating to', truncateDetail(path))
+    return withTool('Navigating')
+  }
+  if (key.startsWith('browser_')) {
+    return withTool('Browsing')
+  }
+  if (key.startsWith('memory_')) {
+    if (query) return withTool('Looking up memory for', `"${truncateDetail(query, 40)}"`)
+    return withTool('Looking up memory')
+  }
+
+  if (command) return withTool('Running', `\`${truncateDetail(command)}\``)
+  if (path) return withTool('Running', truncateDetail(path))
+  if (query) return withTool('Running', `"${truncateDetail(query, 40)}"`)
+  return `Running ${name}`
+}
+
+/**
+ * Status for the bottom streaming pill: live tool hint, or Thinking… when idle between tools.
+ */
+export function deriveLiveStreamStatus(messages: ChatMsg[]): string {
+  const segs = groupToolActivity(messages)
+  for (let i = segs.length - 1; i >= 0; i--) {
+    const seg = segs[i]
+    if (seg.kind !== 'activity') continue
+    // Only mirror status when the activity is at the end of the transcript.
+    if (seg.end !== messages.length - 1) break
+    const running = [...seg.steps].reverse().find(s => s.status === 'running')
+    if (running) return liveActivityHint(running)
+    break
+  }
+  return 'Thinking…'
+}
+
+const LIVE_LEAD_VERBS =
+  /^(Running|Editing|Reading|Exploring|Searching|Fetching|Listing|Saving|Removing|Using|Navigating|Browsing|Looking)\b/
+
+const WHOLE_LEAD_PHRASES = [
+  'Looking up memory…',
+  'Running command…',
+  'Editing…',
+  'Exploring…',
+  'Searching…',
+  'Fetching…',
+  'Browsing…',
+  'Thinking…',
+  'No tools',
+  'Done',
+]
+
+/** Split summary text into accent lead + muted rest (+ optional error suffix). */
+export function splitActivitySummary(
+  text: string,
+  variant: ActivitySummaryVariant,
+): Pick<ActivitySummary, 'lead' | 'rest' | 'errorSuffix'> {
+  let body = text
+  let errorSuffix: string | undefined
+  if (variant === 'error') {
+    const idx = text.indexOf(' · ')
+    if (idx >= 0) {
+      body = text.slice(0, idx)
+      errorSuffix = text.slice(idx)
+    }
+  }
+
+  for (const phrase of WHOLE_LEAD_PHRASES) {
+    if (body === phrase) {
+      return { lead: phrase, rest: '', errorSuffix }
+    }
+    if (body.startsWith(phrase)) {
+      return { lead: phrase, rest: body.slice(phrase.length), errorSuffix }
+    }
+  }
+
+  const liveLead = body.match(LIVE_LEAD_VERBS)
+  if (liveLead) {
+    return {
+      lead: liveLead[1],
+      rest: body.slice(liveLead[1].length),
+      errorSuffix,
+    }
+  }
+
+  const verbMatch = body.match(/^(Edited|Explored|Ran|Used|Using)\b/)
+  if (verbMatch) {
+    return {
+      lead: verbMatch[1],
+      rest: body.slice(verbMatch[1].length),
+      errorSuffix,
+    }
+  }
+
+  const comma = body.indexOf(', ')
+  if (comma >= 0) {
+    return {
+      lead: body.slice(0, comma),
+      rest: body.slice(comma),
+      errorSuffix,
+    }
+  }
+
+  return { lead: body, rest: '', errorSuffix }
+}
+
+function withSplit(text: string, variant: ActivitySummaryVariant): ActivitySummary {
+  return { text, variant, ...splitActivitySummary(text, variant) }
+}
+
+function countLines(s: string): number {
+  if (!s) return 0
+  const parts = s.split('\n')
+  if (parts.length === 1 && parts[0] === '') return 0
+  // Ignore a single trailing newline so "a\n" counts as 1 line.
+  if (parts.length > 1 && parts[parts.length - 1] === '') {
+    return parts.length - 1
+  }
+  return parts.length
+}
+
+/**
+ * Trailing metric for the collapsed activity line.
+ * Prefer approximate +/− line counts from edit/write args; else a step badge.
+ */
+export function activityStats(steps: ToolActivityStep[]): ActivityStats {
+  let added = 0
+  let removed = 0
+  for (const s of steps) {
+    const name = (s.toolName || '').toLowerCase()
+    if (name !== 'write_file' && name !== 'edit_file') continue
+    if (!s.args || typeof s.args !== 'object') continue
+    const args = s.args as Record<string, unknown>
+    if (typeof args.content === 'string') added += countLines(args.content)
+    if (typeof args.new_string === 'string') added += countLines(args.new_string)
+    if (typeof args.old_string === 'string') removed += countLines(args.old_string)
+  }
+  if (added > 0 || removed > 0) {
+    return { kind: 'diff', added, removed }
+  }
+  return { kind: 'badge', count: Math.max(steps.length, 1) }
+}
+
+/** Compact header copy for a tool activity block. */
+export function activitySummary(
+  steps: ToolActivityStep[],
+  opts: { streaming?: boolean } = {},
+): ActivitySummary {
+  if (steps.length === 0) {
+    return withSplit('No tools', 'complete')
+  }
+
+  const failed = steps.filter(s => s.status === 'error')
+  const running = steps.find(s => s.status === 'running')
+
+  if (opts.streaming && running) {
+    return withSplit(liveActivityHint(running), 'running')
+  }
+
+  const body = buildCategorizedBody(steps)
+
+  if (failed.length > 0) {
+    if (failed.length === 1) {
+      return withSplit(`${body} · ${failed[0].toolName} failed`, 'error')
+    }
+    return withSplit(`${body} · ${failed.length} failed`, 'error')
+  }
+
+  return withSplit(body, 'complete')
+}
+
+/** Index lookup helpers for the StudioChat render loop. */
+export function buildActivityRenderIndex(messages: ChatMsg[]): {
+  activityByStart: Map<number, Extract<MessageSegment, { kind: 'activity' }>>
+  skipIndices: Set<number>
+} {
+  const activityByStart = new Map<number, Extract<MessageSegment, { kind: 'activity' }>>()
+  const skipIndices = new Set<number>()
+  for (const seg of groupToolActivity(messages)) {
+    if (seg.kind !== 'activity') continue
+    activityByStart.set(seg.start, seg)
+    for (let i = seg.start + 1; i <= seg.end; i++) {
+      skipIndices.add(i)
+    }
+  }
+  return { activityByStart, skipIndices }
+}

--- a/web/src/test/scenarios/reconnection.test.tsx
+++ b/web/src/test/scenarios/reconnection.test.tsx
@@ -48,13 +48,11 @@ describe('Reconnection Scenarios', () => {
         expect(text).toContain('Go 1.24 was released')
       }, { timeout: 10000 })
 
-      // Tool call should also be visible (web_search)
+      // Tool activity should be visible (collapsed summary or expanded tool name)
       await waitFor(() => {
-        const codeElements = result.container.querySelectorAll('code')
-        const hasWebSearch = Array.from(codeElements).some(el =>
-          el.textContent?.includes('web_search')
-        )
-        expect(hasWebSearch).toBe(true)
+        expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
+        const text = result.container.textContent || ''
+        expect(text).toMatch(/1 search|Searching|web_search/i)
       }, { timeout: 10000 })
     })
 

--- a/web/src/test/scenarios/tool-execution.test.tsx
+++ b/web/src/test/scenarios/tool-execution.test.tsx
@@ -41,11 +41,11 @@ describe('Tool Execution Scenarios', () => {
         expect(screen.getByText(/Let me search for that/)).toBeInTheDocument()
       }, { timeout: 5000 })
 
-      // Tool name should appear in the tool card (inside <code> elements)
+      // Tool activity block should appear with a categorized summary
       await waitFor(() => {
-        const codeElements = result.container.querySelectorAll('code')
-        const hasWebSearch = Array.from(codeElements).some(el => el.textContent?.includes('web_search'))
-        expect(hasWebSearch).toBe(true)
+        expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
+        const text = result.container.textContent || ''
+        expect(text).toMatch(/1 search|Searching|web_search/i)
       }, { timeout: 5000 })
 
       // Final text should appear
@@ -63,7 +63,20 @@ describe('Tool Execution Scenarios', () => {
 
       await result.sendMessage('Search and read file')
 
-      // Both tool names should appear in code elements
+      // Collapsed activity summary should cover both tools
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
+        const text = result.container.textContent || ''
+        expect(text).toMatch(/explored|1 search|Searching/i)
+      }, { timeout: 5000 })
+
+      // Expand the activity block to reveal per-tool names
+      const activityBtn = result.container.querySelector(
+        '[data-testid="tool-activity-block"] > button',
+      ) as HTMLElement
+      expect(activityBtn).toBeTruthy()
+      await result.user.click(activityBtn)
+
       await waitFor(() => {
         const codeElements = result.container.querySelectorAll('code')
         const names = Array.from(codeElements).map(el => el.textContent)

--- a/web/src/test/scenarios/tool-interactions.test.tsx
+++ b/web/src/test/scenarios/tool-interactions.test.tsx
@@ -33,30 +33,39 @@ describe('Tool Interaction Scenarios', () => {
 
       await result.sendMessage('Search')
 
-      // Wait for tool card to appear (code element with "web_search")
+      // Wait for collapsed tool activity block
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
+      }, { timeout: 10000 })
+
+      // Expand the activity block header
+      const activityBtn = result.container.querySelector(
+        '[data-testid="tool-activity-block"] > button',
+      ) as HTMLElement
+      expect(activityBtn).toBeTruthy()
+      await result.user.click(activityBtn)
+
+      // Step row with tool name should appear
       await waitFor(() => {
         const codeElements = result.container.querySelectorAll('code')
         const hasWebSearch = Array.from(codeElements).some(el => el.textContent?.includes('web_search'))
         expect(hasWebSearch).toBe(true)
       }, { timeout: 10000 })
 
-      // Find the tool card button (it has a <button> with class "w-full" wrapping the tool header)
-      const toolButtons = result.container.querySelectorAll('button.w-full')
-      // The tool card buttons contain tool names in code elements
-      let toolButton: HTMLElement | null = null
-      for (const btn of Array.from(toolButtons)) {
+      // Click the step row that contains web_search to reveal args/result
+      const stepButtons = result.container.querySelectorAll('[data-testid="tool-activity-block"] button')
+      let stepButton: HTMLElement | null = null
+      for (const btn of Array.from(stepButtons)) {
         const code = btn.querySelector('code')
         if (code?.textContent?.includes('web_search')) {
-          toolButton = btn as HTMLElement
+          stepButton = btn as HTMLElement
           break
         }
       }
-      expect(toolButton).not.toBeNull()
+      expect(stepButton).not.toBeNull()
+      await result.user.click(stepButton!)
 
-      // Click to expand
-      await result.user.click(toolButton!)
-
-      // After expanding, the tool args JSON should appear in a <pre> element
+      // After expanding the step, the tool args JSON should appear in a <pre>
       await waitFor(() => {
         const preElements = result.container.querySelectorAll('pre')
         const hasArgs = Array.from(preElements).some(el =>
@@ -65,8 +74,8 @@ describe('Tool Interaction Scenarios', () => {
         expect(hasArgs).toBe(true)
       }, { timeout: 10000 })
 
-      // Click again to collapse
-      await result.user.click(toolButton!)
+      // Collapse the activity block
+      await result.user.click(activityBtn)
 
       // The args should no longer be visible in any <pre>
       await waitFor(() => {


### PR DESCRIPTION
## Summary
- Collapse contiguous tool call/result cards into one categorized activity line (e.g. `Edited 2 files, explored 3 files, 2 searches`) with accent lead, muted rest, and trailing step badge or +/- diff when available
- Keep full call/result JSON one expand away; chevron appears on hover only so the chat stays lean
- Replace generic `Processing...` with live tool-specific status (e.g. `Running \`ls -lah\` with shell_command`) on the activity line and bottom streaming pill

## Test plan
- [ ] Start a Studio chat that runs several tools; confirm collapsed summary is categorized and packs left with badge after the text
- [ ] Hover the activity line; confirm chevron appears and there is no hover background wash
- [ ] Expand and inspect a step’s args/result JSON
- [ ] While a tool is in flight, confirm bottom pill and activity line show the same live hint (command/path/tool name)
- [ ] Between tools / while thinking, confirm status shows `Thinking…`
- [ ] Reload a session with tool history and confirm grouping/summary still render
- [ ] `cd web && npm test -- --run src/components/chat/__tests__/toolActivity.test.ts src/components/chat/__tests__/ToolActivityBlock.test.tsx`