### PR TITLE
Add raw content credentials for fleet file injection

### DIFF
--- a/cmd/astonish/credential.go
+++ b/cmd/astonish/credential.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/charmbracelet/huh"
 	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/credentials"
+	"github.com/charmbracelet/huh"
 )
 
 // printSecretField writes a labeled credential field to stdout.
@@ -96,7 +96,7 @@ func handleCredentialList() error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 
 	if len(creds) > 0 {
-		fmt.Println("HTTP Credentials:")
+		fmt.Println("Credentials:")
 		fmt.Fprintf(w, "  NAME\tTYPE\n")
 		fmt.Fprintf(w, "  ----\t----\n")
 		for name, credType := range creds {
@@ -114,7 +114,7 @@ func handleCredentialList() error {
 		fmt.Println()
 	}
 
-	fmt.Printf("%d HTTP credential(s), %d secret(s)\n", len(creds), len(secrets))
+	fmt.Printf("%d credential(s), %d secret(s)\n", len(creds), len(secrets))
 	return nil
 }
 
@@ -157,6 +157,7 @@ func handleCredentialAdd(name string) error {
 					huh.NewOption("OAuth Client Credentials (auto token refresh)", "oauth_client_credentials"),
 					huh.NewOption("OAuth Authorization Code (user-authorized, with refresh token)", "oauth_authorization_code"),
 					huh.NewOption("OpenStack Keystone (auto X-Auth-Token)", "openstack_keystone"),
+					huh.NewOption("Raw Content (JSON/YAML/text file payload)", "raw_content"),
 				).
 				Value(&credType),
 		),
@@ -182,6 +183,8 @@ func handleCredentialAdd(name string) error {
 		cred, err = collectOAuthAuthCodeCred()
 	case credentials.CredOpenStackKeystone:
 		cred, err = collectKeystoneCred()
+	case credentials.CredRawContent:
+		cred, err = collectRawContentCred()
 	default:
 		return fmt.Errorf("unknown credential type: %s", credType)
 	}
@@ -203,7 +206,7 @@ func handleCredentialRemove(name string) error {
 		return err
 	}
 
