### PR TITLE
Fold mid-loop agent narration into dimmed activity process text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,3 +299,10 @@ Skip the lint check only when absolutely necessary:
 ```bash
 git commit --no-verify
 ```
+
+# OpenCode Directives
+
+CRITICAL: Whenever you process a request that involves writing or modifying code, you must execute the following steps before considering the task complete:
+
+1. **Unit Testing:** Always analyze the changes you made and create or modify the corresponding unit tests to ensure the new code is fully covered.
+2. **Documentation Review:** Always check the `docs/` folder. You **MUST update the architecture documentation and user documentation** if they are relevant to the changes you just implemented.

--- a/docs/architecture/chat-rendering-pipeline.md
+++ b/docs/architecture/chat-rendering-pipeline.md
@@ -102,7 +102,7 @@ The backend emits **27 distinct event types** across `chat_runner.go` and `chat_
 Tool messages stay separate in React state (and on the wire). At render time, `groupToolActivity` / `buildActivityRenderIndex` (`web/src/components/chat/toolActivity.ts`) fold **work segments** into one compact `ToolActivityBlock` (`web/src/components/chat/ToolActivityBlock.tsx`):
 
 - **Collapsed by default** — categorized human language (e.g. `Edited 2 files, explored 3 files, 2 searches`) plus optional `· N notes`. While streaming: live tool hints (`Running \`ls\` with shell_command`). Errors append after the categories.
-- **Interstitial agent text** between tools in the same soft+tool run is absorbed as muted process narration. While the turn is still streaming, agent text **after the last tool** is also absorbed as provisional process text (always-visible dimmed `.thinking-note` under the activity line) so it never flashes as an Agent bubble. When the stream ends, trailing agent text after the last tool becomes a normal Agent bubble (user-facing answer, including report/video harness placeholders).
+- **Interstitial agent text** between tools in the same soft+tool run is absorbed as muted process narration. While the turn is still streaming, agent text **after the last tool** is also absorbed as provisional process text (always-visible dimmed `.thinking-note` under the activity line) so it never flashes as an Agent bubble. When the stream ends, trailing agent text after the last tool becomes a normal Agent bubble (user-facing answer, including report/video harness placeholders). Agent messages that contain an `astonish-app` fence are **never** absorbed — they stay passthrough so `AppCodeIndicator` (“Generating app…”) remains visible during streaming.
 - **Hard breaks** always passthrough and split folds: `user`, `subtask_execution`, `plan`, `fleet_*`, `browser_handoff`, `app_*`, `distill_*`, `tutorial_*`, `artifact`, `approval`, `network_denial`, `image`, `error*`, `system`, and any unknown future type. Soft absorbable allowlist only: `agent` (interstitial / provisional), `thinking`, `auto_approved`, `retry`.
 - Expand the block for paired tool steps + notes; expand a step for full args/result JSON.
 - Source citation chips (`collectSourceUrls`) still walk raw `tool_result` messages — grouping is display-only. Report three-signal gate is unchanged.
@@ -346,6 +346,8 @@ const appFenceRe = /```astonish-app\s*\n([\s\S]*?)(?:\n```|$)/
 ```
 
 When matched, it renders an `AppCodeIndicator` (pulsing "Generating app..." with expandable code view) instead of the raw fence text. After streaming completes, the `app_preview` event arrives and replaces the indicator with a stream `HarnessPlaceholder` plus the full `AppPreviewCard` in `HarnessPanel`.
+
+**Work-segment fold carve-out:** agent messages containing an `astonish-app` fence are never absorbed into activity process notes (even with `absorbTrailingSoft`), so this indicator is not replaced by italic narration while code streams.
 
 **This streaming interceptor is intentionally `astonish-app`-only.** Do not generalize it to other fence types without implementing the full backend event + frontend handler + ResultCard integration for that type.
 

--- a/docs/architecture/chat-rendering-pipeline.md
+++ b/docs/architecture/chat-rendering-pipeline.md
@@ -99,12 +99,13 @@ The backend emits **27 distinct event types** across `chat_runner.go` and `chat_
 | `approval` | `{name, args, options}` | Show approval card with Approve/Deny buttons |
 | `auto_approved` | `{name}` | Show auto-approved badge |
 
-Tool messages stay separate in React state (and on the wire). At render time, `groupToolActivity` / `buildActivityRenderIndex` (`web/src/components/chat/toolActivity.ts`) fold **contiguous** `tool_call` / `tool_result` runs into one compact `ToolActivityBlock` (`web/src/components/chat/ToolActivityBlock.tsx`):
+Tool messages stay separate in React state (and on the wire). At render time, `groupToolActivity` / `buildActivityRenderIndex` (`web/src/components/chat/toolActivity.ts`) fold **work segments** into one compact `ToolActivityBlock` (`web/src/components/chat/ToolActivityBlock.tsx`):
 
-- **Collapsed by default** — a discrete muted line with **categorized human language** (not a raw tool-name list), e.g. `Edited 2 files, explored 3 files, 2 searches, ran 1 command`. While streaming: a short verb hint (`Searching…`, `Fetching…`). Errors append after the categories (`… · http_request failed`).
-- **Expand the block** to see paired steps; expand a step for full args/result JSON.
-- Agent text, approvals, artifacts, handoffs, etc. split groups so narration between tool batches still reads naturally.
-- Source citation chips (`collectSourceUrls`) still walk raw `tool_result` messages — grouping is display-only.
+- **Collapsed by default** — categorized human language (e.g. `Edited 2 files, explored 3 files, 2 searches`) plus optional `· N notes`. While streaming: live tool hints (`Running \`ls\` with shell_command`). Errors append after the categories.
+- **Interstitial agent text** between tools in the same soft+tool run is absorbed as muted process narration. While the turn is still streaming, agent text **after the last tool** is also absorbed as provisional process text (always-visible dimmed `.thinking-note` under the activity line) so it never flashes as an Agent bubble. When the stream ends, trailing agent text after the last tool becomes a normal Agent bubble (user-facing answer, including report/video harness placeholders).
+- **Hard breaks** always passthrough and split folds: `user`, `subtask_execution`, `plan`, `fleet_*`, `browser_handoff`, `app_*`, `distill_*`, `tutorial_*`, `artifact`, `approval`, `network_denial`, `image`, `error*`, `system`, and any unknown future type. Soft absorbable allowlist only: `agent` (interstitial / provisional), `thinking`, `auto_approved`, `retry`.
+- Expand the block for paired tool steps + notes; expand a step for full args/result JSON.
+- Source citation chips (`collectSourceUrls`) still walk raw `tool_result` messages — grouping is display-only. Report three-signal gate is unchanged.
 
 ### Artifact & File Events
 
@@ -188,7 +189,7 @@ graph TD
 |-------------|-----------|-------|
 | `user` | Inline chat bubble | "You" label, plain text |
 | `agent` | `ReactMarkdown` bubble + report/video `HarnessPlaceholder` | Last agent message: gated reports and last-turn videos open in `HarnessPanel` |
-| `tool_call` | `ToolActivityBlock` | Grouped with contiguous results; categorized collapsed summary |
+| `tool_call` | `ToolActivityBlock` | Work-segment fold with contiguous soft notes; categorized summary |
 | `tool_result` | `ToolActivityBlock` | Paired into the same activity block as its call |
 | `browser_handoff` | `HarnessPlaceholder` → `HarnessPanel`/`BrowserView` | VNC proxy fills the right panel |
 | `image` | Inline `<img>` | Base64 data URI |

