### PR TITLE
Rebase personal scheduler fork changes

### DIFF
--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -1191,6 +1191,14 @@ func StudioChatHandler(w http.ResponseWriter, r *http.Request) {
 					pool.Remove(sessionID)
 				}
 			}
+			// Match daemon SetGatewayConfig so SessionBridge can PreSeed/AutoApprove.
+			if appCfg := effectiveAppConfig(r); appCfg != nil && appCfg.Sandbox.OpenShell.GatewayAddr != "" {
+				cfg := openshell.GRPCClientConfig{
+					Addr: appCfg.Sandbox.OpenShell.GatewayAddr,
+					TLS:  appCfg.Sandbox.OpenShell.OpenShellGatewayTLS(),
+				}
+				localExec.GatewayConfig = &cfg
+			}
 			return localExec.Execute(execCtx, job)
 		})
 	}

--- a/pkg/api/network_denial_check.go
+++ b/pkg/api/network_denial_check.go
@@ -18,11 +18,11 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/sandbox/netpolicy"
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/gorilla/mux"
 )
 
 // NetworkDenialCheckHandler returns pending network denial proposals for a sandbox

--- a/pkg/api/scheduler_handlers.go
+++ b/pkg/api/scheduler_handlers.go
@@ -40,8 +40,8 @@ func GetExecutor() *scheduler.Executor {
 // Used by the RunJobFunc in chat_handlers.go to construct a local executor on
 // API pods that don't have the global scheduler Executor.
 var (
-	runHeadlessMu   sync.RWMutex
-	runHeadlessFn   scheduler.RunHeadlessFunc
+	runHeadlessMu sync.RWMutex
+	runHeadlessFn scheduler.RunHeadlessFunc
 )
 
 // SetRunHeadlessFunc registers the headless runner function.

--- a/pkg/api/scheduler_handlers_test.go
+++ b/pkg/api/scheduler_handlers_test.go
@@ -490,8 +490,8 @@ func (s *stubCredStore) Count(context.Context) int                            { 
 func (s *stubCredStore) Resolve(context.Context, string) (string, string, error) {
 	return "", "", nil
 }
-func (s *stubCredStore) InvalidateToken(context.Context, string)              {}
-func (s *stubCredStore) SetSecret(context.Context, string, string) error      { return nil }
+func (s *stubCredStore) InvalidateToken(context.Context, string)         {}
+func (s *stubCredStore) SetSecret(context.Context, string, string) error { return nil }
 func (s *stubCredStore) SetSecretBatch(context.Context, map[string]string) error {
 	return nil
 }
@@ -499,8 +499,8 @@ func (s *stubCredStore) GetSecret(context.Context, string) string { return "" }
 func (s *stubCredStore) RemoveSecret(context.Context, string) error {
 	return nil
 }
-func (s *stubCredStore) HasSecrets(context.Context) bool  { return false }
-func (s *stubCredStore) SecretCount(context.Context) int  { return 0 }
+func (s *stubCredStore) HasSecrets(context.Context) bool { return false }
+func (s *stubCredStore) SecretCount(context.Context) int { return 0 }
 func (s *stubCredStore) ListSecrets(context.Context) []string {
 	return nil
 }

--- a/pkg/sandbox/backend_pool.go
+++ b/pkg/sandbox/backend_pool.go
@@ -71,18 +71,18 @@ const backendExecTimeout = 5 * time.Minute
 // triggers the first network round-trip. Safe for concurrent Call().
 type backendNodeClient struct {
 	backend    Backend
-	sessionID  string // set by BindSession; stable after first call
-	templateID string // may be empty → backend default
+	sessionID  string   // set by BindSession; stable after first call
+	templateID string   // may be empty → backend default
 	layerChain []string // pre-resolved chain (K8s); nil → derive from templateID
-	image      string // per-template container image (OpenShell); empty → backend default
+	image      string   // per-template container image (OpenShell); empty → backend default
 	limits     ResourceLimits
 	sessionEnv map[string]string
 
-	mu         sync.Mutex
-	bound      bool          // BindSession has run
-	bindDone   chan struct{} // closed once the create/start round-trip finishes
-	bindErr    error         // captured on bindDone close
-	closed     bool          // Cleanup has run
+	mu       sync.Mutex
+	bound    bool          // BindSession has run
+	bindDone chan struct{} // closed once the create/start round-trip finishes
+	bindErr  error         // captured on bindDone close
+	closed   bool          // Cleanup has run
 	// networkAllowEndpoints are baked into OpenShell CreateSession when set
 	// before BindSession completes provisioning (see SetNetworkAllowEndpoints).
 	networkAllowEndpoints []NetworkAllowEndpoint

--- a/pkg/sandbox/internal/backendpool_test/backend_pool_test.go
+++ b/pkg/sandbox/internal/backendpool_test/backend_pool_test.go
@@ -509,4 +509,3 @@ func TestBackendPool_RemoveDropsClientWithoutDestroy(t *testing.T) {
 		t.Fatalf("CreateSessionCalls = %d, want 2 (second client provisions)", n)
 	}
 }
-

--- a/pkg/sandbox/sessioncreds/vault.go
+++ b/pkg/sandbox/sessioncreds/vault.go
@@ -174,12 +174,12 @@ func (s *Store) SetSecret(context.Context, string, string) error { return nil }
 func (s *Store) SetSecretBatch(context.Context, map[string]string) error {
 	return nil
 }
-func (s *Store) GetSecret(context.Context, string) string      { return "" }
-func (s *Store) RemoveSecret(context.Context, string) error    { return nil }
-func (s *Store) HasSecrets(context.Context) bool               { return false }
-func (s *Store) SecretCount(context.Context) int               { return 0 }
-func (s *Store) ListSecrets(context.Context) []string          { return nil }
-func (s *Store) Reload(context.Context) error                  { return nil }
+func (s *Store) GetSecret(context.Context, string) string   { return "" }
+func (s *Store) RemoveSecret(context.Context, string) error { return nil }
+func (s *Store) HasSecrets(context.Context) bool            { return false }
+func (s *Store) SecretCount(context.Context) int            { return 0 }
+func (s *Store) ListSecrets(context.Context) []string       { return nil }
+func (s *Store) Reload(context.Context) error               { return nil }
 
 func (s *Store) tokenFetcher(name string) store.OAuthTokenFetcher {
 	return func(cred *store.Credential) (string, error) {


### PR DESCRIPTION
## Summary

This PR brings the remaining `feat/scheduler-personal-fork` work back onto the current `main` branch after rebasing it over the latest upstream scheduler, sandbox, and OpenShell changes.

The branch incorporates the personal scheduler fork work and the related hardening needed for scheduled jobs to behave like interactive Studio chat runs:

- **Personal scheduler execution path**: keeps personal jobs scoped to the owning user, with the same personal-first/team-fallback credential behavior used by Studio chat and with team-only execution preserved for shared team jobs.
- **Run Now / `test_first` parity**: ensures manual scheduler executions use the same execution context as cron ticks, including credential stores, flow stores, and network-policy stores.
- **OpenShell network-policy parity**: carries the adaptive scheduler changes that pre-seed allowed network endpoints and auto-approve policy-allowed denials so headless scheduler sandboxes do not fail on hosts already allowed for chat.
- **In-sandbox credential vault support**: keeps credential resolution available to sandboxed `http_request` calls while preserving Keystone/OAuth token fetches inside the sandbox network path.
- **Adaptive scheduler sandbox hardening**: keeps adaptive scheduler sandboxes ephemeral per run and makes the sandbox client pool rebind cleanly after a destroyed sandbox.

Because several of these changes had already landed on `main` through adjacent work, this rebased PR is mostly the remaining reconciliation delta needed to make the branch mergeable without reintroducing older behavior.

## Testing

- `go test ./pkg/api ./pkg/daemon ./pkg/scheduler ./pkg/sandbox/...`