-	// Try HTTP credentials first
+	// Try named credentials first
 	if store.Get(name) != nil {
 		if err := store.Remove(name); err != nil {
 			return fmt.Errorf("failed to remove: %w", err)
@@ -281,6 +284,10 @@ func handleCredentialTest(name string) error {
 	case credentials.CredPassword:
 		fmt.Printf("Credential %q configured (password, user: %s)\n", name, cred.Username)
 		fmt.Println("Use resolve_credential in chat to retrieve username/password for SSH/FTP/database connections.")
+
+	case credentials.CredRawContent:
+		fmt.Printf("Credential %q configured (raw_content, %d bytes)\n", name, len(cred.Content))
+		fmt.Println("Use resolve_credential field content or fleet credential_injection field content.")
 
 	default:
 		fmt.Printf("Credential %q configured (type: %s)\n", name, cred.Type)
@@ -521,6 +528,36 @@ func collectOAuthAuthCodeCred() (*credentials.Credential, error) {
 	}, nil
 }
 
+func collectRawContentCred() (*credentials.Credential, error) {
+	contentType := "text/plain"
+	content := ""
+
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Content type (optional)").
+				Description("e.g., text/plain, application/json, application/yaml, text/x-dotenv").
+				Value(&contentType),
+			huh.NewText().
+				Title("Raw content").
+				Description("Paste the exact JSON, YAML, dotenv, or text content to store encrypted.").
+				Value(&content),
+		),
+	).Run()
+	if err != nil {
+		return nil, err
+	}
+	if content == "" {
+		return nil, fmt.Errorf("content is required")
+	}
+
+	return &credentials.Credential{
+		Type:        credentials.CredRawContent,
+		Content:     content,
+		ContentType: contentType,
+	}, nil
+}
+
 func collectKeystoneCred() (*credentials.Credential, error) {
 	var method string
 	err := huh.NewForm(
@@ -655,7 +692,7 @@ func handleCredentialShow(name string) error {
 		}
 	}
 
-	// Try HTTP credential first
+	// Try named credential first
 	cred := store.Get(name)
 	if cred != nil {
 		fmt.Printf("Credential: %s\n", name)
@@ -688,6 +725,11 @@ func handleCredentialShow(name string) error {
 			if cred.Scope != "" {
 				fmt.Printf("Scope:         %s\n", cred.Scope)
 			}
+		case credentials.CredRawContent:
+			if cred.ContentType != "" {
+				fmt.Printf("Content Type:  %s\n", cred.ContentType)
+			}
+			printSecretField("Content:\n", cred.Content)
 		case credentials.CredOpenStackKeystone:
 			fmt.Printf("Auth URL:      %s\n", cred.AuthURL)
 			if cred.ApplicationCredentialID != "" {

--- a/docs/architecture/credentials.md
+++ b/docs/architecture/credentials.md
@@ -106,8 +106,9 @@ Minimum signature length is 8 characters to avoid false positives with short val
 | `oauth_client_credentials` | Machine-to-machine OAuth2 | `client_secret` | `client_id`, `auth_url`, `scope` |
 | `oauth_authorization_code` | User-consent OAuth2 (Google, GitHub) | `client_secret`, `access_token`, `refresh_token` | `client_id`, `token_url`, `scope` |
 | `openstack_keystone` | OpenStack Keystone v3 | `password` or `application_credential_secret` | `auth_url`, `username` / `application_credential_id`, project/domain fields |
+| `raw_content` | Arbitrary JSON/YAML/dotenv/text payloads for sandbox file materialization | `content` | `content_type` |
 
-Non-secret fields are returned as plaintext because the LLM needs them for decision-making (e.g., knowing which header name to use, which auth URL to call).
+Non-secret fields are returned as plaintext because the LLM needs them for decision-making (e.g., knowing which header name to use, which auth URL to call). `raw_content` is intentionally not an HTTP credential: `Resolve()` rejects it, and fleet/drill file injection should reference `field: content`. The `content` value is not normalized or trimmed because exact file bytes, whitespace, and trailing punctuation can be meaningful.
 
 ### OAuth Token Management
 
@@ -203,5 +204,5 @@ Do **not** publish a personal OAuth/API credential to the team just to schedule 
 - **Tools**: `resolve_credential` returns placeholders. `http_request` accepts credential names and resolves internally. `save_credential` triggers retroactive redaction.
 - **API/SSE**: The SSE streaming handler applies Redactor to all text events before sending to the browser.
 - **Channels**: Telegram and email adapters receive already-redacted text.
-- **Sandbox**: Credential resolution happens on the host side (in callbacks), before tool args reach the container. Raw secrets are never stored in container state.
+- **Sandbox**: Credential resolution happens on the host side (in callbacks), before tool args reach the container. Raw secrets are never stored in container state. Fleet/drill file injection uses the same store for `raw_content` credentials and materializes the `content` field into the sandbox only when the run starts.
 - **Scheduler**: Personal jobs use merged credentials; team jobs and fleet use team-only. See daemon-scheduler.md.

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -187,6 +187,6 @@ The fleet plan wizard (700+ line system prompt) guides users through configuring
 - **Sandbox**: Each fleet agent gets its own sandbox container with a workspace. Tools are sandbox-wrapped per-agent.
 - **Channels**: Chat channel for Studio UI; GitHub Issues channel for automated workflows.
 - **Scheduler**: PlanActivator creates scheduler jobs for GitHub issue polling.
-- **Credentials**: Fleet plans declare required credentials, resolved from the encrypted store.
+- **Credentials**: Fleet plans declare required credentials, resolved from the encrypted store. Environment injection uses type-specific fields such as `token` or `password`; file injection should use `raw_content` credentials with `field: content` for JSON/YAML/dotenv/text payloads. Older plans that stored file payloads as `api_key.value` continue to work for compatibility.
 - **Memory**: Agent context uses memory-scoped messages, not the general memory store.
 - **API/Studio**: Fleet view in Studio shows session status, message stream, and controls.

--- a/docs/website/docs/security/credential-security.md
+++ b/docs/website/docs/security/credential-security.md
@@ -21,6 +21,10 @@ Credentials are stored encrypted using [envelope encryption](./envelope-encrypti
 | `password` | Username + password for SSH, FTP, SMTP, databases |
 | `oauth_client_credentials` | OAuth2 client credentials with automatic token refresh |
 | `oauth_authorization_code` | User-authorized OAuth2 with refresh token |
+| `openstack_keystone` | OpenStack Keystone v3 token authentication |
+| `raw_content` | Encrypted JSON, YAML, dotenv, or text payload for sandbox file injection; not HTTP auth |
+
+Use `raw_content` when a fleet or drill needs to materialize a configuration file in the sandbox at run time. The content stays encrypted in the credential store and is injected as `field: content` only when needed.
 
 ## Output Redaction
 
@@ -42,9 +46,9 @@ When an agent invokes a tool that requires credentials:
 
 1. The credential is resolved (personal-first, team fallback).
 2. The encrypted ciphertext is decrypted in memory using the org's DEK.
-3. The plaintext is injected as an **environment variable** into the sandbox container.
-4. The tool reads the credential from its environment.
-5. After execution, the environment is destroyed with the container.
+3. The plaintext is injected as an **environment variable** or, for `raw_content`, materialized as a sandbox file requested by the fleet/drill configuration.
+4. The tool reads the credential from its environment or file path.
+5. After execution, the environment/container state is destroyed.
 
 At no point does the LLM see the credential value. The model only knows that a credential named (e.g.) `GITHUB_TOKEN` is available — never its contents.
 

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -1078,6 +1078,12 @@ func StudioChatHandler(w http.ResponseWriter, r *http.Request) {
 		runner.InjectFleetStores(svc.FleetTemplates, svc.FleetPlans)
 	}
 
+	// Inject setup stores, including API fallback stores when DB-backed stores
+	// are unavailable, so setup tools update the same drafts created by handlers.
+	if svc := store.FromRequest(r); svc != nil {
+		runner.InjectFleetSetupStores(getSetupProfileStore(svc), getSetupDraftStore(svc))
+	}
+
 	// Inject the team's custom sandbox template so that chat containers use
 	// the team's pre-configured image rather than always falling back to @base.
 	if svc := store.FromRequest(r); svc != nil && svc.Settings != nil {

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -289,6 +289,18 @@ func (cr *ChatRunner) InjectFleetStores(templates store.FleetTemplateStore, plan
 	}
 }
 
+// InjectFleetSetupStores adds tenant-scoped fleet setup stores to the runner's
+// context so setup tools can update the same drafts created by the Studio API.
+// Must be called before Run().
+func (cr *ChatRunner) InjectFleetSetupStores(profiles store.FleetSetupProfileStore, drafts store.FleetSetupDraftStore) {
+	if profiles != nil {
+		cr.ctx = store.WithFleetSetupProfileStore(cr.ctx, profiles)
+	}
+	if drafts != nil {
+		cr.ctx = store.WithFleetSetupDraftStore(cr.ctx, drafts)
+	}
+}
+
 // InjectSandboxTemplate adds the team's custom sandbox template name to the
 // runner's context. NodeTool reads this at container creation time so that chat
 // sessions use the team's pre-configured container image rather than @base.

--- a/pkg/api/credentials_handlers.go
+++ b/pkg/api/credentials_handlers.go
@@ -6,18 +6,18 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/gorilla/mux"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/gorilla/mux"
 )
 
 // --- Credential API types ---
 
 // credentialListItem represents a single credential in the list response.
 type credentialListItem struct {
-	Name     string              `json:"name"`
+	Name     string               `json:"name"`
 	Type     store.CredentialType `json:"type"`
-	Scope    string              `json:"scope,omitempty"`    // "personal" or "team" (platform mode only)
-	Shadowed bool                `json:"shadowed,omitempty"` // true if personal overrides this team credential
+	Scope    string               `json:"scope,omitempty"`    // "personal" or "team" (platform mode only)
+	Shadowed bool                 `json:"shadowed,omitempty"` // true if personal overrides this team credential
 }
 
 // credentialListResponse is the response for GET /api/credentials.
@@ -58,6 +58,8 @@ type credentialDetailResponse struct {
 	ProjectDomain               string               `json:"project_domain,omitempty"`
 	ApplicationCredentialID     string               `json:"application_credential_id,omitempty"`
 	ApplicationCredentialSecret string               `json:"application_credential_secret,omitempty"`
+	Content                     string               `json:"content,omitempty"`
+	ContentType                 string               `json:"content_type,omitempty"`
 }
 
 // credentialSaveRequest is the body for POST /api/credentials.
@@ -291,6 +293,8 @@ func GetCredentialHandler(w http.ResponseWriter, r *http.Request) {
 		ProjectDomain:               cred.ProjectDomain,
 		ApplicationCredentialID:     cred.ApplicationCredentialID,
 		ApplicationCredentialSecret: cred.ApplicationCredentialSecret,
+		Content:                     cred.Content,
+		ContentType:                 cred.ContentType,
 	}
 
 	respondJSON(w, http.StatusOK, resp)

--- a/pkg/api/fleet_setup_context_test.go
+++ b/pkg/api/fleet_setup_context_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/SAP/astonish/pkg/store"
+)
+
+func TestChatRunnerInjectFleetSetupStores(t *testing.T) {
+	runner := newChatRunner("session-setup", studioChatUserID, true)
+	profileStore := getSetupProfileStore(&store.Services{})
+	draftStore := getSetupDraftStore(&store.Services{})
+
+	runner.InjectFleetSetupStores(profileStore, draftStore)
+
+	if got := store.FleetSetupProfileStoreFromContext(runner.ctx); got == nil {
+		t.Fatal("expected setup profile store in runner context")
+	}
+	if got := store.FleetSetupDraftStoreFromContext(runner.ctx); got == nil {
+		t.Fatal("expected setup draft store in runner context")
+	}
+}

--- a/pkg/credentials/redact.go
+++ b/pkg/credentials/redact.go
@@ -220,6 +220,8 @@ func (r *Redactor) addSecretFieldsLocked(name string, cred *Credential) {
 			r.addVariantsLocked(name, "password", cred.Password)
 			r.addVariantsLocked(name, "username", cred.Username)
 		}
+	case CredRawContent:
+		r.addVariantsLocked(name, "content", cred.Content)
 	}
 }
 

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -51,6 +51,11 @@ const (
 	// (password or application_credential) and produces X-Auth-Token: <token>.
 	// Resolve() auto-fetches and caches tokens until near expiry.
 	CredOpenStackKeystone CredentialType = "openstack_keystone"
+
+	// CredRawContent stores arbitrary encrypted file content for sandbox
+	// materialization. It is not an HTTP credential; use the content field via
+	// resolve_credential or fleet credential_injection files.
+	CredRawContent CredentialType = "raw_content"
 )
 
 // Credential holds authentication data for a single named credential.
@@ -87,6 +92,10 @@ type Credential struct {
 	ProjectDomain               string `json:"project_domain,omitempty"`
 	ApplicationCredentialID     string `json:"application_credential_id,omitempty"`
 	ApplicationCredentialSecret string `json:"application_credential_secret,omitempty"`
+
+	// raw_content fields
+	Content     string `json:"content,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 // storeData is the JSON structure inside the encrypted file.
@@ -207,7 +216,9 @@ func sanitizeCredential(cred *Credential) {
 	cred.TokenURL = cleanFieldValue(cred.TokenURL)
 	cred.AccessToken = cleanFieldValue(cred.AccessToken)
 	cred.RefreshToken = cleanFieldValue(cred.RefreshToken)
-	// Note: TokenExpiry is an RFC3339 timestamp, skip sanitization
+	cred.ContentType = cleanFieldValue(cred.ContentType)
+	// Note: TokenExpiry is an RFC3339 timestamp, skip sanitization.
+	// Note: Content is arbitrary file payload and must remain byte-for-byte intact.
 }
 
 // sanitizeSecretValue strips common copy-paste artifacts from a secret value.
@@ -352,6 +363,9 @@ func (s *Store) Resolve(name string) (headerKey, headerValue string, err error) 
 
 	case CredPassword:
 		return "", "", fmt.Errorf("credential %q is a password credential (for SSH/FTP/etc.), not an HTTP credential — use resolve_credential to access its fields", name)
+
+	case CredRawContent:
+		return "", "", fmt.Errorf("credential %q is raw content for file materialization, not an HTTP credential — use resolve_credential to access its content field", name)
 
 	case CredOAuthAuthCode:
 		token, err := s.resolveAuthCode(name, &credCopy)

--- a/pkg/credentials/store_adapter.go
+++ b/pkg/credentials/store_adapter.go
@@ -66,6 +66,8 @@ func storeCredToInternal(sc *store.Credential) *Credential {
 		ProjectDomain:               sc.ProjectDomain,
 		ApplicationCredentialID:     sc.ApplicationCredentialID,
 		ApplicationCredentialSecret: sc.ApplicationCredentialSecret,
+		Content:                     sc.Content,
+		ContentType:                 sc.ContentType,
 	}
 }
 

--- a/pkg/credentials/store_test.go
+++ b/pkg/credentials/store_test.go
@@ -427,6 +427,53 @@ func TestStoreEncryptedOnDisk(t *testing.T) {
 	}
 }
 
+func TestStoreRawContentRoundTripPreservesFormatting(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	content := "  {\n  \"token\": \"abc12345\",\n  \"trailing\": \"keep ,;\"\n}\n  "
+	if err := store.Set("providers-file", &Credential{
+		Type:        CredRawContent,
+		Content:     content,
+		ContentType: " application/json ",
+	}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got := store.Get("providers-file")
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Type != CredRawContent {
+		t.Fatalf("Type = %q, want %q", got.Type, CredRawContent)
+	}
+	if got.Content != content {
+		t.Fatalf("Content was sanitized or changed: got %q want %q", got.Content, content)
+	}
+	if got.ContentType != "application/json" {
+		t.Fatalf("ContentType = %q, want application/json", got.ContentType)
+	}
+}
+
+func TestStoreResolveRawContentRejectedForHTTP(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := Open(dir)
+	if err := store.Set("config-file", &Credential{Type: CredRawContent, Content: "secret-content-12345"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	_, _, err := store.Resolve("config-file")
+	if err == nil {
+		t.Fatal("expected Resolve to reject raw_content")
+	}
+	if !strings.Contains(err.Error(), "raw content") {
+		t.Fatalf("Resolve error = %v, want raw content message", err)
+	}
+}
+
 func TestStoreResolveAPIKey(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := Open(dir)
@@ -1316,14 +1363,14 @@ func TestSanitizeCredential(t *testing.T) {
 		{
 			name: "surrounding single quotes",
 			input: &Credential{
-				Type:  CredAPIKey,
+				Type:   CredAPIKey,
 				Header: "X-API-Key",
-				Value: `'my-api-key'`,
+				Value:  `'my-api-key'`,
 			},
 			expected: &Credential{
-				Type:  CredAPIKey,
+				Type:   CredAPIKey,
 				Header: "X-API-Key",
-				Value: "my-api-key",
+				Value:  "my-api-key",
 			},
 		},
 		{

--- a/pkg/credentials/substitute.go
+++ b/pkg/credentials/substitute.go
@@ -454,6 +454,14 @@ func resolveField(resolver CredentialResolver, name, field, fallback string) str
 		if cred.AuthURL != "" {
 			return cred.AuthURL
 		}
+	case "content":
+		if cred.Content != "" {
+			return cred.Content
+		}
+	case "content_type":
+		if cred.ContentType != "" {
+			return cred.ContentType
+		}
 	}
 
 	return fallback

--- a/pkg/credentials/substitute_test.go
+++ b/pkg/credentials/substitute_test.go
@@ -76,6 +76,27 @@ func TestSubstituteMap_NoPlaceholders(t *testing.T) {
 	}
 }
 
+type testCredentialResolver struct {
+	creds map[string]*Credential
+}
+
+func (r *testCredentialResolver) Get(name string) *Credential            { return r.creds[name] }
+func (r *testCredentialResolver) Resolve(string) (string, string, error) { return "", "", nil }
+func (r *testCredentialResolver) Reload() error                          { return nil }
+
+func TestSubstitutePlaceholders_RawContent(t *testing.T) {
+	content := "providers:\n  alpaca:\n    key: abc12345\n"
+	resolver := &testCredentialResolver{creds: map[string]*Credential{
+		"providers-file": {Type: CredRawContent, Content: content},
+	}}
+
+	got := SubstitutePlaceholders("file={{CREDENTIAL:providers-file:content}}", resolver)
+	want := "file=" + content
+	if got != want {
+		t.Fatalf("SubstitutePlaceholders = %q, want %q", got, want)
+	}
+}
+
 func TestResolveField_UnknownCredential(t *testing.T) {
 	// resolveField with unknown credential should return fallback
 	fallback := "{{CREDENTIAL:nonexistent:password}}"

--- a/pkg/fleet/bundled/setup-profiles/software-development.yaml
+++ b/pkg/fleet/bundled/setup-profiles/software-development.yaml
@@ -137,14 +137,14 @@ steps:
     \ env vars and/or files into\n   the sandbox at session start — secrets are NEVER baked into templates.\n\n\
     **Sub-steps:**\n\n**2a. Check for existing credentials.**\nCall `list_credentials` to see what's already in the credential\
     \ store.\n\n**2b. Collect and save credentials.**\nFor each required integration:\n- Ask the user for the secret value.\n\
-    - Use `save_credential` to store it (bearer for tokens; api_key with field\n  `value` for YAML/JSON config file contents).\n\
+    - Use `save_credential` to store it (bearer for tokens; raw_content with field\n  `content` for YAML/JSON/dotenv/text file contents).\n\
     - Record the mapping: logical name → store entry name.\n\nFor GitHub (github_issues or private repos):\n- PAT with `repo`\
     \ scope; logical name `github`.\n- Validate: `test_credential` or `GH_TOKEN=... gh auth status`.\n\nFor config-file apps\
-    \ (e.g., trading providers YAML):\n- Save full file content as api_key type, logical name e.g. `trading`.\n- Declare file\
+    \ (e.g., trading providers YAML):\n- Save full file content as raw_content type, logical name e.g. `trading`.\n- Declare file\
     \ injection in `credential_injection` (see 2c).\n\n**2c. Wire credential_injection.**\nCall `update_setup_draft` with\
     \ a `credential_injection` object describing how\nsecrets reach the container at session start:\n\n```yaml\ncredential_injection:\n\
     \  env:\n    - credential: github\n      var: GH_TOKEN\n      field: token\n  files:\n    - credential: trading\n\
-    \      path: /root/<app>/config/credentials.yaml\n      field: value\n      format: yaml\n      mode: \"0600\"\n```\n\n\
+    \      path: /root/<app>/config/credentials.yaml\n      field: content\n      format: yaml\n      mode: \"0600\"\n```\n\n\
     GitHub-only plans: if you omit `credential_injection`, Fleet defaults to\nGH_TOKEN from the `github` credential.\n\n\
     **2d. Persist mappings in the draft.**\nUse `update_setup_draft` step_id=credentials with:\n- github: <store-name> (when\
     \ applicable)\n- any other logical names as additional fields\n- credential_injection: { env: [...], files: [...] }\n\n\

--- a/pkg/fleet/bundled_test.go
+++ b/pkg/fleet/bundled_test.go
@@ -1,6 +1,9 @@
 package fleet
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsBundledKey(t *testing.T) {
 	t.Parallel()
@@ -17,5 +20,45 @@ func TestBundledKeys(t *testing.T) {
 	keys := BundledKeys()
 	if _, ok := keys["software-dev"]; !ok {
 		t.Fatal("BundledKeys missing software-dev")
+	}
+}
+
+func TestSoftwareDevelopmentSetupProfileUsesRawContentForFileCredentials(t *testing.T) {
+	t.Parallel()
+
+	profile, ok := GetBundledSetupProfile("software-development")
+	if !ok {
+		t.Fatal("missing software-development setup profile")
+	}
+
+	var credentialsPrompt string
+	for _, step := range profile.Steps {
+		if step.ID == "credentials" {
+			credentialsPrompt = step.Prompt
+			break
+		}
+	}
+	if credentialsPrompt == "" {
+		t.Fatal("software-development setup profile missing credentials step prompt")
+	}
+
+	for _, want := range []string{
+		"raw_content with field\n  `content` for YAML/JSON/dotenv/text file contents",
+		"Save full file content as raw_content type",
+		"field: content",
+	} {
+		if !strings.Contains(credentialsPrompt, want) {
+			t.Fatalf("credentials prompt missing %q\n\nPrompt:\n%s", want, credentialsPrompt)
+		}
+	}
+
+	for _, old := range []string{
+		"api_key with field\n  `value` for YAML/JSON config file contents",
+		"Save full file content as api_key type",
+		"field: value",
+	} {
+		if strings.Contains(credentialsPrompt, old) {
+			t.Fatalf("credentials prompt still contains old api_key file guidance %q\n\nPrompt:\n%s", old, credentialsPrompt)
+		}
 	}
 }

--- a/pkg/fleet/credential_injection.go
+++ b/pkg/fleet/credential_injection.go
@@ -343,6 +343,10 @@ func extractCredentialField(ctx context.Context, cs store.CredentialStore, store
 			if resolved.Username != "" {
 				return resolved.Username, nil
 			}
+		case "content":
+			if resolved.Content != "" {
+				return resolved.Content, nil
+			}
 		}
 	}
 	return "", fmt.Errorf("credential %q field %q not found", storeName, field)

--- a/pkg/fleet/credential_injection_test.go
+++ b/pkg/fleet/credential_injection_test.go
@@ -34,15 +34,15 @@ func (m *memCredStore) Count(_ context.Context) int { return len(m.creds) }
 func (m *memCredStore) Resolve(_ context.Context, name string) (string, string, error) {
 	return store.ResolveCredentialHeader(name, m.Get(context.Background(), name), nil)
 }
-func (m *memCredStore) InvalidateToken(_ context.Context, _ string) {}
-func (m *memCredStore) SetSecret(_ context.Context, _, _ string) error { return nil }
+func (m *memCredStore) InvalidateToken(_ context.Context, _ string)                 {}
+func (m *memCredStore) SetSecret(_ context.Context, _, _ string) error              { return nil }
 func (m *memCredStore) SetSecretBatch(_ context.Context, _ map[string]string) error { return nil }
-func (m *memCredStore) GetSecret(_ context.Context, _ string) string { return "" }
-func (m *memCredStore) RemoveSecret(_ context.Context, _ string) error { return nil }
-func (m *memCredStore) HasSecrets(_ context.Context) bool { return false }
-func (m *memCredStore) SecretCount(_ context.Context) int { return 0 }
-func (m *memCredStore) ListSecrets(_ context.Context) []string { return nil }
-func (m *memCredStore) Reload(_ context.Context) error { return nil }
+func (m *memCredStore) GetSecret(_ context.Context, _ string) string                { return "" }
+func (m *memCredStore) RemoveSecret(_ context.Context, _ string) error              { return nil }
+func (m *memCredStore) HasSecrets(_ context.Context) bool                           { return false }
+func (m *memCredStore) SecretCount(_ context.Context) int                           { return 0 }
+func (m *memCredStore) ListSecrets(_ context.Context) []string                      { return nil }
+func (m *memCredStore) Reload(_ context.Context) error                              { return nil }
 
 func TestPlanBoundCredentialStore_Allowlist(t *testing.T) {
 	inner := &memCredStore{creds: map[string]*store.Credential{
@@ -129,6 +129,35 @@ func TestBuildInjectionEnv_FileField(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = credentials.ResolveField(credentials.NewStoreAdapter(cs), "juicytrade-providers", "value")
+}
+
+func TestBuildInjectionEnv_RawContentField(t *testing.T) {
+	yamlContent := "providers:\n  alpaca:\n    key: raw-secret-12345\n"
+	plan := &FleetPlan{
+		Key: "p1",
+		Credentials: map[string]string{
+			"providers": "providers-file",
+		},
+		CredentialInjection: &CredentialInjection{
+			Files: []FileInjection{
+				{Credential: "providers", Path: "/root/app/config/providers.yaml", Field: "content", Format: "yaml"},
+			},
+		},
+	}
+	cs := &memCredStore{creds: map[string]*store.Credential{
+		"providers-file": {Type: store.CredRawContent, Content: yamlContent, ContentType: "application/yaml"},
+	}}
+	resolved, err := ResolveCredentialsPlatform(context.Background(), plan, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved["providers"].Content != yamlContent {
+		t.Fatalf("resolved content mismatch")
+	}
+	val, err := extractCredentialField(context.Background(), cs, "providers-file", "content", resolved["providers"])
+	if err != nil || val != yamlContent {
+		t.Fatalf("extract content: %v %q", err, val)
+	}
 }
 
 func TestValidateFileInjectionPaths_RejectsRelative(t *testing.T) {

--- a/pkg/fleet/credentials.go
+++ b/pkg/fleet/credentials.go
@@ -26,6 +26,8 @@ type ResolvedCredential struct {
 	Username string
 	// Password holds the password for basic/password credentials.
 	Password string
+	// Content holds arbitrary raw content for file materialization credentials.
+	Content string
 }
 
 // ResolveCredentials resolves all credential references in a fleet plan from the
@@ -132,6 +134,8 @@ func resolveOne(credStore *credentials.Store, logicalName, storeName string) *Re
 			if rc.Token == "" {
 				rc.Token = cred.Token
 			}
+		case credentials.CredRawContent:
+			rc.Content = cred.Content
 		}
 
 		return rc
@@ -180,6 +184,8 @@ func resolveOnePlatform(ctx context.Context, cs store.CredentialStore, logicalNa
 			if rc.Token == "" {
 				rc.Token = cred.Token
 			}
+		case store.CredRawContent:
+			rc.Content = cred.Content
 		}
 
 		return rc

--- a/pkg/fleet/setup_engine.go
+++ b/pkg/fleet/setup_engine.go
@@ -82,7 +82,7 @@ func (e *SetupEngine) ValidateStep(profile *SetupProfile, stepID string, collect
 				return nil
 			}
 		}
-		return fmt.Errorf("step %q: acknowledge before continuing", stepID)
+		return fmt.Errorf("step %q: acknowledge before continuing with values {\"_ack\": true}", stepID)
 	}
 	if step.EffectiveType() == "review" {
 		return nil
@@ -143,11 +143,11 @@ func (e *SetupEngine) BuildPlanArgs(profile *SetupProfile, templateKey string, c
 	}
 
 	build := &SetupPlanBuild{
-		BaseFleetKey:    templateKey,
-		SetupProfileKey: profile.Key,
-		ChannelConfig:   map[string]any{},
-		Artifacts:       map[string]PlanArtifactConfig{},
-		Credentials:     map[string]string{},
+		BaseFleetKey:      templateKey,
+		SetupProfileKey:   profile.Key,
+		ChannelConfig:     map[string]any{},
+		Artifacts:         map[string]PlanArtifactConfig{},
+		Credentials:       map[string]string{},
 		BehaviorOverrides: map[string]string{},
 	}
 

--- a/pkg/fleet/setup_engine_test.go
+++ b/pkg/fleet/setup_engine_test.go
@@ -161,6 +161,24 @@ func TestSetupEngine_CurrentStep_SoftwareDevelopment(t *testing.T) {
 	if !strings.Contains(prompt, "Overview") && !strings.Contains(prompt, "Communication channel") {
 		t.Fatalf("prompt should focus on early steps, got head: %s", prompt[:min(250, len(prompt))])
 	}
+	if !strings.Contains(prompt, `"_ack": true`) {
+		t.Fatalf("overview prompt should document info-step acknowledgement payload, got head: %s", prompt[:min(500, len(prompt))])
+	}
+}
+
+func TestSetupEngine_ValidateStep_InfoAckErrorNamesField(t *testing.T) {
+	profile, ok := GetBundledSetupProfile("software-development")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	engine := NewSetupEngine(nil)
+	err := engine.ValidateStep(profile, "overview", SetupCollected{"overview": {"acknowledged": true}})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), `"_ack": true`) {
+		t.Fatalf("expected error to mention _ack payload, got %q", err.Error())
+	}
 }
 
 func TestSetupEngine_ComposeWizardPrompt(t *testing.T) {

--- a/pkg/fleet/setup_prompt.go
+++ b/pkg/fleet/setup_prompt.go
@@ -110,6 +110,11 @@ func (e *SetupEngine) composeStrictRules(profile *SetupProfile, stepID string, c
 	b.WriteString("STRICT RULES:\n")
 	b.WriteString("- Focus ONLY on the current step. Do not collect data for future steps.\n")
 	b.WriteString("- When all required fields for this step are gathered, call update_setup_draft with step_id and values.\n")
+	if profile != nil {
+		if step, ok := profile.StepByID(stepID); ok && step.EffectiveType() == "info" {
+			b.WriteString("- For this info step, after the user confirms, call update_setup_draft with values {\"_ack\": true}. No other acknowledgement key completes the step.\n")
+		}
+	}
 	b.WriteString("- If validation fails or information is missing, ask follow-up questions. Do not advance.\n")
 	b.WriteString("- Call get_setup_profile with draft_id to check completion state.\n")
 	if stepID == "review" || profile != nil {

--- a/pkg/store/context.go
+++ b/pkg/store/context.go
@@ -230,6 +230,8 @@ func MCPServerStoresFromContext(ctx context.Context) *MCPServerStores {
 
 const fleetTemplateStoreKey contextKey = "astonish_fleet_template_store"
 const fleetPlanStoreKey contextKey = "astonish_fleet_plan_store"
+const fleetSetupProfileStoreKey contextKey = "astonish_fleet_setup_profile_store"
+const fleetSetupDraftStoreKey contextKey = "astonish_fleet_setup_draft_store"
 const fleetRunStateStoreKey contextKey = "astonish_fleet_run_state_store"
 const fleetMailboxStoreKey contextKey = "astonish_fleet_mailbox_store"
 const fleetTaskBoardStoreKey contextKey = "astonish_fleet_task_board_store"
@@ -283,6 +285,38 @@ func FleetPlanStoreFromContext(ctx context.Context) FleetPlanStore {
 		return nil
 	}
 	fs, _ := ctx.Value(fleetPlanStoreKey).(FleetPlanStore)
+	return fs
+}
+
+// WithFleetSetupProfileStore returns a new context containing a tenant-scoped FleetSetupProfileStore.
+// Used to propagate setup profile stores into ADK tool contexts during fleet plan setup.
+func WithFleetSetupProfileStore(ctx context.Context, fs FleetSetupProfileStore) context.Context {
+	return context.WithValue(ctx, fleetSetupProfileStoreKey, fs)
+}
+
+// FleetSetupProfileStoreFromContext retrieves the FleetSetupProfileStore from a context.
+// Returns nil if no FleetSetupProfileStore is present.
+func FleetSetupProfileStoreFromContext(ctx context.Context) FleetSetupProfileStore {
+	if ctx == nil {
+		return nil
+	}
+	fs, _ := ctx.Value(fleetSetupProfileStoreKey).(FleetSetupProfileStore)
+	return fs
+}
+
+// WithFleetSetupDraftStore returns a new context containing a tenant-scoped FleetSetupDraftStore.
+// Used to propagate setup draft stores into ADK tool contexts during fleet plan setup.
+func WithFleetSetupDraftStore(ctx context.Context, fs FleetSetupDraftStore) context.Context {
+	return context.WithValue(ctx, fleetSetupDraftStoreKey, fs)
+}
+
+// FleetSetupDraftStoreFromContext retrieves the FleetSetupDraftStore from a context.
+// Returns nil if no FleetSetupDraftStore is present.
+func FleetSetupDraftStoreFromContext(ctx context.Context) FleetSetupDraftStore {
+	if ctx == nil {
+		return nil
+	}
+	fs, _ := ctx.Value(fleetSetupDraftStoreKey).(FleetSetupDraftStore)
 	return fs
 }
 

--- a/pkg/store/credentials.go
+++ b/pkg/store/credentials.go
@@ -10,13 +10,14 @@ import (
 type CredentialType = string
 
 const (
-	CredAPIKey           CredentialType = "api_key"
-	CredBearer           CredentialType = "bearer"
-	CredBasic            CredentialType = "basic"
+	CredAPIKey            CredentialType = "api_key"
+	CredBearer            CredentialType = "bearer"
+	CredBasic             CredentialType = "basic"
 	CredOAuthClientCreds  CredentialType = "oauth_client_credentials"
 	CredPassword          CredentialType = "password"
 	CredOAuthAuthCode     CredentialType = "oauth_authorization_code"
 	CredOpenStackKeystone CredentialType = "openstack_keystone"
+	CredRawContent        CredentialType = "raw_content"
 )
 
 // Credential represents a stored credential entry.
@@ -41,6 +42,8 @@ type Credential struct {
 	ProjectDomain               string         `json:"project_domain,omitempty"`
 	ApplicationCredentialID     string         `json:"application_credential_id,omitempty"`
 	ApplicationCredentialSecret string         `json:"application_credential_secret,omitempty"`
+	Content                     string         `json:"content,omitempty"`
+	ContentType                 string         `json:"content_type,omitempty"`
 }
 
 // OAuthTokenFetcher fetches an OAuth access token for a credential.
@@ -109,6 +112,9 @@ func ResolveCredentialHeader(name string, cred *Credential, oauthFetcher OAuthTo
 
 	case CredPassword:
 		return "", "", fmt.Errorf("credential %q is a password credential (for SSH/FTP/etc.), not an HTTP credential — use resolve_credential to access its fields", name)
+
+	case CredRawContent:
+		return "", "", fmt.Errorf("credential %q is raw content for file materialization, not an HTTP credential — use resolve_credential to access its content field", name)
 
 	default:
 		return "", "", fmt.Errorf("credential %q: unsupported type %q", name, cred.Type)

--- a/pkg/store/entstore/credentials_test.go
+++ b/pkg/store/entstore/credentials_test.go
@@ -295,6 +295,33 @@ func TestCredential_BackwardCompat_OldPgstoreEncrypted(t *testing.T) {
 
 // TestCredential_NoMasterKey verifies graceful degradation when no master key
 // is configured: data is stored as plain JSON and can be read back.
+func TestCredential_RawContentRoundTrip(t *testing.T) {
+	cs, _ := setupPersonalStore(t)
+	ctx := context.Background()
+
+	content := "providers:\n  alpaca:\n    key: raw-secret-12345\n"
+	cred := &store.Credential{
+		Type:        store.CredRawContent,
+		Content:     content,
+		ContentType: "application/yaml",
+	}
+	if err := cs.Set(ctx, "providers-file", cred); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got := cs.Get(ctx, "providers-file")
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Type != store.CredRawContent || got.Content != content || got.ContentType != "application/yaml" {
+		t.Fatalf("Get = %#v", got)
+	}
+	_, _, err := cs.Resolve(ctx, "providers-file")
+	if err == nil || !strings.Contains(err.Error(), "raw content") {
+		t.Fatalf("Resolve error = %v, want raw content rejection", err)
+	}
+}
+
 func TestCredential_NoMasterKey(t *testing.T) {
 	// Ensure no master key is available via env or file.
 	t.Setenv("ASTONISH_MASTER_KEY", "")

--- a/pkg/tools/credential_tool.go
+++ b/pkg/tools/credential_tool.go
@@ -136,6 +136,8 @@ func credToStoreCred(c *credentials.Credential) *store.Credential {
 		AccessToken:  c.AccessToken,
 		RefreshToken: c.RefreshToken,
 		TokenExpiry:  c.TokenExpiry,
+		Content:      c.Content,
+		ContentType:  c.ContentType,
 	}
 }
 
@@ -156,6 +158,8 @@ func storeCredToCred(c *store.Credential) *credentials.Credential {
 		AccessToken:  c.AccessToken,
 		RefreshToken: c.RefreshToken,
 		TokenExpiry:  c.TokenExpiry,
+		Content:      c.Content,
+		ContentType:  c.ContentType,
 	}
 }
 
@@ -163,7 +167,7 @@ func storeCredToCred(c *store.Credential) *credentials.Credential {
 
 type SaveCredentialArgs struct {
 	Name                        string `json:"name" jsonschema:"Short identifier for this credential (e.g., 'my-api', 'proxmox', 'google-calendar')"`
-	Type                        string `json:"type" jsonschema:"Credential type: 'api_key' (custom header+value), 'bearer' (Authorization: Bearer token), 'basic' (HTTP Basic Auth), 'password' (plain username+password for SSH/FTP/SMTP/databases), 'oauth_client_credentials' (auto-refreshing OAuth2 server-to-server), 'oauth_authorization_code' (user-authorized OAuth2 with refresh token — Google, GitHub, etc.), 'openstack_keystone' (OpenStack Keystone v3 token auth — password or application credential)"`
+	Type                        string `json:"type" jsonschema:"Credential type: 'api_key' (custom header+value), 'bearer' (Authorization: Bearer token), 'basic' (HTTP Basic Auth), 'password' (plain username+password for SSH/FTP/SMTP/databases), 'oauth_client_credentials' (auto-refreshing OAuth2 server-to-server), 'oauth_authorization_code' (user-authorized OAuth2 with refresh token — Google, GitHub, etc.), 'openstack_keystone' (OpenStack Keystone v3 token auth — password or application credential), 'raw_content' (arbitrary JSON/YAML/text file content for sandbox file injection; not HTTP auth)"`
 	Header                      string `json:"header,omitempty" jsonschema:"Header name for api_key type (e.g., 'X-API-Key', 'Authorization'). Required for api_key type."`
 	Value                       string `json:"value,omitempty" jsonschema:"The API key value. Required for api_key type."`
 	Token                       string `json:"token,omitempty" jsonschema:"The bearer token. Required for bearer type."`
@@ -182,6 +186,8 @@ type SaveCredentialArgs struct {
 	ProjectDomain               string `json:"project_domain,omitempty" jsonschema:"Keystone project domain name (openstack_keystone password auth). Defaults to 'Default'."`
 	ApplicationCredentialID     string `json:"application_credential_id,omitempty" jsonschema:"Keystone application credential ID (openstack_keystone). Prefer over password auth when available."`
 	ApplicationCredentialSecret string `json:"application_credential_secret,omitempty" jsonschema:"Keystone application credential secret (openstack_keystone)."`
+	Content                     string `json:"content,omitempty" jsonschema:"Raw JSON, YAML, dotenv, or text content. Required for raw_content type. Preserve exact newlines and formatting."`
+	ContentType                 string `json:"content_type,omitempty" jsonschema:"Optional MIME/content hint for raw_content, e.g. text/plain, application/json, application/yaml, text/x-dotenv."`
 }
 
 type SaveCredentialResult struct {
@@ -288,6 +294,16 @@ func saveCredential(ctx tool.Context, args SaveCredentialArgs) (SaveCredentialRe
 			Scope:        args.Scope,
 		}
 
+	case store.CredRawContent:
+		if args.Content == "" {
+			return SaveCredentialResult{ToolResult: toolError("content is required for raw_content type")}, nil
+		}
+		storeCred = &store.Credential{
+			Type:        store.CredRawContent,
+			Content:     args.Content,
+			ContentType: args.ContentType,
+		}
+
 	case store.CredOpenStackKeystone:
 		if args.AuthURL == "" {
 			return SaveCredentialResult{ToolResult: toolError("auth_url is required for openstack_keystone type (e.g., https://identity.example.com/v3/auth/tokens)")}, nil
@@ -317,7 +333,7 @@ func saveCredential(ctx tool.Context, args SaveCredentialArgs) (SaveCredentialRe
 
 	default:
 		return SaveCredentialResult{
-			ToolResult: toolError("Unknown type %q. Use: api_key, bearer, basic, password, oauth_client_credentials, oauth_authorization_code, or openstack_keystone", args.Type),
+			ToolResult: toolError("Unknown type %q. Use: api_key, bearer, basic, password, oauth_client_credentials, oauth_authorization_code, openstack_keystone, or raw_content", args.Type),
 		}, nil
 	}
 
@@ -333,11 +349,15 @@ func saveCredential(ctx tool.Context, args SaveCredentialArgs) (SaveCredentialRe
 		r.HydrateFromStore(cs)
 	}
 
+	message := fmt.Sprintf("Credential %q saved (%s). The value is encrypted and will not appear in conversation history.", args.Name, args.Type)
+	if credType == store.CredRawContent {
+		message += fmt.Sprintf(" Use it with resolve_credential field content or fleet credential_injection files using field content. IMPORTANT: Now save a memory note documenting credential name %q, the intended file path/use, and content type only. Do NOT include the actual content in the memory note.", args.Name)
+	} else {
+		message += fmt.Sprintf(" IMPORTANT: Now save a memory note documenting: (1) credential name %q, (2) what format/prefix is already included in the stored value (so you never double-prefix it), (3) the header name and how to use it with api_call, (4) the target API base URL. Do NOT include the actual secret value in the memory note — reference it by name only.", args.Name)
+	}
+
 	return SaveCredentialResult{
-		ToolResult: ToolResult{Status: "saved", Message: fmt.Sprintf("Credential %q saved (%s). The value is encrypted and will not appear in conversation history. "+
-			"IMPORTANT: Now save a memory note documenting: (1) credential name %q, (2) what format/prefix is already included in the stored value "+
-			"(so you never double-prefix it), (3) the header name and how to use it with api_call, (4) the target API base URL. "+
-			"Do NOT include the actual secret value in the memory note — reference it by name only.", args.Name, args.Type, args.Name)},
+		ToolResult: ToolResult{Status: "saved", Message: message},
 	}, nil
 }
 
@@ -474,14 +494,14 @@ func listCredentials(ctx tool.Context, args ListCredentialsArgs) (ListCredential
 	var msg string
 	if total == 0 {
 		if args.Filter != "" {
-			msg = fmt.Sprintf("Nothing matching %q. Use save_credential for HTTP credentials or the setup commands for provider keys.", args.Filter)
+			msg = fmt.Sprintf("Nothing matching %q. Use save_credential for credentials or raw file content, or the setup commands for provider keys.", args.Filter)
 		} else {
 			msg = "No stored credentials or secrets."
 		}
 	} else {
 		parts := make([]string, 0, 2)
 		if len(credSummaries) > 0 {
-			parts = append(parts, fmt.Sprintf("%d HTTP credential(s)", len(credSummaries)))
+			parts = append(parts, fmt.Sprintf("%d credential(s)", len(credSummaries)))
 		}
 		if len(secretSummaries) > 0 {
 			parts = append(parts, fmt.Sprintf("%d secret(s)", len(secretSummaries)))
@@ -596,6 +616,11 @@ func testCredential(ctx tool.Context, args TestCredentialArgs) (TestCredentialRe
 			ToolResult: ToolResult{Status: "ok", Message: fmt.Sprintf("Credential %q configured (%s, user: %s). Use resolve_credential to retrieve the username and password for SSH/FTP/database connections.", args.Name, cred.Type, cred.Username)},
 		}, nil
 
+	case store.CredRawContent:
+		return TestCredentialResult{
+			ToolResult: ToolResult{Status: "ok", Message: fmt.Sprintf("Credential %q configured (raw_content, %d bytes). Use resolve_credential field content or fleet credential_injection field content.", args.Name, len(cred.Content))},
+		}, nil
+
 	default:
 		return TestCredentialResult{
 			ToolResult: ToolResult{Status: "ok", Message: fmt.Sprintf("Credential %q configured (%s). Use http_request with credential=%q to test connectivity.", args.Name, cred.Type, args.Name)},
@@ -610,16 +635,18 @@ type ResolveCredentialArgs struct {
 }
 
 type ResolveCredentialResult struct {
-	Status   string `json:"status"`
-	Message  string `json:"message,omitempty"`
-	Type     string `json:"type,omitempty"`
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Token    string `json:"token,omitempty"`
-	Header   string `json:"header,omitempty"`
-	Value    string `json:"value,omitempty"`
-	AuthURL  string `json:"auth_url,omitempty"`
-	ClientID string `json:"client_id,omitempty"`
+	Status      string `json:"status"`
+	Message     string `json:"message,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Username    string `json:"username,omitempty"`
+	Password    string `json:"password,omitempty"`
+	Token       string `json:"token,omitempty"`
+	Header      string `json:"header,omitempty"`
+	Value       string `json:"value,omitempty"`
+	AuthURL     string `json:"auth_url,omitempty"`
+	ClientID    string `json:"client_id,omitempty"`
+	Content     string `json:"content,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 func resolveCredential(ctx tool.Context, args ResolveCredentialArgs) (ResolveCredentialResult, error) {
@@ -672,6 +699,10 @@ func resolveCredential(ctx tool.Context, args ResolveCredentialArgs) (ResolveCre
 		result.AuthURL = cred.AuthURL
 		result.Token = credentials.FormatPlaceholder(args.Name, "token")
 		result.Message = "Use http_request with credential parameter for Keystone — X-Auth-Token is injected automatically."
+	case store.CredRawContent:
+		result.Content = credentials.FormatPlaceholder(args.Name, "content")
+		result.ContentType = cred.ContentType
+		result.Message = "Raw content credential. Use the content placeholder directly where file content is needed, or configure fleet credential_injection files with field=content."
 	}
 
 	return result, nil
@@ -681,15 +712,15 @@ func resolveCredential(ctx tool.Context, args ResolveCredentialArgs) (ResolveCre
 
 func NewSaveCredentialTool() (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
-		Name: "save_credential",
-		Description: `Save a credential to the encrypted store. Credentials saved here are PERSONAL (only you can see/use them). To share with the team, use the Settings UI 'Publish to Team'. Use IMMEDIATELY when the user provides any secret. Types: api_key, bearer, basic, password, oauth_client_credentials, oauth_authorization_code, openstack_keystone. HTTP credentials work with http_request; password credentials with resolve_credential. After saving, ALWAYS use memory_save to document: credential name, what format/prefix is already in the stored value, the header name, and the target API base URL — but NEVER include the actual secret value in the memory note.`,
+		Name:        "save_credential",
+		Description: `Save a credential to the encrypted store. Credentials saved here are PERSONAL (only you can see/use them). To share with the team, use the Settings UI 'Publish to Team'. Use IMMEDIATELY when the user provides any secret. Types: api_key, bearer, basic, password, oauth_client_credentials, oauth_authorization_code, openstack_keystone, raw_content. HTTP credentials work with http_request; password and raw_content credentials with resolve_credential. Use raw_content for JSON/YAML/dotenv/text files that will be injected into sandboxes; store payload in content and inject field content. After saving, ALWAYS use memory_save to document safe metadata such as credential name, required prefix/header or target file path, and API base URL/content type — but NEVER include the actual secret value/content in the memory note.`,
 	}, saveCredential)
 }
 
 func NewListCredentialsTool() (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
 		Name:        "list_credentials",
-		Description: "List all stored credentials and secrets. Shows HTTP credentials (name + type) and provider/channel/MCP secrets (dot-notation keys like 'provider.anthropic.api_key'). Secret values are never exposed. Optionally filter by name or key.",
+		Description: "List all stored credentials and secrets. Shows named credentials (name + type, including HTTP auth and raw_content) and provider/channel/MCP secrets (dot-notation keys like 'provider.anthropic.api_key'). Secret values are never exposed. Optionally filter by name or key.",
 	}, listCredentials)
 }
 
@@ -710,7 +741,7 @@ func NewTestCredentialTool() (tool.Tool, error) {
 func NewResolveCredentialTool() (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
 		Name:        "resolve_credential",
-		Description: `Retrieve fields of a stored credential by name. Use for non-HTTP auth (SSH, FTP, databases). Returns type-specific fields: non-secret fields (username, header) as plaintext, secret fields (password, token, value) as {{CREDENTIAL:name:field}} placeholders. Pass placeholders directly to process_write, shell_command, browser_type, etc. — the system substitutes real values at execution time. The real secrets never appear in your context.`,
+		Description: `Retrieve fields of a stored credential by name. Use for non-HTTP auth (SSH, FTP, databases) and raw_content file payloads. Returns type-specific fields: non-secret fields (username, header, content_type) as plaintext, secret fields (password, token, value, content) as {{CREDENTIAL:name:field}} placeholders. Pass placeholders directly to process_write, shell_command, browser_type, etc. — the system substitutes real values at execution time. The real secrets never appear in your context.`,
 	}, resolveCredential)
 }
 

--- a/pkg/tools/fleet_plan_tool.go
+++ b/pkg/tools/fleet_plan_tool.go
@@ -155,7 +155,7 @@ type SaveFleetPlanArgs struct {
 	// Credentials maps logical names to credential store entry names.
 	Credentials map[string]string `json:"credentials,omitempty" jsonschema:"Credential mappings for external service authentication. Key is a logical name agents use (e.g., 'github', 'trading'). Value is the credential name in the encrypted store. IMPORTANT: For github_issues channel plans, include a 'github' entry so the GitHub token is auto-injected into gh CLI commands. If credentials were validated with validate_fleet_plan, include the same mappings here."`
 	// CredentialInjection declares how credentials are injected into fleet sandbox containers at session start (env vars and files).
-	CredentialInjection *SaveFleetPlanCredentialInjection `json:"credential_injection,omitempty" jsonschema:"How plan credentials are injected at fleet session start. env: map logical credentials to container environment variables. files: materialize credential fields to absolute paths inside the container (e.g., /root/app/config/credentials.yaml). Required for apps that read config files — store the file content via save_credential (type api_key, field value) and reference it here. GitHub-only plans get GH_TOKEN by default when omitted."`
+	CredentialInjection *SaveFleetPlanCredentialInjection `json:"credential_injection,omitempty" jsonschema:"How plan credentials are injected at fleet session start. env: map logical credentials to container environment variables. files: materialize credential fields to absolute paths inside the container (e.g., /root/app/config/credentials.yaml). Required for apps that read config files — store file payloads via save_credential (type raw_content, field content) and reference them here. Existing api_key/value mappings remain supported for old plans. GitHub-only plans get GH_TOKEN by default when omitted."`
 	// WorkspaceBaseDir overrides the base directory where project files are stored.
 	// The final workspace path will be <workspace_base_dir>/<repo-name or plan-key>.
 	// If omitted, the template's default is used (typically ~/astonish_projects).
@@ -564,8 +564,9 @@ func GetFleetPlanTools() ([]tool.Tool, error) {
 			"injection into fleet sandbox containers. " +
 			"IMPORTANT: If credentials were validated with validate_fleet_plan, pass the same " +
 			"credentials map and credential_injection here. Use save_credential during setup to store " +
-			"secrets in the encrypted store, then reference store entry names in credentials and declare " +
-			"how they are injected (env vars and/or file paths) in credential_injection. " +
+			"secrets in the encrypted store. For file payloads, use type raw_content and inject field content. " +
+			"Then reference store entry names in credentials and declare how they are injected " +
+			"(env vars and/or file paths) in credential_injection. " +
 			"Use include_agents to select a subset of agents from the template (e.g., only ['dev']). " +
 			"The plan is stored as a YAML file and can be launched from the Studio UI.",
 	}, saveFleetPlan)

--- a/pkg/tools/fleet_setup_tool.go
+++ b/pkg/tools/fleet_setup_tool.go
@@ -14,7 +14,7 @@ import (
 type UpdateSetupDraftArgs struct {
 	DraftID  string         `json:"draft_id" jsonschema:"Setup draft UUID from the fleet setup wizard"`
 	StepID   string         `json:"step_id" jsonschema:"Step ID being updated (e.g., provisioning, channel)"`
-	Values   map[string]any `json:"values" jsonschema:"Field values for this step"`
+	Values   map[string]any `json:"values" jsonschema:"Field values for this step. Info steps are acknowledged with {\"_ack\": true}."`
 	MarkStep string         `json:"current_step,omitempty" jsonschema:"Optional current step pointer after update"`
 }
 
@@ -67,6 +67,7 @@ func updateSetupDraft(tc tool.Context, args UpdateSetupDraftArgs) (UpdateSetupDr
 	if err != nil {
 		return UpdateSetupDraftResult{Status: "error", Message: err.Error()}, nil
 	}
+	normalizeInfoStepAck(profile, stepID, existing)
 	engine := fleet.NewSetupEngine(nil)
 	collected := fleet.ParseSetupCollected(draft.Collected)
 	if valErr := engine.ValidateStep(profile, stepID, collected); valErr != nil {
@@ -154,7 +155,54 @@ func getSetupProfile(tc tool.Context, args GetSetupProfileArgs) (GetSetupProfile
 	return result, nil
 }
 
+func normalizeInfoStepAck(profile *fleet.SetupProfile, stepID string, values map[string]any) {
+	if profile == nil || values == nil {
+		return
+	}
+	step, ok := profile.StepByID(stepID)
+	if !ok || step.EffectiveType() != "info" {
+		return
+	}
+	if isTruthyAck(values["_ack"]) {
+		values["_ack"] = true
+		return
+	}
+	for _, key := range []string{
+		"ack",
+		"acknowledged",
+		"acknowledge",
+		"confirmed",
+		"user_confirmed",
+		"overview_acknowledged",
+		"overview_ack",
+		"proceed",
+	} {
+		if isTruthyAck(values[key]) {
+			values["_ack"] = true
+			return
+		}
+	}
+	if status, ok := values["status"].(string); ok && strings.EqualFold(strings.TrimSpace(status), "acknowledged") {
+		values["_ack"] = true
+	}
+}
+
+func isTruthyAck(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case string:
+		s := strings.TrimSpace(strings.ToLower(x))
+		return s == "true" || s == "yes" || s == "y" || s == "acknowledged" || s == "confirmed"
+	default:
+		return false
+	}
+}
+
 func setupDraftStoreFromContext(tc tool.Context) store.FleetSetupDraftStore {
+	if fs := store.FleetSetupDraftStoreFromContext(tc); fs != nil {
+		return fs
+	}
 	if svc := store.FromContext(tc); svc != nil && svc.FleetSetupDrafts != nil {
 		return svc.FleetSetupDrafts
 	}
@@ -162,6 +210,9 @@ func setupDraftStoreFromContext(tc tool.Context) store.FleetSetupDraftStore {
 }
 
 func setupProfileStoreFromContext(tc tool.Context) store.FleetSetupProfileStore {
+	if fs := store.FleetSetupProfileStoreFromContext(tc); fs != nil {
+		return fs
+	}
 	if svc := store.FromContext(tc); svc != nil && svc.FleetSetupProfiles != nil {
 		return svc.FleetSetupProfiles
 	}
@@ -173,14 +224,15 @@ func GetFleetSetupTools() ([]tool.Tool, error) {
 	updateTool, err := functiontool.New(functiontool.Config{
 		Name: "update_setup_draft",
 		Description: "Merge collected setup values into an in-progress fleet setup draft. " +
-			"Validates the step before saving. Returns next_step when the step is complete. " +
+			"Validates the step before saving. For info steps, acknowledge with values {\"_ack\": true}. " +
+			"Returns next_step when the step is complete. " +
 			"Use during plan creation to persist step outputs, especially provisioning (template, container_workspace_dir).",
 	}, updateSetupDraft)
 	if err != nil {
 		return nil, fmt.Errorf("update_setup_draft: %w", err)
 	}
 	getTool, err := functiontool.New(functiontool.Config{
-		Name: "get_setup_profile",
+		Name:        "get_setup_profile",
 		Description: "Load a fleet setup profile definition, current step prompt, tools, and draft completion status.",
 	}, getSetupProfile)
 	if err != nil {

--- a/pkg/tools/fleet_setup_tool_test.go
+++ b/pkg/tools/fleet_setup_tool_test.go
@@ -1,0 +1,160 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/store"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+type setupDraftMemoryStore struct {
+	drafts map[string]*store.FleetSetupDraft
+}
+
+func newSetupDraftMemoryStore() *setupDraftMemoryStore {
+	return &setupDraftMemoryStore{drafts: map[string]*store.FleetSetupDraft{}}
+}
+
+func (m *setupDraftMemoryStore) Create(_ context.Context, draft *store.FleetSetupDraft) error {
+	copied := *draft
+	m.drafts[draft.ID] = &copied
+	return nil
+}
+
+func (m *setupDraftMemoryStore) Get(_ context.Context, id string) (*store.FleetSetupDraft, bool) {
+	draft, ok := m.drafts[id]
+	if !ok {
+		return nil, false
+	}
+	copied := *draft
+	return &copied, true
+}
+
+func (m *setupDraftMemoryStore) Update(_ context.Context, draft *store.FleetSetupDraft) error {
+	copied := *draft
+	m.drafts[draft.ID] = &copied
+	return nil
+}
+
+func (m *setupDraftMemoryStore) Delete(_ context.Context, id string) error {
+	delete(m.drafts, id)
+	return nil
+}
+
+type setupToolCtx struct {
+	context.Context
+}
+
+var _ tool.Context = (*setupToolCtx)(nil)
+
+func (m *setupToolCtx) UserContent() *genai.Content { return nil }
+func (m *setupToolCtx) InvocationID() string        { return "test" }
+func (m *setupToolCtx) AgentName() string           { return "test" }
+func (m *setupToolCtx) ReadonlyState() session.ReadonlyState {
+	return nil
+}
+func (m *setupToolCtx) UserID() string                 { return "" }
+func (m *setupToolCtx) AppName() string                { return "" }
+func (m *setupToolCtx) SessionID() string              { return "" }
+func (m *setupToolCtx) Branch() string                 { return "" }
+func (m *setupToolCtx) Artifacts() agent.Artifacts     { return nil }
+func (m *setupToolCtx) State() session.State           { return nil }
+func (m *setupToolCtx) FunctionCallID() string         { return "" }
+func (m *setupToolCtx) Actions() *session.EventActions { return nil }
+func (m *setupToolCtx) SearchMemory(_ context.Context, _ string) (*memory.SearchResponse, error) {
+	return nil, nil
+}
+func (m *setupToolCtx) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *setupToolCtx) RequestConfirmation(_ string, _ any) error            { return nil }
+
+func TestUpdateSetupDraftUsesContextDraftStore(t *testing.T) {
+	draftStore := newSetupDraftMemoryStore()
+	seedSetupDraft(t, draftStore, "draft-1")
+
+	ctx := store.WithFleetSetupDraftStore(context.Background(), draftStore)
+	result, err := updateSetupDraft(&setupToolCtx{Context: ctx}, UpdateSetupDraftArgs{
+		DraftID:  "draft-1",
+		StepID:   "overview",
+		MarkStep: "channel",
+		Values: map[string]any{
+			"_ack": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("updateSetupDraft error: %v", err)
+	}
+	if result.Status != "ok" {
+		t.Fatalf("status = %q, message = %q", result.Status, result.Message)
+	}
+	if result.Message == "Setup draft store not available" {
+		t.Fatal("setup draft store was not resolved from context")
+	}
+
+	assertOverviewAckPersisted(t, draftStore, "draft-1")
+	updated, _ := draftStore.Get(context.Background(), "draft-1")
+	if updated.CurrentStep != "channel" {
+		t.Fatalf("CurrentStep = %q, want channel", updated.CurrentStep)
+	}
+}
+
+func TestUpdateSetupDraftNormalizesInfoStepAckAliases(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		values map[string]any
+	}{
+		{name: "acknowledged", values: map[string]any{"acknowledged": true}},
+		{name: "confirmed", values: map[string]any{"confirmed": true}},
+		{name: "ack string", values: map[string]any{"ack": "yes"}},
+		{name: "status acknowledged", values: map[string]any{"status": "acknowledged"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			draftStore := newSetupDraftMemoryStore()
+			seedSetupDraft(t, draftStore, "draft-"+tt.name)
+
+			ctx := store.WithFleetSetupDraftStore(context.Background(), draftStore)
+			result, err := updateSetupDraft(&setupToolCtx{Context: ctx}, UpdateSetupDraftArgs{
+				DraftID: "draft-" + tt.name,
+				StepID:  "overview",
+				Values:  tt.values,
+			})
+			if err != nil {
+				t.Fatalf("updateSetupDraft error: %v", err)
+			}
+			if result.Status != "ok" {
+				t.Fatalf("status = %q, message = %q", result.Status, result.Message)
+			}
+			assertOverviewAckPersisted(t, draftStore, "draft-"+tt.name)
+		})
+	}
+}
+
+func seedSetupDraft(t *testing.T, draftStore *setupDraftMemoryStore, id string) {
+	t.Helper()
+	draft := &store.FleetSetupDraft{
+		ID:              id,
+		TemplateKey:     "software-dev",
+		SetupProfileKey: "software-development",
+		Collected:       map[string]any{},
+	}
+	if err := draftStore.Create(context.Background(), draft); err != nil {
+		t.Fatalf("Create draft: %v", err)
+	}
+}
+
+func assertOverviewAckPersisted(t *testing.T, draftStore *setupDraftMemoryStore, id string) {
+	t.Helper()
+	updated, ok := draftStore.Get(context.Background(), id)
+	if !ok {
+		t.Fatal("updated draft not found")
+	}
+	overview, _ := updated.Collected["overview"].(map[string]any)
+	if ack, _ := overview["_ack"].(bool); !ack {
+		t.Fatalf("overview _ack not persisted: %+v", overview)
+	}
+}

--- a/web/src/components/settings/CredentialsSettings.tsx
+++ b/web/src/components/settings/CredentialsSettings.tsx
@@ -40,6 +40,8 @@ interface RevealedCredential {
   project_domain?: string
   application_credential_id?: string
   application_credential_secret?: string
+  content?: string
+  content_type?: string
   [key: string]: unknown
 }
 
@@ -72,6 +74,8 @@ interface CredForm {
   project_domain: string
   application_credential_id: string
   application_credential_secret: string
+  content: string
+  content_type: string
 }
 
 const emptyCredForm = (): CredForm => ({
@@ -95,7 +99,9 @@ const emptyCredForm = (): CredForm => ({
   project_name: '',
   project_domain: 'Default',
   application_credential_id: '',
-  application_credential_secret: ''
+  application_credential_secret: '',
+  content: '',
+  content_type: 'text/plain'
 })
 
 interface SecretForm {
@@ -231,7 +237,8 @@ const TYPE_LABELS: Record<string, string> = {
   password: 'Password',
   oauth_client_credentials: 'OAuth Client Credentials',
   oauth_authorization_code: 'OAuth Auth Code',
-  openstack_keystone: 'OpenStack Keystone'
+  openstack_keystone: 'OpenStack Keystone',
+  raw_content: 'Raw Content'
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -241,7 +248,8 @@ const TYPE_COLORS: Record<string, string> = {
   password: '#ef4444',
   oauth_client_credentials: '#10b981',
   oauth_authorization_code: '#06b6d4',
-  openstack_keystone: '#f97316'
+  openstack_keystone: '#f97316',
+  raw_content: '#14b8a6'
 }
 
 const SCOPE_COLORS: Record<string, string> = {
@@ -529,7 +537,9 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
       project_name: revealed.project_name || '',
       project_domain: revealed.project_domain || 'Default',
       application_credential_id: revealed.application_credential_id || '',
-      application_credential_secret: revealed.application_credential_secret || ''
+      application_credential_secret: revealed.application_credential_secret || '',
+      content: revealed.content || '',
+      content_type: revealed.content_type || 'text/plain'
     })
     setCredFormError('')
     setShowCredModal(true)
@@ -556,6 +566,7 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
         case 'basic': case 'password': cred.username = credForm.username; cred.password = credForm.password; break
         case 'oauth_client_credentials': cred.auth_url = credForm.auth_url; cred.client_id = credForm.client_id; cred.client_secret = credForm.client_secret; cred.scope = credForm.scope; break
         case 'oauth_authorization_code': cred.token_url = credForm.token_url; cred.client_id = credForm.client_id; cred.client_secret = credForm.client_secret; cred.access_token = credForm.access_token; cred.refresh_token = credForm.refresh_token; cred.scope = credForm.scope; break
+        case 'raw_content': cred.content = credForm.content; cred.content_type = credForm.content_type; break
         case 'openstack_keystone':
           cred.auth_url = credForm.auth_url
           if (credForm.keystone_method === 'application_credential') {
@@ -787,6 +798,12 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
               </>
             )}
             {revealed.type === 'bearer' && <FieldRow label="Token" value={revealed.token} secret />}
+            {revealed.type === 'raw_content' && (
+              <>
+                {revealed.content_type && <FieldRow label="Content Type" value={revealed.content_type} />}
+                <FieldRow label="Content" value={revealed.content} secret multiline />
+              </>
+            )}
             {(revealed.type === 'basic' || revealed.type === 'password') && (
               <>
                 <FieldRow label="Username" value={revealed.username} />
@@ -890,7 +907,7 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
     const canManage = !isTeamScope || isAdmin
     return (
       <div>
-        {/* HTTP Credentials */}
+        {/* Named Credentials */}
         <div>
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-sm font-medium flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
@@ -1026,7 +1043,7 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
         </>
       ) : (
         // Personal mode: single section (no scope labels)
-        renderCredentialSection('HTTP Credentials', personalCreds, personalSecrets)
+        renderCredentialSection('Credentials', personalCreds, personalSecrets)
       )}
 
       {/* Master Key Prompt Modal */}
@@ -1115,6 +1132,7 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
                 <option value="oauth_client_credentials">OAuth Client Credentials</option>
                 <option value="oauth_authorization_code">OAuth Authorization Code</option>
                 <option value="openstack_keystone">OpenStack Keystone</option>
+                <option value="raw_content">Raw Content (JSON/YAML/text file)</option>
               </select>
             </div>
 
@@ -1136,6 +1154,19 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
                 <label className="block text-sm font-medium mb-2" style={labelStyle}>Token</label>
                 <input type="password" value={credForm.token} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCredForm({ ...credForm, token: e.target.value })} className={inputClass + ' font-mono'} style={inputStyle} />
               </div>
+            )}
+            {credForm.type === 'raw_content' && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium mb-2" style={labelStyle}>Content Type <span className="font-normal" style={hintStyle}>(optional)</span></label>
+                  <input type="text" value={credForm.content_type} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCredForm({ ...credForm, content_type: e.target.value })} placeholder="text/plain, application/json, application/yaml" className={inputClass + ' font-mono'} style={inputStyle} />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-2" style={labelStyle}>Raw Content</label>
+                  <textarea value={credForm.content} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCredForm({ ...credForm, content: e.target.value })} placeholder="Paste JSON, YAML, dotenv, or text content" className={inputClass + ' font-mono min-h-32'} style={inputStyle} />
+                  <p className="text-xs mt-1" style={hintStyle}>Stored encrypted and used via resolve_credential field content or fleet credential_injection field content.</p>
+                </div>
+              </>
             )}
             {(credForm.type === 'basic' || credForm.type === 'password') && (
               <>
@@ -1315,20 +1346,29 @@ export default function CredentialsSettings({ isPlatform: isPlatformProp }: { is
 }
 
 // Reusable field row for revealed credentials
-function FieldRow({ label, value, secret }: { label: string; value: string | undefined; secret?: boolean }) {
+function FieldRow({ label, value, secret, multiline }: { label: string; value: string | undefined; secret?: boolean; multiline?: boolean }) {
   const [show, setShow] = useState(!secret)
+  const displayValue = show ? value : '*'.repeat(Math.min(value?.length || 8, 32))
   return (
-    <div className="flex items-center gap-2">
+    <div className={multiline ? 'space-y-1.5' : 'flex items-center gap-2'}>
       <span className="text-xs w-28 flex-shrink-0" style={hintStyle}>{label}</span>
-      <span className="font-mono text-xs break-all flex-1" style={{ color: 'var(--text-primary)' }}>
-        {show ? value : '*'.repeat(Math.min(value?.length || 8, 32))}
-      </span>
-      {secret && (
-        <button onClick={() => setShow(!show)} className="p-0.5 flex-shrink-0">
-          {show ? <EyeOff size={12} style={{ color: 'var(--text-muted)' }} /> : <Eye size={12} style={{ color: 'var(--text-muted)' }} />}
-        </button>
+      {multiline ? (
+        <pre className="font-mono text-xs whitespace-pre-wrap break-all rounded p-2 max-h-48 overflow-auto" style={{ color: 'var(--text-primary)', background: 'var(--bg-tertiary)', border: '1px solid var(--border-color)' }}>
+          {displayValue}
+        </pre>
+      ) : (
+        <span className="font-mono text-xs break-all flex-1" style={{ color: 'var(--text-primary)' }}>
+          {displayValue}
+        </span>
       )}
-      {show && <CopyButton text={value} />}
+      <div className={multiline ? 'flex items-center gap-1' : 'contents'}>
+        {secret && (
+          <button onClick={() => setShow(!show)} className="p-0.5 flex-shrink-0">
+            {show ? <EyeOff size={12} style={{ color: 'var(--text-muted)' }} /> : <Eye size={12} style={{ color: 'var(--text-muted)' }} />}
+          </button>
+        )}
+        {show && <CopyButton text={value} />}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add a `raw_content` credential type for encrypted JSON, YAML, dotenv, and text payloads.
- Wire raw content through credential stores, redaction, placeholder resolution, fleet file injection, CLI/API/tool surfaces, and Studio settings.
- Update the software-development setup profile to recommend `raw_content` with `field: content` for injected config files.
- Fix fleet setup draft tools so chat-driven setup can update drafts and info-step acknowledgement is documented and forgiving.

## Verification

- `go test ./pkg/credentials ./pkg/fleet ./pkg/tools ./pkg/api ./pkg/store/entstore ./cmd/astonish`
- `go test ./pkg/fleet ./pkg/tools ./pkg/api ./pkg/store`
- `cd web && npm run lint`
- `git diff --check`
- pre-commit `golangci-lint` passed with 0 issues