--- a/docs/architecture/daemon-scheduler.md
+++ b/docs/architecture/daemon-scheduler.md
@@ -73,6 +73,12 @@ Studio chat applies platform/org/team network allow rules via `ChatRunner` (pre-
 
 The scheduler injects `NetworkPolicyStores` and OpenShell gateway config into the exec context. **Persisted allow rules must be active before the first in-sandbox egress**: `NodeTool` PreSeeds (and waits for policy load) after `EnsureReady` and before the first tool `Call`, and OpenShell `CreateSession` also merges DB allow endpoints into the create-time policy when known. Post-result PreSeed in `SessionBridge` / `ChatRunner` is a no-op once that has run. Chat “Approve broader” persists an allow rule to the team/org store so future scheduler sandboxes inherit it — without that rule, headless jobs still cannot reach the host.
 
+**Routine scheduler jobs** (`executeRoutine` → headless flow) share the same contract: `NetworkPolicyStores` from the multi-tenant tick plus `WithGatewayConfig` so PreSeed runs before the first curl/CONNECT. Adaptive already had gateway; routine previously omitted it and no-oped PreSeed.
+
+**Interactive Flows** share Chat PreSeed semantics as well:
+- Classic Flows UI (`HandleChat` / `POST /api/chat`) and headless `FlowRunHandler` call `withRuntimeNetworkPolicyContext` (+ sandbox template context) so DB allows land in the flow sandbox.
+- `run_flow` via `InteractiveFlowRunner` uses `withFlowNetworkPolicyContext` (gateway + stores from parent ChatRunner ctx or request `Services`) so nested flow sandboxes do not start with presets-only egress.
+
 ### Adaptive Sandboxes Are Ephemeral Per Run
 
 The ADK session id stays stable (`scheduler-adaptive-{jobID}`) for transcript continuity, but the **OpenShell sandbox is destroyed at the start and end of each adaptive run**. That avoids reusing a registry row whose gateway pod was idle-evicted or deleted (which previously caused `EnsureReady` to no-op and credential vault `PushFile` to fail with “sandbox not found”). OpenShell `CreateSession` also heals stale registry rows when `GetSandbox` returns NotFound/Gone. After destroy, the ToolNodePool client for that session id is **Remove**d so the next tick’s `EnsureReady` rebinds instead of treating a gone pod as still ready.

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -188,6 +188,16 @@ mcp_dependencies:
 
 Before execution, the system checks that required MCP servers are available and the specified tools are registered. Sources: `store` (official MCP store), `tap` (flow repository), or `inline` (embedded configuration).
 
+## Latency vs Studio Chat
+
+Flows often feel slower than Chat for the same `shell_command` / OpenStack curl even though the graph is “streamlined.” Main reasons:
+
+1. **Per-run sandbox isolation** — each flow run gets a fresh session (`flow-run-…` or ADK session ID) and destroys it on cleanup. Chat reuses a warm sandbox across turns of one conversation. **Sandboxes are not shared across flow runs** (would leak `write_file` / shell state).
+2. **Distilled shell steps are usually `llm` + `tools: true`** — not deterministic `type: tool` nodes — so each step still pays LLM round-trips (see `flow_distiller.go` shell guidance).
+3. **Cold start used to serialize on the first tool** — Chat overlaps `BindSession` with the LLM via `NodeTool.ProcessRequest`. Flows now call `sandbox.WarmFlowSession` after ADK session create so provisioning overlaps the first LLM node **within the same run** only; cleanup still destroys the sandbox.
+
+`type: tool` nodes honor global `AutoApprove` (same as LLM nodes) so headless / `run_flow` do not pause for “Yes” when `AstonishAgent.AutoApprove` is set.
+
 ## Key Files
 
 | File | Purpose |
@@ -195,6 +205,8 @@ Before execution, the system checks that required MCP servers are available and 
 | `pkg/config/yaml_loader.go` | Flow YAML schema: AgentConfig, Node, FlowItem, Edge, ParallelConfig |
 | `pkg/agent/astonish_agent.go` | AstonishAgent: flow state machine, node dispatch, approval handling |
 | `pkg/agent/node_llm.go` | LLM node execution: retry logic, callback wiring, variable interpolation |
+| `pkg/agent/node_tool.go` | Deterministic tool nodes; AutoApprove parity with LLM nodes |
+| `pkg/sandbox/flow_warm.go` | Same-run eager BindSession / EnsureReady / PreSeed |
 | `pkg/agent/condition_evaluator.go` | Starlark-based condition evaluation for flow edges |
 | `pkg/agent/error_recovery.go` | Intelligent error analysis and retry decisions |
 | `pkg/agent/flow_distiller.go` | LLM-powered trace-to-YAML flow conversion |

--- a/docs/website/docs/security/network-policy.md
+++ b/docs/website/docs/security/network-policy.md
@@ -95,6 +95,8 @@ When a chat message is processed, all allow-list rules from the effective policy
 - No fail-then-retry cycle is needed for configured endpoints
 - The agent can reach allowed hosts immediately without any visible delay or error
 
+The same PreSeed path applies to **Flows** (Studio Flows UI, headless flow run, and `run_flow` from chat) and to **scheduler** jobs (routine and adaptive). Persisted allow rules (Settings or “Approve broader”) are required for headless/scheduled runs — session-only in-chat grants do not carry over.
+
 The same admin-managed allow/deny rules also apply to **Apps** `http:` data sources. Apps fetch outbound HTTP **inside the App sandbox session** (shared with Apps MCP: `app-mcp-{userID}`), after Network Policy PreSeed — the same path as agent tools. Studio does not dial the target URL itself; OpenShell L7 and `cert_bundles` provide TLS trust for corp MITM.
 
 Studio still rejects non-`http(s)` schemes and hard-blocked IP literals (loopback, link-local, cloud metadata) before Exec. Soft-private destinations are gated by sandbox Network Policy (and config `extra_endpoints` PreSeed), not by a separate Studio SSRF allow list. In-chat network grants do **not** apply to Apps — only persistent admin rules and config `extra_endpoints`. Apps HTTP requires a sandbox backend.

--- a/pkg/agent/credential_flow_test.go
+++ b/pkg/agent/credential_flow_test.go
@@ -363,17 +363,17 @@ func (m *mockPGCredentialStore) Count(_ context.Context) int { return len(m.cred
 func (m *mockPGCredentialStore) Resolve(_ context.Context, _ string) (string, string, error) {
 	return "", "", nil
 }
-func (m *mockPGCredentialStore) InvalidateToken(_ context.Context, _ string)        {}
-func (m *mockPGCredentialStore) Reload(_ context.Context) error                     { return nil }
-func (m *mockPGCredentialStore) GetSecret(_ context.Context, _ string) string        { return "" }
-func (m *mockPGCredentialStore) SetSecret(_ context.Context, _, _ string) error      { return nil }
+func (m *mockPGCredentialStore) InvalidateToken(_ context.Context, _ string)    {}
+func (m *mockPGCredentialStore) Reload(_ context.Context) error                 { return nil }
+func (m *mockPGCredentialStore) GetSecret(_ context.Context, _ string) string   { return "" }
+func (m *mockPGCredentialStore) SetSecret(_ context.Context, _, _ string) error { return nil }
 func (m *mockPGCredentialStore) SetSecretBatch(_ context.Context, _ map[string]string) error {
 	return nil
 }
 func (m *mockPGCredentialStore) RemoveSecret(_ context.Context, _ string) error { return nil }
-func (m *mockPGCredentialStore) HasSecrets(_ context.Context) bool               { return false }
-func (m *mockPGCredentialStore) SecretCount(_ context.Context) int               { return 0 }
-func (m *mockPGCredentialStore) ListSecrets(_ context.Context) []string          { return nil }
+func (m *mockPGCredentialStore) HasSecrets(_ context.Context) bool              { return false }
+func (m *mockPGCredentialStore) SecretCount(_ context.Context) int              { return 0 }
+func (m *mockPGCredentialStore) ListSecrets(_ context.Context) []string         { return nil }
 
 func TestBeforeToolCallback_CredentialResolutionFromContext(t *testing.T) {
 	// Simulate the PG credential store in context (as FlowRunHandler does)
@@ -477,5 +477,37 @@ func TestToolNodeCredentialResolution(t *testing.T) {
 	}
 	if !strings.Contains(cmd, "s3cret!") {
 		t.Errorf("password not resolved, got:\n%s", cmd)
+	}
+}
+
+func TestFlowShellCommandCredentialResolution_ZeroWidthOpenStackToken(t *testing.T) {
+	pgStore := &mockPGCredentialStore{
+		creds: map[string]*store.Credential{
+			"openstack-keystone": {
+				Type:  store.CredBearer,
+				Token: "resolved-keystone-token",
+			},
+		},
+	}
+	ctx := store.WithCredentialStore(context.Background(), pgStore)
+	resolver := credentials.NewStoreAdapter(store.CredentialStoreFromContext(ctx))
+	if resolver == nil {
+		t.Fatal("resolver should not be nil")
+	}
+
+	resolvedArgs := map[string]any{
+		"command": "curl -s -H \"X-Auth-Token: {\u200b{CREDENTIAL:openstack-keystone:token}}\" https://kubernikus.qa-de-1.cloud.sap/api/v1/clusters",
+	}
+	credentials.SubstituteAndRestore(resolvedArgs, resolver, "command")
+
+	cmd := resolvedArgs["command"].(string)
+	if !strings.Contains(cmd, "export __ASTONISH_CRED_") {
+		t.Fatalf("expected env var exports in command, got:\n%s", cmd)
+	}
+	if strings.Contains(cmd, "CREDENTIAL:openstack-keystone:token") {
+		t.Fatalf("credential placeholder should be resolved, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "resolved-keystone-token") {
+		t.Fatalf("expected resolved token in shell-safe export, got:\n%s", cmd)
 	}
 }

--- a/pkg/agent/node_tool.go
+++ b/pkg/agent/node_tool.go
@@ -53,9 +53,10 @@ func (a *AstonishAgent) handleToolNode(ctx context.Context, node *config.Node, s
 	}
 	toolName := node.ToolsSelection[0]
 
-	// 3. Approval Workflow
+	// 3. Approval Workflow — match llm-node semantics: per-node
+	// tools_auto_approval OR global AutoApprove (headless / run_flow).
 	approved := false
-	if node.ToolsAutoApproval {
+	if node.ToolsAutoApproval || a.AutoApprove {
 		approved = true
 	} else {
 		// Check if we already have approval for this specific tool execution

--- a/pkg/agent/node_tool_autoapprove_test.go
+++ b/pkg/agent/node_tool_autoapprove_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/config"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+)
+
+func TestHandleToolNode_GlobalAutoApproveBypassesApproval(t *testing.T) {
+	state := NewMockState()
+	toolExecuted := false
+	mockTool := &MockTool{
+		NameFunc: func() string { return "shell_command" },
+		RunFunc: func(ctx tool.Context, args any) (map[string]any, error) {
+			toolExecuted = true
+			return map[string]any{"stdout": "ok"}, nil
+		},
+	}
+	a := &AstonishAgent{
+		AutoApprove: true,
+		Tools:       []tool.Tool{mockTool},
+	}
+	node := &config.Node{
+		Name:            "run_curl",
+		Type:            "tool",
+		ToolsSelection:  []string{"shell_command"},
+		ToolsAutoApproval: false,
+		Args:            map[string]interface{}{"command": "echo hi"},
+	}
+
+	paused := false
+	ok := a.handleToolNode(context.Background(), node, state, func(ev *session.Event, err error) bool {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev != nil && ev.Actions.StateDelta != nil {
+			if awaiting, _ := ev.Actions.StateDelta["awaiting_approval"].(bool); awaiting {
+				paused = true
+			}
+		}
+		return true
+	})
+	if !ok {
+		t.Fatal("expected handleToolNode to continue (not pause)")
+	}
+	if paused {
+		t.Fatal("expected no approval pause when AutoApprove is true")
+	}
+	if !toolExecuted {
+		t.Fatal("expected tool to run when AutoApprove is true")
+	}
+	if awaiting, _ := state.Get("awaiting_approval"); awaiting == true {
+		t.Fatal("expected awaiting_approval unset when AutoApprove is true")
+	}
+}
+
+func TestHandleToolNode_NoAutoApproveRequestsApproval(t *testing.T) {
+	state := NewMockState()
+	toolExecuted := false
+	mockTool := &MockTool{
+		NameFunc: func() string { return "shell_command" },
+		RunFunc: func(ctx tool.Context, args any) (map[string]any, error) {
+			toolExecuted = true
+			return map[string]any{"stdout": "ok"}, nil
+		},
+	}
+	a := &AstonishAgent{
+		AutoApprove: false,
+		Tools:       []tool.Tool{mockTool},
+	}
+	node := &config.Node{
+		Name:              "run_curl",
+		Type:              "tool",
+		ToolsSelection:    []string{"shell_command"},
+		ToolsAutoApproval: false,
+		Args:              map[string]interface{}{"command": "echo hi"},
+	}
+
+	pausedForApproval := false
+	ok := a.handleToolNode(context.Background(), node, state, func(ev *session.Event, err error) bool {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev != nil && ev.Actions.StateDelta != nil {
+			if awaiting, _ := ev.Actions.StateDelta["awaiting_approval"].(bool); awaiting {
+				pausedForApproval = true
+			}
+		}
+		return true
+	})
+	if ok {
+		t.Fatal("expected handleToolNode to pause (return false) when approval required")
+	}
+	if !pausedForApproval {
+		t.Fatal("expected awaiting_approval event when AutoApprove is false")
+	}
+	if toolExecuted {
+		t.Fatal("expected tool NOT to run before approval")
+	}
+}

--- a/pkg/api/app_data_handler_test.go
+++ b/pkg/api/app_data_handler_test.go
@@ -441,7 +441,7 @@ func TestFetchHTTPViaSandbox_Status000ClearsSeedAndRetries(t *testing.T) {
 	}
 }
 
-func TestWithAppNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
+func TestWithRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
 	teamStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
 		Host:   "github.wdf.sap.corp",
 		Port:   443,
@@ -454,7 +454,7 @@ func TestWithAppNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
 	appCfg := &config.AppConfig{}
 	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
 
-	ctx := withAppNetworkPolicyContext(context.Background(), r, appCfg)
+	ctx := withRuntimeNetworkPolicyContext(context.Background(), r, appCfg)
 	nps := store.NetworkPolicyStoresFromContext(ctx)
 	if nps == nil || nps.Team == nil {
 		t.Fatal("expected NetworkPolicyStores on context")

--- a/pkg/api/app_http_sandbox.go
+++ b/pkg/api/app_http_sandbox.go
@@ -41,7 +41,7 @@ func fetchHTTPViaSandbox(ctx context.Context, r *http.Request, method, rawURL st
 		slog.Warn("app HTTP sandbox transport failure; clearing PreSeed and retrying once",
 			"session", sessionID, "status", status, "error", err)
 		netpolicy.ClearSessionSeeded(sessionID)
-		seedCtx := withAppNetworkPolicyContext(ctx, r, appCfg)
+		seedCtx := withRuntimeNetworkPolicyContext(ctx, r, appCfg)
 		netpolicy.EnsurePreSeedFromContext(seedCtx, sessionID)
 		status, respBody, err = execAppHTTPCurl(ctx, backend, sessionID, method, rawURL, headers, body)
 	}

--- a/pkg/api/app_sandbox_session.go
+++ b/pkg/api/app_sandbox_session.go
@@ -80,16 +80,16 @@ func ensureAppSandboxSessionImpl(ctx context.Context, r *http.Request, userID st
 		return nil, "", nil, nil, fmt.Errorf("app sandbox session not ready for user %q: %w", userID, err)
 	}
 
-	seedCtx := withAppNetworkPolicyContext(ctx, r, appCfg)
+	seedCtx := withRuntimeNetworkPolicyContext(ctx, r, appCfg)
 	netpolicy.EnsurePreSeedFromContext(seedCtx, syntheticSessionID)
 
 	appMCPIdleTracker.touch(syntheticSessionID)
 	return backend, syntheticSessionID, appCfg, cleanup, nil
 }
 
-// withAppNetworkPolicyContext attaches DB Network Policy stores and OpenShell
+// withRuntimeNetworkPolicyContext attaches DB Network Policy stores and OpenShell
 // gateway config so EnsurePreSeedFromContext can push allows into the sandbox.
-func withAppNetworkPolicyContext(ctx context.Context, r *http.Request, appCfg *config.AppConfig) context.Context {
+func withRuntimeNetworkPolicyContext(ctx context.Context, r *http.Request, appCfg *config.AppConfig) context.Context {
 	if r != nil {
 		if svc := store.FromRequest(r); svc != nil {
 			ctx = store.WithNetworkPolicyStores(ctx, &store.NetworkPolicyStores{

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/SAP/astonish/pkg/agent"
 	"github.com/SAP/astonish/pkg/credentials"
-	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	"github.com/SAP/astonish/pkg/store"
@@ -1669,10 +1668,6 @@ func (r *chatRunnerRegistry) startCleanupLoop() {
 }
 
 func init() {
-	// Wire NodeTool → netpolicy PreSeed without an import cycle
-	// (sandbox cannot import netpolicy → openshell → sandbox).
-	sandbox.NetworkPolicyPreSeeder = netpolicy.EnsurePreSeedFromContext
-
 	// Start the cleanup loop when the package is loaded
 	registry := getChatRunnerRegistry()
 	registry.startCleanupLoop()

--- a/pkg/api/flow_network_policy_context_test.go
+++ b/pkg/api/flow_network_policy_context_test.go
@@ -12,6 +12,16 @@ import (
 )
 
 func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
+	platformStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "platform.example.com",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	orgStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "org.example.com",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
 	teamStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
 		Host:   "api.example.com",
 		Port:   443,
@@ -19,7 +29,9 @@ func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) 
 	}}}
 	r := httptest.NewRequest(http.MethodPost, "/api/agents/test/run", nil)
 	r = r.WithContext(store.WithServices(r.Context(), &store.Services{
-		TeamNetworkPolicies: teamStore,
+		PlatformNetworkPolicies: platformStore,
+		NetworkPolicies:         orgStore,
+		TeamNetworkPolicies:     teamStore,
 	}))
 
 	appCfg := &config.AppConfig{}
@@ -27,8 +39,8 @@ func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) 
 
 	ctx := withRuntimeNetworkPolicyContext(context.Background(), r, appCfg)
 	nps := store.NetworkPolicyStoresFromContext(ctx)
-	if nps == nil || nps.Team != teamStore {
-		t.Fatalf("expected team network policy store on flow context, got %+v", nps)
+	if nps == nil || nps.Platform != platformStore || nps.Org != orgStore || nps.Team != teamStore {
+		t.Fatalf("expected all network policy stores on flow context, got %+v", nps)
 	}
 	gw := netpolicy.GatewayConfigFromContext(ctx)
 	if gw == nil || gw.Addr != "openshell.example:8443" {

--- a/pkg/api/flow_network_policy_context_test.go
+++ b/pkg/api/flow_network_policy_context_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/config"
+	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+	"github.com/SAP/astonish/pkg/store"
+)
+
+func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
+	teamStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "api.example.com",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	r := httptest.NewRequest(http.MethodPost, "/api/agents/test/run", nil)
+	r = r.WithContext(store.WithServices(r.Context(), &store.Services{
+		TeamNetworkPolicies: teamStore,
+	}))
+
+	appCfg := &config.AppConfig{}
+	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
+
+	ctx := withRuntimeNetworkPolicyContext(context.Background(), r, appCfg)
+	nps := store.NetworkPolicyStoresFromContext(ctx)
+	if nps == nil || nps.Team != teamStore {
+		t.Fatalf("expected team network policy store on flow context, got %+v", nps)
+	}
+	gw := netpolicy.GatewayConfigFromContext(ctx)
+	if gw == nil || gw.Addr != "openshell.example:8443" {
+		t.Fatalf("expected OpenShell gateway config on flow context, got %+v", gw)
+	}
+}

--- a/pkg/api/flow_network_policy_context_test.go
+++ b/pkg/api/flow_network_policy_context_test.go
@@ -48,6 +48,46 @@ func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) 
 	}
 }
 
+// HandleChat (/api/chat) must use the same helpers as FlowRunHandler so classic
+// Flows UI sandboxes inherit platform/org/team allows (e.g. **.cloud.sap).
+func TestHandleChatRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) {
+	platformStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "**.cloud.sap",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	orgStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "org.example.com",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	teamStore := &stubNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "kubernikus.qa-de-1.cloud.sap",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	r := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+	r = r.WithContext(store.WithServices(r.Context(), &store.Services{
+		PlatformNetworkPolicies: platformStore,
+		NetworkPolicies:         orgStore,
+		TeamNetworkPolicies:     teamStore,
+	}))
+
+	appCfg := &config.AppConfig{}
+	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
+
+	ctx := withRuntimeNetworkPolicyContext(context.Background(), r, appCfg)
+	ctx = withRuntimeSandboxContext(ctx, r)
+	nps := store.NetworkPolicyStoresFromContext(ctx)
+	if nps == nil || nps.Platform != platformStore || nps.Org != orgStore || nps.Team != teamStore {
+		t.Fatalf("expected all network policy stores on HandleChat context, got %+v", nps)
+	}
+	gw := netpolicy.GatewayConfigFromContext(ctx)
+	if gw == nil || gw.Addr != "openshell.example:8443" {
+		t.Fatalf("expected OpenShell gateway config on HandleChat context, got %+v", gw)
+	}
+}
+
 func TestFlowRuntimeSandboxContext_AttachesTeamTemplateLayerAndImage(t *testing.T) {
 	prevTemplateLayer := resolveRuntimeTemplateLayerChain
 	prevTemplateImage := resolveRuntimeTemplateImage

--- a/pkg/api/flow_network_policy_context_test.go
+++ b/pkg/api/flow_network_policy_context_test.go
@@ -47,3 +47,36 @@ func TestFlowRuntimeNetworkPolicyContext_AttachesStoresAndGateway(t *testing.T) 
 		t.Fatalf("expected OpenShell gateway config on flow context, got %+v", gw)
 	}
 }
+
+func TestFlowRuntimeSandboxContext_AttachesTeamTemplateLayerAndImage(t *testing.T) {
+	prevTemplateLayer := resolveRuntimeTemplateLayerChain
+	prevTemplateImage := resolveRuntimeTemplateImage
+	prevBaseLayer := resolveRuntimeBaseLayerChain
+	prevBaseImage := resolveRuntimeBaseImage
+	t.Cleanup(func() {
+		resolveRuntimeTemplateLayerChain = prevTemplateLayer
+		resolveRuntimeTemplateImage = prevTemplateImage
+		resolveRuntimeBaseLayerChain = prevBaseLayer
+		resolveRuntimeBaseImage = prevBaseImage
+	})
+	resolveRuntimeTemplateLayerChain = func(context.Context, string) []string { return []string{"@base", "team-layer"} }
+	resolveRuntimeTemplateImage = func(context.Context, string) string { return "ghcr.io/sap/team-sandbox:test" }
+	resolveRuntimeBaseLayerChain = func(context.Context) []string { return []string{"@base", "base-layer"} }
+	resolveRuntimeBaseImage = func(context.Context) string { return "ghcr.io/sap/base-sandbox:test" }
+
+	r := httptest.NewRequest(http.MethodPost, "/api/agents/test/run", nil)
+	r = r.WithContext(store.WithServices(r.Context(), &store.Services{
+		Settings: &mockTeamSettingsStore{settings: &store.TeamSettings{TemplateName: "team-general"}},
+	}))
+
+	ctx := withRuntimeSandboxContext(context.Background(), r)
+	if got := store.SandboxTemplateFromContext(ctx); got != "team-general" {
+		t.Fatalf("expected team template, got %q", got)
+	}
+	if got := store.SandboxLayerChainFromContext(ctx); len(got) != 2 || got[1] != "team-layer" {
+		t.Fatalf("expected team layer chain, got %v", got)
+	}
+	if got := store.SandboxImageFromContext(ctx); got != "ghcr.io/sap/team-sandbox:test" {
+		t.Fatalf("expected team image, got %q", got)
+	}
+}

--- a/pkg/api/flow_run_handler.go
+++ b/pkg/api/flow_run_handler.go
@@ -127,6 +127,7 @@ func FlowRunHandler(w http.ResponseWriter, r *http.Request) {
 	// 2. Determine Provider/Model
 	appCfg := effectiveAppConfig(r)
 	injectProviderSecrets(appCfg)
+	ctx = withRuntimeNetworkPolicyContext(ctx, r, appCfg)
 
 	providerName := req.Provider
 	if providerName == "" {

--- a/pkg/api/flow_run_handler.go
+++ b/pkg/api/flow_run_handler.go
@@ -258,6 +258,10 @@ func FlowRunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	sess := resp.Session
 
+	// Overlap OpenShell/Incus cold start with runner setup + first LLM node.
+	// Still destroyed by result.Cleanup at end of this run (isolation preserved).
+	sandbox.WarmFlowSession(ctx, internalTools, sess.ID())
+
 	// 7. Create Runner
 	rnr, err := runner.New(runner.Config{
 		AppName:        "astonish",

--- a/pkg/api/flow_run_handler.go
+++ b/pkg/api/flow_run_handler.go
@@ -128,6 +128,7 @@ func FlowRunHandler(w http.ResponseWriter, r *http.Request) {
 	appCfg := effectiveAppConfig(r)
 	injectProviderSecrets(appCfg)
 	ctx = withRuntimeNetworkPolicyContext(ctx, r, appCfg)
+	ctx = withRuntimeSandboxContext(ctx, r)
 
 	providerName := req.Provider
 	if providerName == "" {

--- a/pkg/api/flow_sandbox_context.go
+++ b/pkg/api/flow_sandbox_context.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/SAP/astonish/pkg/store"
+)
+
+var (
+	resolveRuntimeTemplateLayerChain = resolveTemplateLayerChain
+	resolveRuntimeTemplateImage      = resolveTemplateImage
+	resolveRuntimeBaseLayerChain     = resolveBaseLayerChain
+	resolveRuntimeBaseImage          = resolveBaseImage
+)
+
+func withRuntimeSandboxContext(ctx context.Context, r *http.Request) context.Context {
+	if r != nil {
+		if svc := store.FromRequest(r); svc != nil && svc.Settings != nil {
+			if settings, err := svc.Settings.Get(r.Context()); err == nil && settings != nil && settings.TemplateName != "" {
+				ctx = store.WithSandboxTemplate(ctx, settings.TemplateName)
+				if chain := resolveRuntimeTemplateLayerChain(r.Context(), settings.TemplateName); len(chain) > 0 {
+					ctx = store.WithSandboxLayerChain(ctx, chain)
+				}
+				if img := resolveRuntimeTemplateImage(r.Context(), settings.TemplateName); img != "" {
+					ctx = store.WithSandboxImage(ctx, img)
+				}
+			}
+		}
+	}
+	if store.SandboxLayerChainFromContext(ctx) == nil {
+		if chain := resolveRuntimeBaseLayerChain(ctx); len(chain) > 0 {
+			ctx = store.WithSandboxLayerChain(ctx, chain)
+		}
+	}
+	if store.SandboxImageFromContext(ctx) == "" {
+		if img := resolveRuntimeBaseImage(ctx); img != "" {
+			ctx = store.WithSandboxImage(ctx, img)
+		}
+	}
+	return ctx
+}

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -12,10 +12,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/flowstore"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/gorilla/mux"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
 	"gopkg.in/yaml.v3"
@@ -523,13 +523,15 @@ func resolveAgentYAMLDependencies(rawYAML string, agentConfig config.AgentConfig
 
 		// Resolve dependencies
 		deps := ResolveMCPDependencies(tools, cachedTools, storeServers, agentConfig.MCPDependencies, mcpCfg)
+		deps = sanitizeMCPDependencies(deps)
+		existingDeps := sanitizeMCPDependencies(agentConfig.MCPDependencies)
 
 		// Check if mcp_dependencies section already exists
 		hasMcpDeps := len(agentConfig.MCPDependencies) > 0
 
-		// Only add deps if we have them AND section doesn't exist yet
-		// (Avoids re-encoding when deps already exist, preserving formatting)
-		if len(deps) > 0 && !hasMcpDeps {
+		// Add, update, or remove mcp_dependencies when the sanitized dependency
+		// set differs. This also cleans stale built-in-tool deps from old YAML.
+		if !mcpDependenciesEqual(deps, existingDeps) || (hasMcpDeps && len(deps) == 0) {
 			// Parse as yaml.Node to preserve ordering
 			var rootNode yaml.Node
 			if err := yaml.Unmarshal([]byte(rawYAML), &rootNode); err == nil && rootNode.Kind == yaml.DocumentNode && len(rootNode.Content) > 0 {
@@ -554,6 +556,16 @@ func resolveAgentYAMLDependencies(rawYAML string, agentConfig config.AgentConfig
 						if layoutIndex > mcpDepsIndex {
 							layoutIndex -= 2
 						}
+					}
+					if len(deps) == 0 {
+						var buf bytes.Buffer
+						encoder := yaml.NewEncoder(&buf)
+						encoder.SetIndent(2)
+						if err := encoder.Encode(&rootNode); err == nil {
+							return buf.String()
+						}
+						encoder.Close()
+						return rawYAML
 					}
 
 					// Marshal deps to yaml.Node

--- a/pkg/api/mcp_dependencies.go
+++ b/pkg/api/mcp_dependencies.go
@@ -137,6 +137,32 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 	return deps
 }
 
+func sanitizeMCPDependencies(deps []config.MCPDependency) []config.MCPDependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	builtInTools := flowBuiltInToolSet()
+	cleaned := make([]config.MCPDependency, 0, len(deps))
+	for _, dep := range deps {
+		if len(dep.Tools) == 0 {
+			cleaned = append(cleaned, dep)
+			continue
+		}
+		filteredTools := make([]string, 0, len(dep.Tools))
+		for _, toolName := range dep.Tools {
+			if !builtInTools[toolName] {
+				filteredTools = append(filteredTools, toolName)
+			}
+		}
+		if len(filteredTools) == 0 {
+			continue
+		}
+		dep.Tools = filteredTools
+		cleaned = append(cleaned, dep)
+	}
+	return cleaned
+}
+
 func flowBuiltInToolSet() map[string]bool {
 	decls := tools.GetAllFlowToolDeclarations()
 	out := make(map[string]bool, len(decls))
@@ -215,6 +241,7 @@ func CheckMCPDependenciesHandler(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
+	req.Dependencies = sanitizeMCPDependencies(req.Dependencies)
 
 	// Determine installed servers based on mode
 	installedServers := make(map[string]bool)

--- a/pkg/api/mcp_dependencies.go
+++ b/pkg/api/mcp_dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SAP/astonish/pkg/flowstore"
 	"github.com/SAP/astonish/pkg/mcpstore"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/SAP/astonish/pkg/tools"
 )
 
 // ResolveMCPDependencies analyzes tools used in a flow and resolves them to MCP server dependencies.
@@ -29,6 +30,7 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 
 	// Build a map of tool name -> server source
 	toolToServer := make(map[string]string)
+	builtInTools := flowBuiltInToolSet()
 
 	// 1. First populate from system cache (installed tools)
 	for _, tool := range cachedTools {
@@ -47,6 +49,9 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 	// Group tools by their server source
 	serverToTools := make(map[string][]string)
 	for _, toolName := range toolsSelection {
+		if builtInTools[toolName] {
+			continue
+		}
 		serverName := toolToServer[toolName]
 		if serverName == "" || serverName == "internal" {
 			continue // Skip internal/unknown tools
@@ -130,6 +135,15 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 	}
 
 	return deps
+}
+
+func flowBuiltInToolSet() map[string]bool {
+	decls := tools.GetAllFlowToolDeclarations()
+	out := make(map[string]bool, len(decls))
+	for _, decl := range decls {
+		out[decl.Name] = true
+	}
+	return out
 }
 
 // configsMatch compares two MCP server configs to determine if they're from the same source

--- a/pkg/api/mcp_dependencies_test.go
+++ b/pkg/api/mcp_dependencies_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SAP/astonish/pkg/config"
@@ -312,6 +313,61 @@ func TestCheckMCPDependenciesHandler_StoreIDResolution(t *testing.T) {
 				t.Errorf("expected %d deps in response, got %d", len(tt.dependencies), len(resp.Dependencies))
 			}
 		})
+	}
+}
+
+func TestCheckMCPDependenciesHandler_SkipsStaleBuiltInToolDependencies(t *testing.T) {
+	reqBody := CheckMCPDependenciesRequest{
+		Dependencies: []config.MCPDependency{
+			{Server: "credentials", Source: "inline", Tools: []string{"resolve_credential"}},
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-dependencies/check", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	CheckMCPDependenciesHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp CheckMCPDependenciesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if !resp.AllInstalled || resp.Missing != 0 || len(resp.Dependencies) != 0 {
+		t.Fatalf("expected stale built-in deps ignored, got %+v", resp)
+	}
+}
+
+func TestResolveAgentYAMLDependencies_RemovesStaleBuiltInOnlyDependencies(t *testing.T) {
+	raw := `name: kubernikus
+nodes:
+  - name: list
+    type: llm
+    tools_selection:
+      - resolve_credential
+mcp_dependencies:
+  - server: credentials
+    source: inline
+    tools:
+      - resolve_credential
+layout: {}
+`
+	cfg := config.AgentConfig{
+		Nodes: []config.Node{{Name: "list", Type: "llm", ToolsSelection: []string{"resolve_credential"}}},
+		MCPDependencies: []config.MCPDependency{
+			{Server: "credentials", Source: "inline", Tools: []string{"resolve_credential"}},
+		},
+	}
+
+	got := resolveAgentYAMLDependencies(raw, cfg, nil, []ToolInfo{{Name: "resolve_credential", Source: "credentials"}})
+	if strings.Contains(got, "mcp_dependencies") {
+		t.Fatalf("expected stale mcp_dependencies removed, got:\n%s", got)
+	}
+	if !strings.Contains(got, "layout:") {
+		t.Fatalf("expected layout preserved, got:\n%s", got)
 	}
 }
 

--- a/pkg/api/mcp_dependencies_test.go
+++ b/pkg/api/mcp_dependencies_test.go
@@ -159,6 +159,31 @@ func TestResolveMCPDependencies_ExactNameMatching(t *testing.T) {
 			expectedDeps: nil,
 		},
 		{
+			name:           "built-in credential tools are skipped even when cache source is category",
+			toolsSelection: []string{"resolve_credential"},
+			cachedTools: []ToolInfo{
+				{Name: "resolve_credential", Source: "credentials"},
+			},
+			storeServers: nil,
+			existingDeps: nil,
+			expectedDeps: nil,
+		},
+		{
+			name:           "built-in flow tools are skipped before MCP fallback",
+			toolsSelection: []string{"shell_command", "http_request", "resolve_credential", "browser_navigate"},
+			cachedTools: []ToolInfo{
+				{Name: "shell_command", Source: "internal"},
+				{Name: "http_request", Source: "internal"},
+				{Name: "resolve_credential", Source: "credentials"},
+				{Name: "browser_navigate", Source: "browser"},
+			},
+			storeServers: nil,
+			existingDeps: []config.MCPDependency{
+				{Server: "credentials", Tools: []string{"resolve_credential"}, Source: "inline"},
+			},
+			expectedDeps: nil,
+		},
+		{
 			name:           "existing deps used as fallback for unknown tools",
 			toolsSelection: []string{"missing_tool"},
 			cachedTools:    []ToolInfo{}, // Not in cache
@@ -215,7 +240,7 @@ func TestCheckMCPDependenciesHandler_StoreIDResolution(t *testing.T) {
 	// Note: This is a more integration-style test. For unit testing,
 	// we'd need to mock loadAllServersFromTaps(). This test documents
 	// the expected behavior.
-	
+
 	tests := []struct {
 		name         string
 		dependencies []config.MCPDependency
@@ -268,7 +293,7 @@ func TestCheckMCPDependenciesHandler_StoreIDResolution(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/api/mcp-dependencies/check", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
-			
+
 			rr := httptest.NewRecorder()
 			CheckMCPDependenciesHandler(rr, req)
 
@@ -294,7 +319,7 @@ func TestCheckMCPDependenciesHandler_StoreIDResolution(t *testing.T) {
 func TestCheckMCPDependenciesHandler_InvalidRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/mcp-dependencies/check", bytes.NewReader([]byte("invalid json")))
 	req.Header.Set("Content-Type", "application/json")
-	
+
 	rr := httptest.NewRecorder()
 	CheckMCPDependenciesHandler(rr, req)
 
@@ -404,10 +429,10 @@ func TestMCPDependencyStatus_JSONTags(t *testing.T) {
 // TestCheckMCPDependenciesResponse_AllInstalled verifies the all_installed calculation
 func TestCheckMCPDependenciesResponse_AllInstalled(t *testing.T) {
 	tests := []struct {
-		name         string
-		statuses     []MCPDependencyStatus
-		expectAll    bool
-		expectCount  int
+		name        string
+		statuses    []MCPDependencyStatus
+		expectAll   bool
+		expectCount int
 	}{
 		{
 			name: "all installed",

--- a/pkg/api/mcp_dependency_utils.go
+++ b/pkg/api/mcp_dependency_utils.go
@@ -1,0 +1,23 @@
+package api
+
+import "github.com/SAP/astonish/pkg/config"
+
+func mcpDependenciesEqual(a, b []config.MCPDependency) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Server != b[i].Server || a[i].Source != b[i].Source || a[i].StoreID != b[i].StoreID {
+			return false
+		}
+		if len(a[i].Tools) != len(b[i].Tools) {
+			return false
+		}
+		for j := range a[i].Tools {
+			if a[i].Tools[j] != b[i].Tools[j] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/api/run_handler.go
+++ b/pkg/api/run_handler.go
@@ -737,6 +737,10 @@ func HandleChat(w http.ResponseWriter, r *http.Request) {
 	// 2. Determine Provider/Model
 	appCfg := effectiveAppConfig(r)
 	injectProviderSecrets(appCfg)
+	// Same PreSeed path as FlowRunHandler / Studio Chat: DB allow rules
+	// (e.g. **.cloud.sap) + OpenShell gateway must be on ctx before first egress.
+	ctx = withRuntimeNetworkPolicyContext(ctx, r, appCfg)
+	ctx = withRuntimeSandboxContext(ctx, r)
 
 	providerName := req.Provider
 	if providerName == "" {

--- a/pkg/api/run_handler.go
+++ b/pkg/api/run_handler.go
@@ -889,6 +889,9 @@ func HandleChat(w http.ResponseWriter, r *http.Request) {
 	}
 	sm.mu.Unlock()
 
+	// Overlap sandbox cold start with the first LLM/tool work in this run.
+	sandbox.WarmFlowSession(ctx, internalTools, sess.ID())
+
 	// 7. Create Runner
 	rnr, err := runner.New(runner.Config{
 		AppName:        "astonish",

--- a/pkg/api/sandbox_network_preseed.go
+++ b/pkg/api/sandbox_network_preseed.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/SAP/astonish/pkg/sandbox"
+	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+)
+
+func init() {
+	// Wire NodeTool -> netpolicy PreSeed without an import cycle.
+	// This is API-wide: chat, flows, app sandboxes, and fleet all share NodeTool.
+	sandbox.NetworkPolicyPreSeeder = netpolicy.EnsurePreSeedFromContext
+}

--- a/pkg/credentials/substitute.go
+++ b/pkg/credentials/substitute.go
@@ -35,7 +35,7 @@ func FormatPlaceholder(credName, field string) string {
 
 // ContainsPlaceholder reports whether text contains any credential placeholder.
 func ContainsPlaceholder(text string) bool {
-	return credentialPlaceholderRe.MatchString(text)
+	return credentialPlaceholderRe.MatchString(normalizeCredentialPlaceholderText(text))
 }
 
 // UnresolvedCredentialNames extracts unique credential names from any
@@ -59,6 +59,7 @@ func UnresolvedCredentialNames(m map[string]any) []string {
 func collectUnresolvedNames(v any, seen map[string]bool) {
 	switch val := v.(type) {
 	case string:
+		val = normalizeCredentialPlaceholderText(val)
 		matches := credentialPlaceholderRe.FindAllStringSubmatch(val, -1)
 		for _, m := range matches {
 			if len(m) >= 2 {
@@ -76,6 +77,19 @@ func collectUnresolvedNames(v any, seen map[string]bool) {
 	}
 }
 
+func normalizeCredentialPlaceholderText(text string) string {
+	if text == "" {
+		return text
+	}
+	replacer := strings.NewReplacer(
+		"\u200b", "",
+		"\u200c", "",
+		"\u200d", "",
+		"\ufeff", "",
+	)
+	return replacer.Replace(text)
+}
+
 // SubstitutePlaceholders replaces all {{CREDENTIAL:name:field}} tokens in text
 // with the actual secret values from the credential store. Unresolvable
 // placeholders are left as-is (the tool will fail naturally, giving the LLM
@@ -88,6 +102,7 @@ func SubstitutePlaceholders(text string, resolver CredentialResolver) string {
 	if resolver == nil {
 		return text
 	}
+	text = normalizeCredentialPlaceholderText(text)
 
 	return credentialPlaceholderRe.ReplaceAllStringFunc(text, func(match string) string {
 		parts := credentialPlaceholderRe.FindStringSubmatch(match)
@@ -116,6 +131,7 @@ func SubstituteShellCommand(command string, resolver CredentialResolver) string 
 	if resolver == nil || !ContainsPlaceholder(command) {
 		return command
 	}
+	command = normalizeCredentialPlaceholderText(command)
 
 	// Find all unique placeholders and resolve them.
 	type resolvedCred struct {
@@ -171,7 +187,7 @@ func SubstituteShellCommand(command string, resolver CredentialResolver) string 
 }
 
 // shellQuoteSingle wraps a value in single quotes, escaping any embedded single
-// quotes with the standard '\'' technique. Single-quoted strings in sh/bash
+// quotes with the standard '\” technique. Single-quoted strings in sh/bash
 // have NO expansion — $, `, \, ! are all literal.
 func shellQuoteSingle(s string) string {
 	// Replace each ' with '\'' (end quote, escaped quote, start quote).

--- a/pkg/credentials/substitute_test.go
+++ b/pkg/credentials/substitute_test.go
@@ -572,3 +572,38 @@ func TestUnresolvedCredentialNames(t *testing.T) {
 		})
 	}
 }
+
+func TestZeroWidthCredentialPlaceholderNormalization(t *testing.T) {
+	placeholder := "{\u200b{CREDENTIAL:openstack-keystone:token}}"
+	if !ContainsPlaceholder(placeholder) {
+		t.Fatal("expected zero-width credential placeholder to be detected")
+	}
+
+	input := map[string]any{"command": "curl -H 'X-Auth-Token: " + placeholder + "' http://api"}
+	got := UnresolvedCredentialNames(input)
+	if len(got) != 1 || got[0] != "openstack-keystone" {
+		t.Fatalf("expected unresolved openstack-keystone placeholder, got %v", got)
+	}
+}
+
+func TestSubstituteShellCommand_ZeroWidthPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	store.Set("openstack-keystone", &Credential{Type: CredBearer, Token: "ks-token-123"})
+
+	command := "curl -s -H \"X-Auth-Token: {\u200b{CREDENTIAL:openstack-keystone:token}}\" https://kubernikus.qa-de-1.cloud.sap/api/v1/clusters"
+	result := SubstituteShellCommand(command, store)
+
+	if !strings.Contains(result, "export __ASTONISH_CRED_") {
+		t.Fatalf("expected env var exports, got:\n%s", result)
+	}
+	if strings.Contains(result, "CREDENTIAL:openstack-keystone:token") {
+		t.Fatalf("placeholder should be resolved, got:\n%s", result)
+	}
+	if !strings.Contains(result, "ks-token-123") {
+		t.Fatalf("expected token value in shell-safe export, got:\n%s", result)
+	}
+}

--- a/pkg/launcher/console.go
+++ b/pkg/launcher/console.go
@@ -18,6 +18,7 @@ import (
 	"github.com/SAP/astonish/pkg/credentials"
 	"github.com/SAP/astonish/pkg/mcp"
 	"github.com/SAP/astonish/pkg/provider"
+	"github.com/SAP/astonish/pkg/sandbox"
 	persistentsession "github.com/SAP/astonish/pkg/session"
 	"github.com/SAP/astonish/pkg/tools"
 	"github.com/SAP/astonish/pkg/ui"
@@ -430,6 +431,7 @@ func RunConsole(ctx context.Context, cfg *ConsoleConfig) error {
 	}
 
 	sess := resp.Session
+	sandbox.WarmFlowSession(ctx, internalTools, sess.ID())
 
 	// Create runner
 	if cfg.DebugMode {

--- a/pkg/launcher/headless.go
+++ b/pkg/launcher/headless.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SAP/astonish/pkg/credentials"
 	"github.com/SAP/astonish/pkg/mcp"
 	"github.com/SAP/astonish/pkg/provider"
+	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/tools"
 	adkagent "google.golang.org/adk/agent"
@@ -203,6 +204,9 @@ func RunHeadless(ctx context.Context, cfg *HeadlessConfig) (string, error) {
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 	sess := resp.Session
+
+	// Overlap sandbox cold start with the first LLM/tool work (same run only).
+	sandbox.WarmFlowSession(ctx, internalTools, sess.ID())
 
 	// Create runner
 	r, err := runner.New(runner.Config{

--- a/pkg/launcher/interactive_flow_runner.go
+++ b/pkg/launcher/interactive_flow_runner.go
@@ -15,6 +15,8 @@ import (
 	"github.com/SAP/astonish/pkg/credentials"
 	"github.com/SAP/astonish/pkg/mcp"
 	"github.com/SAP/astonish/pkg/provider"
+	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	"github.com/SAP/astonish/pkg/tools"
 	adkagent "google.golang.org/adk/agent"
 	"google.golang.org/adk/runner"
@@ -187,6 +189,8 @@ func (ifr *InteractiveFlowRunner) startFlowWithConfig(
 	parameters map[string]string,
 	sessionKey string,
 ) (*tools.FlowRunResult, error) {
+	ctx = withFlowGatewayConfig(ctx, ifr.AppConfig)
+
 	// Suppress default logger in non-debug mode
 	if !ifr.DebugMode {
 		log.SetOutput(io.Discard)
@@ -351,12 +355,24 @@ func (ifr *InteractiveFlowRunner) startFlowWithConfig(
 	return ifr.executeFlowTurn(ctx, sess, nil, parameters)
 }
 
+func withFlowGatewayConfig(ctx context.Context, appCfg *config.AppConfig) context.Context {
+	if appCfg == nil || appCfg.Sandbox.OpenShell.GatewayAddr == "" {
+		return ctx
+	}
+	return netpolicy.WithGatewayConfig(ctx, &openshell.GRPCClientConfig{
+		Addr: appCfg.Sandbox.OpenShell.GatewayAddr,
+		TLS:  appCfg.Sandbox.OpenShell.OpenShellGatewayTLS(),
+	})
+}
+
 // resumeFlow resumes a paused flow with the user's input response.
 func (ifr *InteractiveFlowRunner) resumeFlow(
 	ctx context.Context,
 	sessionKey string,
 	inputResponse string,
 ) (*tools.FlowRunResult, error) {
+	ctx = withFlowGatewayConfig(ctx, ifr.AppConfig)
+
 	val, ok := ifr.sessions.Load(sessionKey)
 	if !ok {
 		return &tools.FlowRunResult{

--- a/pkg/launcher/interactive_flow_runner.go
+++ b/pkg/launcher/interactive_flow_runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/SAP/astonish/pkg/provider"
 	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
+	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/tools"
 	adkagent "google.golang.org/adk/agent"
 	"google.golang.org/adk/runner"
@@ -189,7 +190,7 @@ func (ifr *InteractiveFlowRunner) startFlowWithConfig(
 	parameters map[string]string,
 	sessionKey string,
 ) (*tools.FlowRunResult, error) {
-	ctx = withFlowGatewayConfig(ctx, ifr.AppConfig)
+	ctx = withFlowNetworkPolicyContext(ctx, ifr.AppConfig)
 
 	// Suppress default logger in non-debug mode
 	if !ifr.DebugMode {
@@ -355,6 +356,23 @@ func (ifr *InteractiveFlowRunner) startFlowWithConfig(
 	return ifr.executeFlowTurn(ctx, sess, nil, parameters)
 }
 
+// withFlowNetworkPolicyContext attaches OpenShell gateway config and, when
+// missing, NetworkPolicyStores from request Services so NodeTool can PreSeed
+// DB allow rules (e.g. **.cloud.sap) before the nested flow's first egress.
+// Existing NetworkPolicyStores on ctx (e.g. from ChatRunner) are preserved.
+func withFlowNetworkPolicyContext(ctx context.Context, appCfg *config.AppConfig) context.Context {
+	if store.NetworkPolicyStoresFromContext(ctx) == nil {
+		if svc := store.FromContext(ctx); svc != nil {
+			ctx = store.WithNetworkPolicyStores(ctx, &store.NetworkPolicyStores{
+				Platform: svc.PlatformNetworkPolicies,
+				Org:      svc.NetworkPolicies,
+				Team:     svc.TeamNetworkPolicies,
+			})
+		}
+	}
+	return withFlowGatewayConfig(ctx, appCfg)
+}
+
 func withFlowGatewayConfig(ctx context.Context, appCfg *config.AppConfig) context.Context {
 	if appCfg == nil || appCfg.Sandbox.OpenShell.GatewayAddr == "" {
 		return ctx
@@ -371,7 +389,7 @@ func (ifr *InteractiveFlowRunner) resumeFlow(
 	sessionKey string,
 	inputResponse string,
 ) (*tools.FlowRunResult, error) {
-	ctx = withFlowGatewayConfig(ctx, ifr.AppConfig)
+	ctx = withFlowNetworkPolicyContext(ctx, ifr.AppConfig)
 
 	val, ok := ifr.sessions.Load(sessionKey)
 	if !ok {

--- a/pkg/launcher/interactive_flow_runner.go
+++ b/pkg/launcher/interactive_flow_runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SAP/astonish/pkg/credentials"
 	"github.com/SAP/astonish/pkg/mcp"
 	"github.com/SAP/astonish/pkg/provider"
+	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	"github.com/SAP/astonish/pkg/store"
@@ -351,6 +352,9 @@ func (ifr *InteractiveFlowRunner) startFlowWithConfig(
 		cleanupFuncs:   cleanups,
 	}
 	ifr.sessions.Store(sessionKey, sess)
+
+	// Overlap sandbox cold start with the first LLM/tool work (same run only).
+	sandbox.WarmFlowSession(ctx, internalTools, sess.sessionID)
 
 	// Run the flow with parameters
 	return ifr.executeFlowTurn(ctx, sess, nil, parameters)

--- a/pkg/launcher/interactive_flow_runner_test.go
+++ b/pkg/launcher/interactive_flow_runner_test.go
@@ -1,0 +1,27 @@
+package launcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/config"
+	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+)
+
+func TestWithFlowGatewayConfig_AttachesGateway(t *testing.T) {
+	appCfg := &config.AppConfig{}
+	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
+
+	ctx := withFlowGatewayConfig(context.Background(), appCfg)
+	gw := netpolicy.GatewayConfigFromContext(ctx)
+	if gw == nil || gw.Addr != "openshell.example:8443" {
+		t.Fatalf("expected OpenShell gateway config on flow context, got %+v", gw)
+	}
+}
+
+func TestWithFlowGatewayConfig_NoGatewayLeavesContextUnset(t *testing.T) {
+	ctx := withFlowGatewayConfig(context.Background(), &config.AppConfig{})
+	if gw := netpolicy.GatewayConfigFromContext(ctx); gw != nil {
+		t.Fatalf("expected no gateway config, got %+v", gw)
+	}
+}

--- a/pkg/launcher/interactive_flow_runner_test.go
+++ b/pkg/launcher/interactive_flow_runner_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+	"github.com/SAP/astonish/pkg/store"
 )
 
 func TestWithFlowGatewayConfig_AttachesGateway(t *testing.T) {
@@ -25,3 +26,54 @@ func TestWithFlowGatewayConfig_NoGatewayLeavesContextUnset(t *testing.T) {
 		t.Fatalf("expected no gateway config, got %+v", gw)
 	}
 }
+
+func TestWithFlowNetworkPolicyContext_AttachesStoresFromServicesAndGateway(t *testing.T) {
+	platformStore := &stubFlowNetPolicyStore{}
+	orgStore := &stubFlowNetPolicyStore{}
+	teamStore := &stubFlowNetPolicyStore{}
+	ctx := store.WithServices(context.Background(), &store.Services{
+		PlatformNetworkPolicies: platformStore,
+		NetworkPolicies:         orgStore,
+		TeamNetworkPolicies:     teamStore,
+	})
+	appCfg := &config.AppConfig{}
+	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
+
+	ctx = withFlowNetworkPolicyContext(ctx, appCfg)
+	nps := store.NetworkPolicyStoresFromContext(ctx)
+	if nps == nil || nps.Platform != platformStore || nps.Org != orgStore || nps.Team != teamStore {
+		t.Fatalf("expected network policy stores from Services, got %+v", nps)
+	}
+	gw := netpolicy.GatewayConfigFromContext(ctx)
+	if gw == nil || gw.Addr != "openshell.example:8443" {
+		t.Fatalf("expected gateway on flow context, got %+v", gw)
+	}
+}
+
+func TestWithFlowNetworkPolicyContext_PreservesExistingStores(t *testing.T) {
+	existingTeam := &stubFlowNetPolicyStore{}
+	ctx := store.WithNetworkPolicyStores(context.Background(), &store.NetworkPolicyStores{Team: existingTeam})
+	// Services with different stores must not overwrite ChatRunner-injected stores.
+	ctx = store.WithServices(ctx, &store.Services{
+		TeamNetworkPolicies: &stubFlowNetPolicyStore{},
+	})
+	appCfg := &config.AppConfig{}
+	appCfg.Sandbox.OpenShell.GatewayAddr = "openshell.example:8443"
+
+	ctx = withFlowNetworkPolicyContext(ctx, appCfg)
+	nps := store.NetworkPolicyStoresFromContext(ctx)
+	if nps == nil || nps.Team != existingTeam {
+		t.Fatalf("expected existing team store preserved, got %+v", nps)
+	}
+}
+
+type stubFlowNetPolicyStore struct{}
+
+func (s *stubFlowNetPolicyStore) List(context.Context) ([]store.NetworkPolicyRule, error) {
+	return nil, nil
+}
+func (s *stubFlowNetPolicyStore) Get(context.Context, string) (*store.NetworkPolicyRule, error) {
+	return nil, nil
+}
+func (s *stubFlowNetPolicyStore) Save(context.Context, *store.NetworkPolicyRule) error { return nil }
+func (s *stubFlowNetPolicyStore) Delete(context.Context, string) error                 { return nil }

--- a/pkg/sandbox/flow_warm.go
+++ b/pkg/sandbox/flow_warm.go
@@ -1,0 +1,57 @@
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+
+	"google.golang.org/adk/tool"
+)
+
+// WarmFlowSession begins sandbox provisioning for sessionID so cold start
+// overlaps the first LLM call / early flow work within the same run
+// (same idea as NodeTool.ProcessRequest → BindSession in Chat).
+//
+// Isolation is unchanged: each flow run still uses its own session ID and
+// callers must Cleanup/destroy after the run. This must not be used to
+// share sandboxes across independent flow runs.
+//
+// Safe no-op when sessionID is empty, tools are not sandbox-wrapped, or
+// the pool cannot vend a client.
+func WarmFlowSession(ctx context.Context, tools []tool.Tool, sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	nt := firstNodeTool(tools)
+	if nt == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client := nt.getClientFromContext(ctx, sessionID)
+	if client == nil {
+		return
+	}
+	nt.applyNetworkAllowEndpoints(ctx, client)
+	client.BindSession(sessionID)
+
+	// Finish ready + network PreSeed in the background so the caller can
+	// proceed (first LLM node, MCP already done, etc.) while the pod comes up.
+	go func() {
+		if err := client.EnsureReady(sessionID); err != nil {
+			slog.Debug("flow sandbox warm EnsureReady",
+				"component", "sandbox", "session", sessionID, "error", err)
+			return
+		}
+		ensureNetworkPolicyPreSeed(ctx, sessionID)
+	}()
+}
+
+func firstNodeTool(tools []tool.Tool) *NodeTool {
+	for _, t := range tools {
+		if nt, ok := t.(*NodeTool); ok {
+			return nt
+		}
+	}
+	return nil
+}

--- a/pkg/sandbox/flow_warm_test.go
+++ b/pkg/sandbox/flow_warm_test.go
@@ -1,0 +1,130 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SAP/astonish/pkg/store"
+	"google.golang.org/adk/tool"
+)
+
+type warmSpyClient struct {
+	mu      sync.Mutex
+	bound   bool
+	ready   bool
+	allowed []NetworkAllowEndpoint
+	readyCh chan struct{}
+}
+
+func (c *warmSpyClient) BindSession(string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bound = true
+}
+
+func (c *warmSpyClient) EnsureReady(string) error {
+	c.mu.Lock()
+	c.ready = true
+	ch := c.readyCh
+	c.mu.Unlock()
+	if ch != nil {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	return nil
+}
+
+func (c *warmSpyClient) Call(string, string, map[string]interface{}) (json.RawMessage, error) {
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+func (c *warmSpyClient) SetNetworkAllowEndpoints(endpoints []NetworkAllowEndpoint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.allowed = append([]NetworkAllowEndpoint(nil), endpoints...)
+}
+
+type warmSpyPool struct {
+	client *warmSpyClient
+}
+
+func (s *warmSpyPool) GetOrCreate(string) ToolNodeClient                     { return s.client }
+func (s *warmSpyPool) GetOrCreateWithTemplate(string, string) ToolNodeClient { return s.client }
+func (s *warmSpyPool) GetOrCreateWithChain(string, string, []string) ToolNodeClient {
+	return s.client
+}
+func (s *warmSpyPool) GetOrCreateWithImage(string, string, []string, string) ToolNodeClient {
+	return s.client
+}
+func (s *warmSpyPool) Cleanup()            {}
+func (s *warmSpyPool) GetBackend() Backend { return nil }
+func (s *warmSpyPool) Alias(_, _ string)   {}
+func (s *warmSpyPool) Remove(_ string)     {}
+
+func TestWarmFlowSession_BindsAndEnsuresReady(t *testing.T) {
+	prev := NetworkPolicyPreSeeder
+	t.Cleanup(func() { NetworkPolicyPreSeeder = prev })
+
+	var (
+		mu             sync.Mutex
+		preSeedSession string
+	)
+	NetworkPolicyPreSeeder = func(ctx context.Context, sessionID string) {
+		mu.Lock()
+		defer mu.Unlock()
+		preSeedSession = sessionID
+	}
+
+	client := &warmSpyClient{readyCh: make(chan struct{})}
+	nt := NewNodeToolWithPool(testTool{name: "shell_command"}, &warmSpyPool{client: client})
+	teamStore := &testNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "**.cloud.sap",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	ctx := store.WithNetworkPolicyStores(context.Background(), &store.NetworkPolicyStores{Team: teamStore})
+
+	WarmFlowSession(ctx, []tool.Tool{nt}, "flow-sess-warm")
+
+	client.mu.Lock()
+	bound, allowed := client.bound, append([]NetworkAllowEndpoint(nil), client.allowed...)
+	client.mu.Unlock()
+	if !bound {
+		t.Fatal("expected BindSession during WarmFlowSession")
+	}
+	if len(allowed) != 1 || allowed[0].Host != "**.cloud.sap" {
+		t.Fatalf("expected network allow endpoints before bind, got %+v", allowed)
+	}
+
+	select {
+	case <-client.readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for background EnsureReady")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		seeded := preSeedSession
+		mu.Unlock()
+		if seeded == "flow-sess-warm" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected background PreSeed for flow-sess-warm")
+}
+
+func TestWarmFlowSession_NoopWithoutNodeTool(t *testing.T) {
+	WarmFlowSession(context.Background(), nil, "sess")
+	WarmFlowSession(context.Background(), []tool.Tool{testTool{name: "memory_search"}}, "sess")
+	WarmFlowSession(context.Background(), []tool.Tool{
+		NewNodeToolWithPool(testTool{name: "shell_command"}, &warmSpyPool{client: &warmSpyClient{}}),
+	}, "")
+}

--- a/pkg/sandbox/node_tool_test.go
+++ b/pkg/sandbox/node_tool_test.go
@@ -5,6 +5,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	adkagent "google.golang.org/adk/agent"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/toolconfirmation"
+	"google.golang.org/genai"
+
 	"github.com/SAP/astonish/pkg/store"
 )
 
@@ -58,13 +66,173 @@ func (s *spyPool) Remove(_ string) {}
 // stubClient satisfies ToolNodeClient for test purposes.
 type stubClient struct{}
 
-func (c *stubClient) BindSession(string)           {}
-func (c *stubClient) EnsureReady(string) error     { return nil }
+func (c *stubClient) BindSession(string)       {}
+func (c *stubClient) EnsureReady(string) error { return nil }
 func (c *stubClient) Call(string, string, map[string]interface{}) (json.RawMessage, error) {
 	return nil, nil
 }
-func (c *stubClient) Close() error { return nil }
+func (c *stubClient) Close() error   { return nil }
 func (c *stubClient) IsClosed() bool { return false }
+
+type preseedSpyClient struct {
+	stubClient
+	allowed []NetworkAllowEndpoint
+	bound   bool
+	ready   bool
+	called  bool
+}
+
+func (c *preseedSpyClient) SetNetworkAllowEndpoints(endpoints []NetworkAllowEndpoint) {
+	c.allowed = append([]NetworkAllowEndpoint(nil), endpoints...)
+}
+
+func (c *preseedSpyClient) BindSession(string) {
+	c.bound = true
+}
+
+func (c *preseedSpyClient) EnsureReady(string) error {
+	c.ready = true
+	return nil
+}
+
+func (c *preseedSpyClient) Call(string, string, map[string]interface{}) (json.RawMessage, error) {
+	c.called = true
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+type preseedSpyPool struct {
+	client *preseedSpyClient
+}
+
+func (s *preseedSpyPool) GetOrCreate(string) ToolNodeClient                     { return s.client }
+func (s *preseedSpyPool) GetOrCreateWithTemplate(string, string) ToolNodeClient { return s.client }
+func (s *preseedSpyPool) GetOrCreateWithChain(string, string, []string) ToolNodeClient {
+	return s.client
+}
+func (s *preseedSpyPool) GetOrCreateWithImage(string, string, []string, string) ToolNodeClient {
+	return s.client
+}
+func (s *preseedSpyPool) Cleanup()            {}
+func (s *preseedSpyPool) GetBackend() Backend { return nil }
+func (s *preseedSpyPool) Alias(_, _ string)   {}
+func (s *preseedSpyPool) Remove(_ string)     {}
+
+type testNetworkPolicyStore struct {
+	rules []store.NetworkPolicyRule
+}
+
+func (s *testNetworkPolicyStore) List(context.Context) ([]store.NetworkPolicyRule, error) {
+	return s.rules, nil
+}
+
+func (s *testNetworkPolicyStore) Get(context.Context, string) (*store.NetworkPolicyRule, error) {
+	return nil, nil
+}
+
+func (s *testNetworkPolicyStore) Save(context.Context, *store.NetworkPolicyRule) error {
+	return nil
+}
+
+func (s *testNetworkPolicyStore) Delete(context.Context, string) error {
+	return nil
+}
+
+type testTool struct {
+	name string
+}
+
+func (t testTool) Name() string        { return t.name }
+func (t testTool) Description() string { return "test tool" }
+func (t testTool) IsLongRunning() bool { return false }
+
+type testToolContext struct {
+	context.Context
+	sessionID string
+}
+
+func (c testToolContext) InvocationID() string                 { return "invocation-1" }
+func (c testToolContext) AgentName() string                    { return "agent-1" }
+func (c testToolContext) UserID() string                       { return "user-1" }
+func (c testToolContext) AppName() string                      { return "astonish" }
+func (c testToolContext) SessionID() string                    { return c.sessionID }
+func (c testToolContext) Branch() string                       { return "" }
+func (c testToolContext) UserContent() *genai.Content          { return nil }
+func (c testToolContext) ReadonlyState() session.ReadonlyState { return nil }
+func (c testToolContext) Artifacts() adkagent.Artifacts        { return nil }
+func (c testToolContext) State() session.State                 { return nil }
+func (c testToolContext) FunctionCallID() string               { return "call-1" }
+func (c testToolContext) Actions() *session.EventActions       { return &session.EventActions{} }
+func (c testToolContext) SearchMemory(context.Context, string) (*memory.SearchResponse, error) {
+	return nil, nil
+}
+func (c testToolContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (c testToolContext) RequestConfirmation(string, any) error                { return nil }
+
+var _ tool.Context = (*testToolContext)(nil)
+
+func TestNodeToolRun_AppliesAndPreSeedsNetworkPolicyFromContext(t *testing.T) {
+	prev := NetworkPolicyPreSeeder
+	t.Cleanup(func() { NetworkPolicyPreSeeder = prev })
+
+	var preSeedCalled bool
+	var preSeedSession string
+	NetworkPolicyPreSeeder = func(ctx context.Context, sessionID string) {
+		preSeedCalled = true
+		preSeedSession = sessionID
+		if nps := store.NetworkPolicyStoresFromContext(ctx); nps == nil || nps.Team == nil {
+			t.Fatalf("expected team network policy store in pre-seed context, got %+v", nps)
+		}
+	}
+
+	client := &preseedSpyClient{}
+	nt := &NodeTool{Tool: testTool{name: "http_request"}, pool: &preseedSpyPool{client: client}}
+	teamStore := &testNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "*.cloud.sap",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	baseCtx := store.WithNetworkPolicyStores(context.Background(), &store.NetworkPolicyStores{Team: teamStore})
+	ctx := testToolContext{Context: baseCtx, sessionID: "flow-run-openstack"}
+
+	result, err := nt.Run(ctx, map[string]interface{}{"url": "https://kubernikus.qa-de-1.cloud.sap/api/v1/clusters"})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ok, _ := result["ok"].(bool); !ok {
+		t.Fatalf("expected ok result, got %#v", result)
+	}
+	if len(client.allowed) != 1 || client.allowed[0].Host != "*.cloud.sap" || client.allowed[0].Port != 443 {
+		t.Fatalf("expected *.cloud.sap allow endpoint baked before run, got %+v", client.allowed)
+	}
+	if !client.ready || !client.called {
+		t.Fatalf("expected client to be readied and called, ready=%v called=%v", client.ready, client.called)
+	}
+	if !preSeedCalled || preSeedSession != "flow-run-openstack" {
+		t.Fatalf("expected network policy pre-seed for flow session, called=%v session=%q", preSeedCalled, preSeedSession)
+	}
+}
+
+func TestNodeToolProcessRequest_AppliesNetworkPolicyBeforeBind(t *testing.T) {
+	client := &preseedSpyClient{}
+	nt := &NodeTool{Tool: testTool{name: "http_request"}, pool: &preseedSpyPool{client: client}}
+	teamStore := &testNetworkPolicyStore{rules: []store.NetworkPolicyRule{{
+		Host:   "identity-3.qa-de-1.cloud.sap",
+		Port:   443,
+		Action: store.NetworkPolicyAllow,
+	}}}
+	baseCtx := store.WithNetworkPolicyStores(context.Background(), &store.NetworkPolicyStores{Team: teamStore})
+	ctx := testToolContext{Context: baseCtx, sessionID: "flow-run-bind"}
+
+	if err := nt.ProcessRequest(ctx, &model.LLMRequest{Config: &genai.GenerateContentConfig{}}); err != nil {
+		t.Fatalf("ProcessRequest returned error: %v", err)
+	}
+	if len(client.allowed) != 1 || client.allowed[0].Host != "identity-3.qa-de-1.cloud.sap" {
+		t.Fatalf("expected policy allow endpoint before bind, got %+v", client.allowed)
+	}
+	if !client.bound {
+		t.Fatal("expected session to be bound")
+	}
+}
 
 func TestGetClientFromContext_ChainWithoutTemplate(t *testing.T) {
 	// When a layer chain is set but no template name exists (the @base-only

--- a/pkg/scheduler/executor.go
+++ b/pkg/scheduler/executor.go
@@ -135,6 +135,12 @@ func (e *Executor) executeRoutine(ctx context.Context, job *Job) (string, error)
 		return "", fmt.Errorf("headless runner not configured")
 	}
 
+	// Gateway on ctx so NodeTool PreSeeds DB allow rules before first Call
+	// (NetworkPolicyStores are injected by MultiTenantScheduler / callers).
+	if e.GatewayConfig != nil {
+		ctx = netpolicy.WithGatewayConfig(ctx, e.GatewayConfig)
+	}
+
 	cfg := &HeadlessRunConfig{
 		AppConfig:    e.AppConfig,
 		ProviderName: e.ProviderName,

--- a/pkg/scheduler/executor_network_policy_test.go
+++ b/pkg/scheduler/executor_network_policy_test.go
@@ -1,0 +1,80 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
+	"github.com/SAP/astonish/pkg/sandbox/openshell"
+	"github.com/SAP/astonish/pkg/store"
+)
+
+func TestExecuteRoutine_AttachesGatewayConfig(t *testing.T) {
+	var gotCtx context.Context
+	e := &Executor{
+		GatewayConfig: &openshell.GRPCClientConfig{Addr: "openshell.example:8443"},
+		FlowResolver: func(string) (string, error) {
+			return "name: my-flow\nnodes: []\n", nil
+		},
+		RunHeadless: func(ctx context.Context, cfg *HeadlessRunConfig) (string, error) {
+			gotCtx = ctx
+			return "ok", nil
+		},
+	}
+	teamStore := &stubNetPolicyStore{}
+	ctx := store.WithNetworkPolicyStores(context.Background(), &store.NetworkPolicyStores{Team: teamStore})
+	job := &Job{
+		Name: "routine-netpol",
+		Mode: ModeRoutine,
+		Payload: JobPayload{
+			Flow: "my-flow",
+		},
+	}
+
+	out, err := e.executeRoutine(ctx, job)
+	if err != nil {
+		t.Fatalf("executeRoutine: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("result = %q, want ok", out)
+	}
+	gw := netpolicy.GatewayConfigFromContext(gotCtx)
+	if gw == nil || gw.Addr != "openshell.example:8443" {
+		t.Fatalf("expected gateway on headless ctx, got %+v", gw)
+	}
+	nps := store.NetworkPolicyStoresFromContext(gotCtx)
+	if nps == nil || nps.Team != teamStore {
+		t.Fatalf("expected team network policy store preserved, got %+v", nps)
+	}
+}
+
+func TestExecuteRoutine_NoGatewayWhenUnset(t *testing.T) {
+	var gotCtx context.Context
+	e := &Executor{
+		FlowResolver: func(string) (string, error) {
+			return "name: my-flow\nnodes: []\n", nil
+		},
+		RunHeadless: func(ctx context.Context, _ *HeadlessRunConfig) (string, error) {
+			gotCtx = ctx
+			return "ok", nil
+		},
+	}
+	job := &Job{Name: "routine", Mode: ModeRoutine, Payload: JobPayload{Flow: "my-flow"}}
+	if _, err := e.executeRoutine(context.Background(), job); err != nil {
+		t.Fatalf("executeRoutine: %v", err)
+	}
+	if gw := netpolicy.GatewayConfigFromContext(gotCtx); gw != nil {
+		t.Fatalf("expected no gateway, got %+v", gw)
+	}
+}
+
+type stubNetPolicyStore struct{}
+
+func (s *stubNetPolicyStore) List(context.Context) ([]store.NetworkPolicyRule, error) {
+	return nil, nil
+}
+func (s *stubNetPolicyStore) Get(context.Context, string) (*store.NetworkPolicyRule, error) {
+	return nil, nil
+}
+func (s *stubNetPolicyStore) Save(context.Context, *store.NetworkPolicyRule) error { return nil }
+func (s *stubNetPolicyStore) Delete(context.Context, string) error                 { return nil }

--- a/web/src/components/StudioChat.tsx
+++ b/web/src/components/StudioChat.tsx
@@ -2569,9 +2569,9 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     return sessions.filter(s => (s.title || s.id).toLowerCase().includes(q))
   }, [sessions, sessionFilter])
 
-  const { activityByStart, skipIndices: toolActivitySkipIndices } = useMemo(
-    () => buildActivityRenderIndex(messages),
-    [messages],
+  const { activityByStart, skipIndices: toolActivitySkipIndices, lastActivityStart } = useMemo(
+    () => buildActivityRenderIndex(messages, { absorbTrailingSoft: isStreaming }),
+    [messages, isStreaming],
   )
 
   const liveStreamStatus = useMemo(
@@ -2784,6 +2784,24 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
             <HomePage onSuggestionClick={(text) => { setInput(text); inputRef.current?.focus() }} />
           ) : (
             messages.map((msg, index) => {
+              // Turn-level activity fold: render block at segment start; skip covered indices.
+              const activityAt = activityByStart.get(index)
+              if (activityAt) {
+                // Trailing activity stays "live" for the whole open stream (including
+                // provisional process text after the last tool), not only while a tool runs.
+                const streamingActivity = isStreaming && activityAt.start === lastActivityStart
+                return (
+                  <ToolActivityBlock
+                    key={`activity-${activityAt.start}`}
+                    blockId={`activity-${activityAt.start}`}
+                    steps={activityAt.steps}
+                    notes={activityAt.notes}
+                    streaming={streamingActivity}
+                  />
+                )
+              }
+              if (toolActivitySkipIndices.has(index)) return null
+
               if (msg.type === 'user') {
                 const userMsg = msg as UserMessage
                 return (
@@ -2969,18 +2987,8 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
               }
 
               if (msg.type === 'tool_call' || msg.type === 'tool_result') {
-                if (toolActivitySkipIndices.has(index)) return null
-                const activity = activityByStart.get(index)
-                if (!activity) return null
-                const streamingActivity = isStreaming && activity.end === messages.length - 1
-                return (
-                  <ToolActivityBlock
-                    key={`activity-${activity.start}`}
-                    blockId={`activity-${activity.start}`}
-                    steps={activity.steps}
-                    streaming={streamingActivity}
-                  />
-                )
+                // Covered by activity fold above; unpaired leftovers should not render.
+                return null
               }
 
               if (msg.type === 'browser_handoff') {

--- a/web/src/components/chat/ToolActivityBlock.tsx
+++ b/web/src/components/chat/ToolActivityBlock.tsx
@@ -4,13 +4,16 @@ import {
   activityStats,
   activitySummary,
   formatToolPayload,
+  latestProcessText,
   previewValue,
+  type ActivityNote,
   type ActivityStats,
   type ToolActivityStep,
 } from './toolActivity'
 
 interface ToolActivityBlockProps {
   steps: ToolActivityStep[]
+  notes?: ActivityNote[]
   /** True when this block is the trailing activity during an active stream. */
   streaming?: boolean
   /** Stable key prefix for the block (e.g. activity start index). */
@@ -58,13 +61,15 @@ function TrailingMetric({ stats }: { stats: ActivityStats }) {
  * Cursor-style tool activity line with accent lead, muted rest, and trailing metric.
  * Collapsed by default; expands to paired call/result steps.
  */
-export default function ToolActivityBlock({ steps, streaming = false, blockId }: ToolActivityBlockProps) {
+export default function ToolActivityBlock({ steps, notes = [], streaming = false, blockId }: ToolActivityBlockProps) {
   const [expanded, setExpanded] = useState(false)
   const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set())
 
-  const summary = activitySummary(steps, { streaming })
+  const summary = activitySummary(steps, { streaming, noteCount: notes.length })
   const stats = activityStats(steps)
   const showSpinner = summary.variant === 'running'
+  const processText = latestProcessText(notes)
+  const processPreview = processText.length > 220 ? `${processText.slice(0, 219)}…` : processText
 
   const toggleStep = (stepIndex: number) => {
     setExpandedSteps(prev => {
@@ -127,6 +132,15 @@ export default function ToolActivityBlock({ steps, streaming = false, blockId }:
           )}
         </span>
       </button>
+
+      {processPreview && (
+        <div
+          className="thinking-note max-w-[90%] pl-0.5"
+          data-testid="activity-process-text"
+        >
+          {processPreview}
+        </div>
+      )}
 
       {expanded && (
         <div
@@ -223,6 +237,26 @@ export default function ToolActivityBlock({ steps, streaming = false, blockId }:
               </div>
             )
           })}
+          {notes.length > 0 && (
+            <div
+              data-testid="activity-notes"
+              style={{ borderTop: '1px solid var(--border-color)' }}
+              className="px-3 py-2 space-y-1.5"
+            >
+              <div className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+                Notes
+              </div>
+              {notes.map(note => (
+                <p
+                  key={`${blockId}-note-${note.index}`}
+                  className="text-xs whitespace-pre-wrap"
+                  style={{ color: 'var(--text-muted)' }}
+                >
+                  {note.text.length > 280 ? `${note.text.slice(0, 279)}…` : note.text}
+                </p>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/chat/__tests__/ToolActivityBlock.test.tsx
+++ b/web/src/components/chat/__tests__/ToolActivityBlock.test.tsx
@@ -130,4 +130,35 @@ describe('ToolActivityBlock', () => {
     expect(chevron).toHaveClass('opacity-0')
     expect(chevron).toHaveClass('group-hover:opacity-100')
   })
+
+  it('shows absorbed notes when expanded', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-notes"
+        steps={completeSteps}
+        notes={[{ index: 1, kind: 'agent', text: 'checking credentials next' }]}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /1 note/ })).toBeInTheDocument()
+    // Always-visible dimmed process line (not only after expand)
+    expect(screen.getByTestId('activity-process-text')).toHaveTextContent('checking credentials next')
+    fireEvent.click(screen.getByRole('button', { name: /1 note/ }))
+    expect(screen.getByTestId('activity-notes')).toBeInTheDocument()
+    expect(screen.getAllByText('checking credentials next').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows process text without expanding', () => {
+    render(
+      <ToolActivityBlock
+        blockId="activity-process"
+        steps={completeSteps}
+        notes={[
+          { index: 1, kind: 'agent', text: 'first thought' },
+          { index: 3, kind: 'agent', text: 'latest thought' },
+        ]}
+      />,
+    )
+    expect(screen.getByTestId('activity-process-text')).toHaveTextContent('latest thought')
+    expect(screen.queryByTestId('activity-notes')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/chat/__tests__/toolActivity.test.ts
+++ b/web/src/components/chat/__tests__/toolActivity.test.ts
@@ -8,7 +8,10 @@ import {
   deriveLiveStreamStatus,
   extractPathHint,
   groupToolActivity,
+  isHardBreakType,
+  isSoftNoteType,
   isToolResultError,
+  latestProcessText,
   liveActivityHint,
   previewValue,
   splitActivitySummary,
@@ -37,36 +40,32 @@ describe('previewValue', () => {
 })
 
 describe('groupToolActivity', () => {
-  it('pairs contiguous call/result and splits on agent text', () => {
+  it('folds interstitial agents between tools; keeps final agent outside', () => {
     const messages: ChatMsg[] = [
       { type: 'user', content: 'hi' },
       { type: 'tool_call', toolName: 'search_tools', toolArgs: { q: 'x' } },
       { type: 'tool_result', toolName: 'search_tools', toolResult: { ok: true } },
+      { type: 'agent', content: 'checking next step' },
       { type: 'tool_call', toolName: 'http_request', toolArgs: { url: 'https://a' } },
       { type: 'tool_result', toolName: 'http_request', toolResult: 'body' },
       { type: 'agent', content: 'done' },
-      { type: 'tool_call', toolName: 'write_file', toolArgs: { path: 'a.md' } },
-      { type: 'tool_result', toolName: 'write_file', toolResult: { path: 'a.md' } },
     ]
 
     const segs = groupToolActivity(messages)
     expect(segs.map(s => s.kind)).toEqual([
-      'passthrough',
+      'passthrough', // user
       'activity',
-      'passthrough',
-      'activity',
+      'passthrough', // final agent
     ])
 
-    const first = segs[1]
-    expect(first.kind).toBe('activity')
-    if (first.kind !== 'activity') return
-    expect(first.start).toBe(1)
-    expect(first.end).toBe(4)
-    expect(first.steps).toHaveLength(2)
-    expect(first.steps[0].toolName).toBe('search_tools')
-    expect(first.steps[0].status).toBe('complete')
-    expect(first.steps[1].toolName).toBe('http_request')
-    expect(first.steps[1].result).toBe('body')
+    const activity = segs[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind !== 'activity') return
+    expect(activity.steps).toHaveLength(2)
+    expect(activity.notes).toHaveLength(1)
+    expect(activity.notes[0].text).toBe('checking next step')
+    expect(activity.coveredIndices).toContain(3)
+    expect(activity.coveredIndices).not.toContain(6)
   })
 
   it('marks unpaired call as running', () => {
@@ -101,6 +100,102 @@ describe('groupToolActivity', () => {
       status: 'complete',
       result: 'body',
     })
+  })
+
+  it('breaks fold on subtask_execution and keeps panel outside', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: { command: 'a' } },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: 'ok' },
+      {
+        type: 'subtask_execution',
+        tasks: [{ name: 't1', description: 'd' }],
+        events: [],
+        status: 'running',
+      },
+      { type: 'tool_call', toolName: 'read_file', toolArgs: { path: 'x' } },
+      { type: 'tool_result', toolName: 'read_file', toolResult: 'y' },
+    ]
+    const segs = groupToolActivity(messages)
+    expect(segs.map(s => s.kind)).toEqual(['activity', 'passthrough', 'activity'])
+    const mid = segs[1]
+    expect(mid.kind).toBe('passthrough')
+    if (mid.kind === 'passthrough') expect(mid.index).toBe(2)
+    if (segs[0].kind === 'activity') {
+      expect(segs[0].coveredIndices).not.toContain(2)
+    }
+  })
+
+  it('keeps approval and artifact outside the fold', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: { command: 'ls' } },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: 'ok' },
+      { type: 'approval', toolName: 'shell_command', options: ['Allow', 'Deny'] },
+      { type: 'tool_call', toolName: 'write_file', toolArgs: { path: 'a.md', content: 'x' } },
+      { type: 'tool_result', toolName: 'write_file', toolResult: { ok: true } },
+      { type: 'artifact', path: 'a.md', toolName: 'write_file' },
+    ]
+    const segs = groupToolActivity(messages)
+    expect(segs.map(s => s.kind)).toEqual([
+      'activity',
+      'passthrough', // approval
+      'activity',
+      'passthrough', // artifact
+    ])
+  })
+
+  it('breaks on browser_handoff', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'browser_request_human', toolArgs: {} },
+      {
+        type: 'browser_handoff',
+        vncProxyUrl: 'http://vnc',
+        pageUrl: 'http://app',
+        pageTitle: 'App',
+        reason: 'captcha',
+      },
+    ]
+    const segs = groupToolActivity(messages)
+    expect(segs.map(s => s.kind)).toEqual(['activity', 'passthrough'])
+  })
+
+  it('does not create activity for soft-only or text-only turns', () => {
+    expect(groupToolActivity([
+      { type: 'user', content: 'hi' },
+      { type: 'agent', content: 'hello' },
+    ]).every(s => s.kind === 'passthrough')).toBe(true)
+
+    expect(groupToolActivity([
+      { type: 'thinking', content: '…' },
+      { type: 'auto_approved', toolName: 'shell_command' },
+    ]).every(s => s.kind === 'passthrough')).toBe(true)
+  })
+
+  it('defaults unknown types to hard break', () => {
+    expect(isHardBreakType('brand_new_panel')).toBe(true)
+    expect(isSoftNoteType('brand_new_panel')).toBe(false)
+  })
+
+  it('absorbs trailing soft notes while streaming; keeps them passthrough when finished', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: { command: 'ls' } },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: 'ok' },
+      { type: 'agent', content: 'checking credentials next' },
+    ]
+
+    const finished = groupToolActivity(messages)
+    expect(finished.map(s => s.kind)).toEqual(['activity', 'passthrough'])
+    if (finished[0].kind === 'activity') {
+      expect(finished[0].coveredIndices).not.toContain(2)
+      expect(finished[0].notes).toHaveLength(0)
+    }
+
+    const live = groupToolActivity(messages, { absorbTrailingSoft: true })
+    expect(live.map(s => s.kind)).toEqual(['activity'])
+    if (live[0].kind !== 'activity') throw new Error('expected activity')
+    expect(live[0].coveredIndices).toContain(2)
+    expect(live[0].notes).toHaveLength(1)
+    expect(live[0].notes[0].text).toBe('checking credentials next')
+    expect(latestProcessText(live[0].notes)).toBe('checking credentials next')
   })
 
   it('marks error results', () => {
@@ -304,9 +399,25 @@ describe('buildActivityRenderIndex', () => {
       { type: 'tool_result', toolName: 'a', toolResult: {} },
       { type: 'agent', content: 'x' },
     ]
-    const { activityByStart, skipIndices } = buildActivityRenderIndex(messages)
+    const { activityByStart, skipIndices, lastActivityStart } = buildActivityRenderIndex(messages)
     expect(activityByStart.has(0)).toBe(true)
     expect(skipIndices.has(1)).toBe(true)
     expect(skipIndices.has(0)).toBe(false)
+    expect(skipIndices.has(2)).toBe(false)
+    expect(lastActivityStart).toBe(0)
+  })
+
+  it('skips trailing soft notes when absorbTrailingSoft is set', () => {
+    const messages: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'a', toolArgs: {} },
+      { type: 'tool_result', toolName: 'a', toolResult: {} },
+      { type: 'agent', content: 'provisional' },
+    ]
+    const { skipIndices, activityByStart } = buildActivityRenderIndex(messages, {
+      absorbTrailingSoft: true,
+    })
+    expect(skipIndices.has(2)).toBe(true)
+    const activity = activityByStart.get(0)
+    expect(activity?.notes.map(n => n.text)).toEqual(['provisional'])
   })
 })

--- a/web/src/components/chat/__tests__/toolActivity.test.ts
+++ b/web/src/components/chat/__tests__/toolActivity.test.ts
@@ -8,6 +8,8 @@ import {
   deriveLiveStreamStatus,
   extractPathHint,
   groupToolActivity,
+  hasAppFence,
+  isAppProgressAgent,
   isHardBreakType,
   isSoftNoteType,
   isToolResultError,
@@ -196,6 +198,43 @@ describe('groupToolActivity', () => {
     expect(live[0].notes).toHaveLength(1)
     expect(live[0].notes[0].text).toBe('checking credentials next')
     expect(latestProcessText(live[0].notes)).toBe('checking credentials next')
+  })
+
+  it('never absorbs astonish-app agent messages (AppCodeIndicator must stay visible)', () => {
+    const trailing: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'search_tools', toolArgs: {} },
+      { type: 'tool_result', toolName: 'search_tools', toolResult: {} },
+      {
+        type: 'agent',
+        content: 'Building it now.\n\n```astonish-app\nfunction App() { return <div/> }\n',
+        _streaming: true,
+      },
+    ]
+    const live = groupToolActivity(trailing, { absorbTrailingSoft: true })
+    expect(live.map(s => s.kind)).toEqual(['activity', 'passthrough'])
+    if (live[0].kind !== 'activity') throw new Error('expected activity')
+    expect(live[0].coveredIndices).not.toContain(2)
+    expect(live[0].notes).toHaveLength(0)
+    if (live[1].kind === 'passthrough') expect(live[1].index).toBe(2)
+
+    const between: ChatMsg[] = [
+      { type: 'tool_call', toolName: 'read_file', toolArgs: { path: 'a' } },
+      { type: 'tool_result', toolName: 'read_file', toolResult: 'x' },
+      {
+        type: 'agent',
+        content: '```astonish-app\nconst App = () => null\n```',
+      },
+      { type: 'tool_call', toolName: 'write_file', toolArgs: { path: 'b' } },
+      { type: 'tool_result', toolName: 'write_file', toolResult: { ok: true } },
+    ]
+    const mid = groupToolActivity(between, { absorbTrailingSoft: true })
+    expect(mid.filter(s => s.kind === 'activity')).toHaveLength(1)
+    const activity = mid.find(s => s.kind === 'activity')
+    if (!activity || activity.kind !== 'activity') throw new Error('expected activity')
+    expect(activity.coveredIndices).not.toContain(2)
+    expect(activity.notes).toHaveLength(0)
+    expect(isAppProgressAgent(between[2])).toBe(true)
+    expect(hasAppFence('plain text')).toBe(false)
   })
 
   it('marks error results', () => {

--- a/web/src/components/chat/toolActivity.ts
+++ b/web/src/components/chat/toolActivity.ts
@@ -180,6 +180,21 @@ export function isSoftNote(msg: ChatMsg): boolean {
   return isSoftNoteType(msg.type)
 }
 
+/** True when content hosts (or is streaming into) an astonish-app fence. */
+export function hasAppFence(content: string): boolean {
+  return /```astonish-app\b/.test(content)
+}
+
+/**
+ * Agent messages with an astonish-app fence must stay passthrough so
+ * AppCodeIndicator ("Generating app...") can render during streaming.
+ */
+export function isAppProgressAgent(msg: ChatMsg): boolean {
+  if (msg.type !== 'agent') return false
+  const content = typeof msg.content === 'string' ? msg.content : String(msg.content ?? '')
+  return hasAppFence(content)
+}
+
 function noteTextFromMessage(msg: ChatMsg): string {
   switch (msg.type) {
     case 'agent':
@@ -260,6 +275,8 @@ export function groupToolActivity(
     for (let j = runStart; j <= runEnd; j++) {
       const m = messages[j]
       if (!isSoftNote(m)) continue
+      // Keep astonish-app progress UI outside the fold (AppCodeIndicator).
+      if (isAppProgressAgent(m)) continue
       const absorb = j <= lastToolIndex || absorbTrailingSoft
       if (!absorb) continue
       const text = noteTextFromMessage(m).trim()
@@ -283,6 +300,7 @@ export function groupToolActivity(
     })
 
     // Emit passthrough for soft notes after last tool when not absorbed
+    // (includes astonish-app progress agents that must host AppCodeIndicator).
     for (let j = lastToolIndex + 1; j <= runEnd; j++) {
       if (!covered.has(j)) {
         segments.push({ kind: 'passthrough', index: j })

--- a/web/src/components/chat/toolActivity.ts
+++ b/web/src/components/chat/toolActivity.ts
@@ -11,9 +11,23 @@ export interface ToolActivityStep {
   resultIndex?: number
 }
 
+export interface ActivityNote {
+  index: number
+  kind: 'agent' | 'thinking' | 'auto_approved' | 'retry'
+  text: string
+}
+
 export type MessageSegment =
   | { kind: 'passthrough'; index: number }
-  | { kind: 'activity'; start: number; end: number; steps: ToolActivityStep[] }
+  | {
+      kind: 'activity'
+      start: number
+      end: number
+      steps: ToolActivityStep[]
+      notes: ActivityNote[]
+      /** Indices rendered by this block (tools + absorbed soft notes). */
+      coveredIndices: number[]
+    }
 
 export type ActivitySummaryVariant = 'running' | 'complete' | 'error'
 
@@ -105,7 +119,7 @@ function pairSteps(messages: ChatMsg[], start: number, end: number): ToolActivit
 
   for (let i = start; i <= end; i++) {
     const msg = messages[i]
-    if (!isToolMessage(msg)) break
+    if (!isToolMessage(msg)) continue
 
     if (msg.type === 'tool_call') {
       const name = toolNameOf(msg)
@@ -143,33 +157,155 @@ function pairSteps(messages: ChatMsg[], start: number, end: number): ToolActivit
   return steps
 }
 
+/** Soft notes that may be absorbed into an activity fold (allowlist). */
+export function isSoftNoteType(type: string): boolean {
+  return type === 'agent' || type === 'thinking' || type === 'auto_approved' || type === 'retry'
+}
+
 /**
- * Fold contiguous tool_call / tool_result messages into activity segments.
- * Non-tool messages remain passthrough by index.
+ * Hard breaks always passthrough and split folds.
+ * Unknown / future types default to hard break for safety.
  */
-export function groupToolActivity(messages: ChatMsg[]): MessageSegment[] {
+export function isHardBreakType(type: string): boolean {
+  if (type === 'tool_call' || type === 'tool_result') return false
+  if (isSoftNoteType(type)) return false
+  return true
+}
+
+export function isHardBreak(msg: ChatMsg): boolean {
+  return isHardBreakType(msg.type)
+}
+
+export function isSoftNote(msg: ChatMsg): boolean {
+  return isSoftNoteType(msg.type)
+}
+
+function noteTextFromMessage(msg: ChatMsg): string {
+  switch (msg.type) {
+    case 'agent':
+      return typeof msg.content === 'string' ? msg.content : String(msg.content ?? '')
+    case 'thinking':
+      return typeof msg.content === 'string' ? msg.content : String(msg.content ?? '')
+    case 'auto_approved':
+      return `Auto-approved ${String(msg.toolName ?? 'tool')}`
+    case 'retry':
+      return `Retry ${String(msg.attempt ?? '')}/${String(msg.maxRetries ?? '')}${msg.reason ? `: ${String(msg.reason)}` : ''}`
+    default:
+      return ''
+  }
+}
+
+function noteKindFromMessage(msg: ChatMsg): ActivityNote['kind'] {
+  if (msg.type === 'agent' || msg.type === 'thinking' || msg.type === 'auto_approved' || msg.type === 'retry') {
+    return msg.type
+  }
+  return 'agent'
+}
+
+export interface GroupToolActivityOptions {
+  /**
+   * When true (active stream), soft notes after the last tool are also absorbed
+   * as provisional process text so they never flash as Agent bubbles.
+   * When false (history / turn complete), those notes stay passthrough (final answer).
+   */
+  absorbTrailingSoft?: boolean
+}
+
+/**
+ * Fold tools + interstitial soft notes into activity segments.
+ * Hard-break types always passthrough and split folds.
+ * Agent text after the last tool stays passthrough unless absorbTrailingSoft.
+ */
+export function groupToolActivity(
+  messages: ChatMsg[],
+  opts: GroupToolActivityOptions = {},
+): MessageSegment[] {
+  const absorbTrailingSoft = opts.absorbTrailingSoft === true
   const segments: MessageSegment[] = []
   let i = 0
   while (i < messages.length) {
-    if (!isToolMessage(messages[i])) {
+    const msg = messages[i]
+    if (isHardBreak(msg)) {
       segments.push({ kind: 'passthrough', index: i })
       i += 1
       continue
     }
-    const start = i
-    while (i < messages.length && isToolMessage(messages[i])) {
+
+    // Collect contiguous soft notes + tools until a hard break.
+    const runStart = i
+    while (i < messages.length && !isHardBreak(messages[i])) {
       i += 1
     }
-    const end = i - 1
+    const runEnd = i - 1
+
+    const toolIndices: number[] = []
+    for (let j = runStart; j <= runEnd; j++) {
+      if (isToolMessage(messages[j])) toolIndices.push(j)
+    }
+
+    if (toolIndices.length === 0) {
+      // Soft-only run with no tools → all passthrough
+      for (let j = runStart; j <= runEnd; j++) {
+        segments.push({ kind: 'passthrough', index: j })
+      }
+      continue
+    }
+
+    const lastToolIndex = toolIndices[toolIndices.length - 1]
+    const notes: ActivityNote[] = []
+    const covered = new Set<number>()
+
+    for (const ti of toolIndices) covered.add(ti)
+
+    for (let j = runStart; j <= runEnd; j++) {
+      const m = messages[j]
+      if (!isSoftNote(m)) continue
+      const absorb = j <= lastToolIndex || absorbTrailingSoft
+      if (!absorb) continue
+      const text = noteTextFromMessage(m).trim()
+      if (text) {
+        notes.push({ index: j, kind: noteKindFromMessage(m), text })
+      }
+      covered.add(j)
+    }
+
+    const coveredIndices = [...covered].sort((a, b) => a - b)
+    const start = coveredIndices[0]
+    const end = lastToolIndex
+
     segments.push({
       kind: 'activity',
       start,
       end,
       steps: pairSteps(messages, start, end),
+      notes,
+      coveredIndices,
     })
+
+    // Emit passthrough for soft notes after last tool when not absorbed
+    for (let j = lastToolIndex + 1; j <= runEnd; j++) {
+      if (!covered.has(j)) {
+        segments.push({ kind: 'passthrough', index: j })
+      }
+    }
   }
   return segments
 }
+
+/** Latest agent/thinking note text for the always-visible process line. */
+export function latestProcessText(notes: ActivityNote[]): string {
+  for (let i = notes.length - 1; i >= 0; i--) {
+    const n = notes[i]
+    if ((n.kind === 'agent' || n.kind === 'thinking') && n.text.trim()) {
+      return n.text.trim()
+    }
+  }
+  return ''
+}
+
+/** @deprecated Alias — use groupToolActivity (now turn/work-segment aware). */
+export const groupTurnActivity = groupToolActivity
+
 
 export type ToolActivityCategory =
   | 'edit'
@@ -402,12 +538,15 @@ export function liveActivityHint(step: ToolActivityStep): string {
  * Status for the bottom streaming pill: live tool hint, or Thinking… when idle between tools.
  */
 export function deriveLiveStreamStatus(messages: ChatMsg[]): string {
-  const segs = groupToolActivity(messages)
+  // Streaming pill always absorbs trailing soft notes so coverage matches live UI.
+  const segs = groupToolActivity(messages, { absorbTrailingSoft: true })
+  if (messages.length === 0) return 'Thinking…'
+  const last = messages.length - 1
   for (let i = segs.length - 1; i >= 0; i--) {
     const seg = segs[i]
     if (seg.kind !== 'activity') continue
-    // Only mirror status when the activity is at the end of the transcript.
-    if (seg.end !== messages.length - 1) break
+    // Only mirror status when this activity covers the latest message.
+    if (!seg.coveredIndices.includes(last)) break
     const running = [...seg.steps].reverse().find(s => s.status === 'running')
     if (running) return liveActivityHint(running)
     break
@@ -525,7 +664,7 @@ export function activityStats(steps: ToolActivityStep[]): ActivityStats {
 /** Compact header copy for a tool activity block. */
 export function activitySummary(
   steps: ToolActivityStep[],
-  opts: { streaming?: boolean } = {},
+  opts: { streaming?: boolean; noteCount?: number } = {},
 ): ActivitySummary {
   if (steps.length === 0) {
     return withSplit('No tools', 'complete')
@@ -538,7 +677,10 @@ export function activitySummary(
     return withSplit(liveActivityHint(running), 'running')
   }
 
-  const body = buildCategorizedBody(steps)
+  let body = buildCategorizedBody(steps)
+  if (opts.noteCount && opts.noteCount > 0) {
+    body = `${body} · ${opts.noteCount} ${opts.noteCount === 1 ? 'note' : 'notes'}`
+  }
 
   if (failed.length > 0) {
     if (failed.length === 1) {
@@ -551,18 +693,24 @@ export function activitySummary(
 }
 
 /** Index lookup helpers for the StudioChat render loop. */
-export function buildActivityRenderIndex(messages: ChatMsg[]): {
+export function buildActivityRenderIndex(
+  messages: ChatMsg[],
+  opts: GroupToolActivityOptions = {},
+): {
   activityByStart: Map<number, Extract<MessageSegment, { kind: 'activity' }>>
   skipIndices: Set<number>
+  lastActivityStart: number
 } {
   const activityByStart = new Map<number, Extract<MessageSegment, { kind: 'activity' }>>()
   const skipIndices = new Set<number>()
-  for (const seg of groupToolActivity(messages)) {
+  let lastActivityStart = -1
+  for (const seg of groupToolActivity(messages, opts)) {
     if (seg.kind !== 'activity') continue
     activityByStart.set(seg.start, seg)
-    for (let i = seg.start + 1; i <= seg.end; i++) {
-      skipIndices.add(i)
+    if (seg.start > lastActivityStart) lastActivityStart = seg.start
+    for (const idx of seg.coveredIndices) {
+      if (idx !== seg.start) skipIndices.add(idx)
     }
   }
-  return { activityByStart, skipIndices }
+  return { activityByStart, skipIndices, lastActivityStart }
 }

--- a/web/src/test/scenarios/tool-execution.test.tsx
+++ b/web/src/test/scenarios/tool-execution.test.tsx
@@ -36,21 +36,36 @@ describe('Tool Execution Scenarios', () => {
 
       await result.sendMessage('Search for Go testing best practices')
 
-      // Initial text should be finalized
-      await waitFor(() => {
-        expect(screen.getByText(/Let me search for that/)).toBeInTheDocument()
-      }, { timeout: 5000 })
-
-      // Tool activity block should appear with a categorized summary
+      // Tool activity block should appear (interstitial "Let me search" is folded as process text)
       await waitFor(() => {
         expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
         const text = result.container.textContent || ''
-        expect(text).toMatch(/1 search|Searching|web_search/i)
+        expect(text).toMatch(/1 search|Searching|web_search|1 note/i)
       }, { timeout: 5000 })
 
-      // Final text should appear
+      // Dimmed process narration is visible without expanding
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="activity-process-text"]')?.textContent)
+          .toMatch(/Let me search for that/)
+      }, { timeout: 5000 })
+
+      // Final user-facing text should appear outside the fold as an Agent bubble
       await waitFor(() => {
         expect(screen.getByText(/best practices for Go testing/)).toBeInTheDocument()
+      }, { timeout: 5000 })
+
+      // Interstitial is not labeled as a separate Agent bubble — only the final answer is
+      const agentLabels = Array.from(result.container.querySelectorAll('div'))
+        .filter(el => el.children.length === 0 && el.textContent === 'Agent')
+      expect(agentLabels.length).toBe(1)
+
+      // Expand to confirm interstitial note was preserved in notes list
+      const activityBtn = result.container.querySelector(
+        '[data-testid="tool-activity-block"] > button',
+      ) as HTMLElement
+      await result.user.click(activityBtn)
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-notes')).toBeInTheDocument()
       }, { timeout: 5000 })
     })
   })
@@ -99,15 +114,15 @@ describe('Tool Execution Scenarios', () => {
 
       await result.sendMessage('Search for something')
 
-      // The text "Let me search for that information." should be a separate,
-      // finalized agent message (not lost when tool_call arrives)
-      await waitFor(() => {
-        expect(screen.getByText(/Let me search for that/)).toBeInTheDocument()
-      }, { timeout: 5000 })
-
-      // And the final text should also appear as a separate message
+      // Final answer remains a visible Agent bubble after the fold
       await waitFor(() => {
         expect(screen.getByText(/best practices for Go testing/)).toBeInTheDocument()
+      }, { timeout: 5000 })
+
+      // Pre-tool narration is visible as dimmed process text (not lost / not a second Agent bubble)
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="activity-process-text"]')?.textContent)
+          .toMatch(/Let me search for that/)
       }, { timeout: 5000 })
     })
   })
@@ -120,7 +135,16 @@ describe('Tool Execution Scenarios', () => {
 
       await result.sendMessage('Run a command')
 
-      // Auto-approved badge should show the tool name somewhere
+      // Activity fold absorbs auto_approved as a note; expand to see tool name
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="tool-activity-block"]')).toBeTruthy()
+      }, { timeout: 5000 })
+
+      const activityBtn = result.container.querySelector(
+        '[data-testid="tool-activity-block"] > button',
+      ) as HTMLElement
+      await result.user.click(activityBtn)
+
       await waitFor(() => {
         const text = result.container.textContent || ''
         expect(text).toContain('shell_command')


### PR DESCRIPTION
## Summary
- Fold tools + interstitial soft notes into work-segment `ToolActivityBlock`s with hard breaks for panels, approvals, harness, artifacts, and other interactive surfaces
- While streaming, absorb trailing agent text as provisional dimmed process narration so it never flashes as an Agent bubble; after the stream ends, trailing agent text becomes the final Agent bubble
- Document the work-segment fold / provisional process rule and cover it with unit + scenario tests

## Test plan
- [ ] `cd web && npm test`
- [ ] OpenStack-style tool + mid-loop narration chain shows one activity line with dimmed process text, then one final Agent answer
- [ ] Confirm no Agent-bubble flash for interstitial text between tools during a live stream
- [ ] `delegate_tasks` / TaskPlanPanel, PlanPanel, Fleet panels, approvals, browser handoff, artifacts, and report placeholders still render outside the fold
- [ ] Pure text turns (no tools) unchanged; report three-signal gate unchanged