### PR TITLE
Add memory delete tool

### DIFF
--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -260,6 +260,6 @@ The BM25 index is a pure Go implementation:
 - **Agent Engine**: Auto-knowledge retrieval queries the store before each LLM turn. Memory reflector saves knowledge after turns. ToolIndex shares the same chromem-go DB for tool discovery.
 - **Skills**: Skill documents are indexed alongside memory documents for retrieval.
 - **Flows**: Flow knowledge documents (generated during distillation) are indexed for discovery.
-- **Tools**: `memory_save`, `memory_get`, `memory_search` tools provide direct agent access to the memory system.
+- **Tools**: `memory_save`, `memory_get`, `memory_search`, and `memory_delete` tools provide direct agent access to the memory system. Deletes require an exact memory ID, target the result's tenant-scoped memory tier, and use the same creator/admin authorization path as Studio memory management.
 - **Configuration**: Embedding provider and memory directory are configured in app config.
 - **Daemon**: Memory indexer is initialized during daemon startup with fsnotify watcher for live updates.

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -66,7 +66,7 @@ Both `http_request` and `web_fetch` check resolved DNS addresses against private
 | **Git** | `git_diff_add_line_numbers` | `pkg/tools/` |
 | **HTTP** | `http_request`, `web_fetch` | `pkg/tools/` |
 | **Credentials** | `save_credential`, `list_credentials`, `remove_credential`, `test_credential`, `resolve_credential` | `pkg/tools/credential_tool.go` |
-| **Memory** | `memory_save`, `memory_search`, `memory_get` | `pkg/tools/memory_*.go` |
+| **Memory** | `memory_save`, `memory_search`, `memory_get`, `memory_delete` | `pkg/tools/memory_*.go` |
 | **Delegation** | `delegate_tasks` | `pkg/tools/delegate_tool.go` |
 | **Flows** | `search_flows`, `run_flow`, `distill_flow` | `pkg/tools/` |
 | **Scheduler** | `schedule_job`, `list_scheduled_jobs`, `remove_scheduled_job`, `update_scheduled_job` | `pkg/tools/scheduler_tool.go` |
@@ -142,6 +142,6 @@ The `search_tools` tool and the `ToolIndex` provide dynamic tool discovery:
 - **Sandbox**: `WrapToolsWithNode()` transparently proxies container tools. `ProcessRequest()` eagerly warms containers.
 - **Credentials**: `resolve_credential` returns placeholders. `http_request` uses `Resolve()` for header injection. All tool outputs pass through the Redactor.
 - **Agent Engine**: Tools are registered via `llmagent.Config.Tools`. Dynamic tool injection adds tools per-turn. BeforeToolCallback/AfterToolCallback wrap every tool call.
-- **Memory**: `memory_save/search/get` tools provide direct memory access. Tool descriptions are indexed in the ToolIndex for semantic discovery.
+- **Memory**: `memory_save/search/get/delete` tools provide direct memory access. `memory_delete` deletes by exact ID and scope through tenant-scoped stores, using the same ownership/admin authorization as Studio memory management. Tool descriptions are indexed in the ToolIndex for semantic discovery.
 - **Browser**: Browser tools run in the host process and manage a shared go-rod session. With sandbox enabled they launch Chromium+KasmVNC inside the session container and connect over CDP; sandboxed drills refuse host Chrome.
 - **Drills**: The drill runner uses a composite executor that routes different tool categories to different backends.

--- a/docs/website/docs/agent/memory.md
+++ b/docs/website/docs/agent/memory.md
@@ -9,18 +9,20 @@ Memory is curated knowledge the agent accumulates — distinct from session hist
 - **Save** facts, patterns, and solutions during conversations
 - **Search** across all accessible memory tiers before responding
 - **Retrieve** specific entries for detailed context
+- **Delete** obsolete or incorrect entries when asked
 
 Before responding, the agent automatically retrieves relevant memories based on the current conversation. This happens transparently via the knowledge retrieval system.
 
 ## Memory Tools
 
-The agent interacts with memory through three built-in tools:
+The agent interacts with memory through four built-in tools:
 
 | Tool | Description |
 |------|-------------|
 | `memory_save` | Store a new memory with content and category |
 | `memory_search` | Semantic search across stored memories |
 | `memory_get` | Retrieve full context around a specific memory entry |
+| `memory_delete` | Delete an obsolete or incorrect memory by exact ID |
 
 ### Saving Memory
 
@@ -37,6 +39,17 @@ Agent: [memory_save category="conventions" content="API uses camelCase for JSON,
 Agent: [memory_search query="API naming conventions"]
 → Returns: "API uses camelCase for JSON, snake_case for DB columns" (score: 0.92)
 ```
+
+### Deleting Memory
+
+When a memory is wrong, obsolete, or no longer wanted, the agent can search for the exact entry and delete it by ID:
+
+```
+Agent: [memory_search query="old API naming convention"]
+Agent: [memory_delete id="mem_123" scope="team"]
+```
+
+`memory_delete` targets the result's memory tier and follows the same ownership and admin permissions as Studio memory management.
 
 ## Hybrid Search
 

--- a/docs/website/docs/agent/tools/index.md
+++ b/docs/website/docs/agent/tools/index.md
@@ -13,7 +13,7 @@ Astonish provides 90+ built-in tools across multiple categories, plus unlimited 
 | [Email](./email.md) | 8 | Inbox management, send, search, wait |
 | [Credentials](./credentials.md) | 5 | Secure secret storage and retrieval |
 | [Scheduler & Agent](./scheduler-agent.md) | 10+ | Scheduling, delegation, flows, planning |
-| Memory | 3 | Save, search, retrieve memories |
+| Memory | 4 | Save, search, retrieve, and delete memories |
 | Drill & Testing | 7 | Create, validate, run test suites |
 | Fleet | 2 | Multi-agent collaboration plans |
 | Sandbox | 3 | Sandbox template management |
@@ -27,7 +27,7 @@ Every tool has a confirmation level that determines whether user approval is nee
 Safe, read-only tools that execute immediately:
 
 - `read_file`, `file_tree`, `grep_search`, `find_files`
-- `memory_save`, `memory_search`, `memory_get`
+- `memory_search`, `memory_get`
 - `skill_lookup`, `list_drills`
 - `web_fetch`, `read_pdf`
 
@@ -36,6 +36,7 @@ Safe, read-only tools that execute immediately:
 Tools that modify state or have side effects:
 
 - `write_file`, `edit_file`, `shell_command`
+- `memory_save`, `memory_delete`
 - `http_request` (POST/PUT/DELETE)
 - `email_send`, `email_reply`
 - `schedule_job`, `distill_flow`

--- a/docs/website/docs/platform/three-tier-memory.md
+++ b/docs/website/docs/platform/three-tier-memory.md
@@ -80,8 +80,9 @@ The agent interacts with memory through built-in tools:
 - **`memory_save`** — saves facts to the user's personal memory tier
 - **`memory_search`** — searches across all three tiers with RRF fusion
 - **`memory_get`** — retrieves full context around a specific memory entry
+- **`memory_delete`** — deletes a specific memory by ID from its tier when the user asks to remove obsolete or incorrect knowledge
 
-These tools are always available during chat sessions and sub-agent delegation.
+These tools are always available during chat sessions. Sub-agents can search and retrieve memory, but only the main chat agent can save or delete memories.
 
 ## Configuring Memory
 

--- a/pkg/agent/guidance_content.go
+++ b/pkg/agent/guidance_content.go
@@ -166,7 +166,7 @@ Delegation gives you **parallelism** and **context isolation**. Sub-agents run i
 
 **Call tools directly (no delegation) when:**
 - It's a single quick lookup or one-off fetch where you need the result immediately
-- Your main-thread tools (read_file, write_file, edit_file, shell_command, grep_search, find_files, memory_save, memory_search) are sufficient
+- Your main-thread tools (read_file, write_file, edit_file, shell_command, grep_search, find_files, memory_save, memory_search, memory_delete) are sufficient
 - You need the result to decide your next step before proceeding
 
 ## Task Decomposition Strategy
@@ -393,6 +393,10 @@ When you discover NEW durable facts during an interaction, save them using **mem
 **Behavior preferences:** If the user tells you to change how you behave (e.g., always use a certain tool, skip confirmations for certain operations), save that to INSTRUCTIONS.md rather than MEMORY.md.
 
 **Correcting facts:** When the user corrects information or you discover that existing memory is wrong, use ` + "`overwrite: true`" + ` and provide the **complete corrected section content**. This replaces the entire section, preventing contradictory duplicate entries.
+
+## Deleting from Memory
+
+When the user asks you to forget, remove, delete, or clean up stored memory, use **memory_delete**. First call ` + "`memory_search`" + ` to identify the exact entry, then call ` + "`memory_delete`" + ` with the result's ` + "`id`" + ` and ` + "`scope`" + `. Only delete memories the user explicitly asks to remove.
 
 **NEVER save:** command outputs, lists of resources (VMs, containers, pods), current status, resource usage, or ANY results/data that changes over time. Those MUST always be fetched live. Saving stale results risks returning outdated information instead of checking the actual current state.
 

--- a/pkg/agent/sub_agent.go
+++ b/pkg/agent/sub_agent.go
@@ -241,6 +241,7 @@ type SubAgentManager struct {
 // excludedChildTools are tools that sub-agents must NOT have access to.
 var excludedChildTools = map[string]bool{
 	"memory_save":       true, // Children can't write memory
+	"memory_delete":     true, // Children can't delete memory
 	"delegate_tasks":    true, // Prevent recursive delegation
 	"schedule_job":      true, // Children can't schedule jobs
 	"save_credential":   true, // Children can't modify credentials

--- a/pkg/agent/sub_agent_test.go
+++ b/pkg/agent/sub_agent_test.go
@@ -388,6 +388,7 @@ func TestSubAgentManager_DepthCheck(t *testing.T) {
 func TestExcludedChildTools(t *testing.T) {
 	expected := map[string]bool{
 		"memory_save":       true,
+		"memory_delete":     true,
 		"delegate_tasks":    true,
 		"schedule_job":      true,
 		"save_credential":   true,

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -1001,6 +1001,34 @@ func StudioChatHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		runner.InjectMemoryStoresWithScope(memStore, memoryScope, svc.MemorySearcher)
+		if svc.TenantRouter != nil {
+			if pu := GetPlatformUser(r); pu != nil {
+				if orgStore, err := svc.TenantRouter.ForOrg(pu.OrgSlug); err == nil {
+					runner.InjectMemoryStoresByScope(store.MemoryStoresByScope{
+						Personal: orgStore.ForUser(pu.ID).Memories(),
+						Team:     svc.Memory,
+						Org:      orgStore.OrgMemories(),
+					})
+				}
+				canDeleteTeamMemory := CanManageTeam(r, pu)
+				canDeleteOrgMemory := CanManageOrg(pu)
+				runner.InjectMemoryDeleteAuthorizer(func(_ context.Context, entry *store.MemorySearchResult, scope string) error {
+					canDelete := false
+					switch scope {
+					case string(store.MemoryScopePersonal):
+						canDelete = true
+					case string(store.MemoryScopeTeam):
+						canDelete = entry.CreatedBy == pu.ID || canDeleteTeamMemory
+					case string(store.MemoryScopeOrg):
+						canDelete = entry.CreatedBy == pu.ID || canDeleteOrgMemory
+					}
+					if canDelete {
+						return nil
+					}
+					return fmt.Errorf("permission denied: you can only delete memories you created or that you have admin access to")
+				})
+			}
+		}
 
 		// Inject the cross-session memory merge function so that memory_save
 		// performs dedup/merge instead of blind inserts. This requires the

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -180,6 +180,20 @@ func (cr *ChatRunner) InjectMemoryStoresWithScope(memStore store.MemoryStore, sc
 	}
 }
 
+// InjectMemoryStoresByScope adds all tenant-visible memory stores to the runner
+// context so memory_delete can target a result's explicit scope safely.
+func (cr *ChatRunner) InjectMemoryStoresByScope(stores store.MemoryStoresByScope) {
+	cr.ctx = store.WithMemoryStoresByScope(cr.ctx, stores)
+}
+
+// InjectMemoryDeleteAuthorizer adds a request-scoped authorization function used
+// by memory_delete before it mutates a memory store.
+func (cr *ChatRunner) InjectMemoryDeleteAuthorizer(fn store.MemoryDeleteAuthorizer) {
+	if fn != nil {
+		cr.ctx = store.WithMemoryDeleteAuthorizer(cr.ctx, fn)
+	}
+}
+
 // InjectMemorySaveOrMerge adds a cross-session memory merge function to the
 // runner's context. The memory_save tool requires this function in platform
 // mode so saves become structured cards instead of raw durable memories.

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -222,6 +222,10 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 	if searchErr == nil {
 		coreTools = append(coreTools, searchTool)
 	}
+	memoryDeleteTool, mdErr := tools.NewMemoryDeleteTool()
+	if mdErr == nil {
+		coreTools = append(coreTools, memoryDeleteTool)
+	}
 
 	// --- 2d. Initialize scheduler tools → deferred category ---
 	var schedToolsSlice []tool.Tool
@@ -758,7 +762,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 	// Split coreTools into main-thread essentials and the full "core" group
 	// for sub-agents. Main thread tools: read_file, write_file, edit_file,
 	// shell_command, grep_search, find_files, memory_save, memory_search,
-	// delegate_tasks, resolve_credential, skill_lookup.
+	// memory_delete, delegate_tasks, resolve_credential, skill_lookup.
 	mainThreadToolNames := map[string]bool{
 		"read_file":          true,
 		"write_file":         true,
@@ -768,6 +772,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		"find_files":         true,
 		"memory_save":        true,
 		"memory_search":      true,
+		"memory_delete":      true,
 		"delegate_tasks":     true,
 		"announce_plan":      true,
 		"resolve_credential": true,

--- a/pkg/store/context.go
+++ b/pkg/store/context.go
@@ -12,6 +12,8 @@ const credStoreKey contextKey = "astonish_credential_store"
 const memoryStoreKey contextKey = "astonish_memory_store"
 const memoryScopeKey contextKey = "astonish_memory_scope"
 const memorySearcherKey contextKey = "astonish_memory_searcher"
+const memoryStoresByScopeKey contextKey = "astonish_memory_stores_by_scope"
+const memoryDeleteAuthorizerKey contextKey = "astonish_memory_delete_authorizer"
 const flowStoreKey contextKey = "astonish_flow_store"
 const teamFlowStoreKey contextKey = "astonish_team_flow_store"
 const drillReportStoreKey contextKey = "astonish_drill_report_store"
@@ -104,6 +106,47 @@ func WithThreeTierSearcher(ctx context.Context, ts ThreeTierSearcher) context.Co
 func ThreeTierSearcherFromContext(ctx context.Context) ThreeTierSearcher {
 	ts, _ := ctx.Value(memorySearcherKey).(ThreeTierSearcher)
 	return ts
+}
+
+// MemoryStoresByScope groups the writable memory stores available to the
+// current tenant context. Tools use this to target a specific memory tier by ID
+// without bypassing tenant routing.
+type MemoryStoresByScope struct {
+	Personal MemoryStore
+	Team     MemoryStore
+	Org      MemoryStore
+}
+
+// WithMemoryStoresByScope returns a new context containing per-scope memory stores.
+func WithMemoryStoresByScope(ctx context.Context, stores MemoryStoresByScope) context.Context {
+	return context.WithValue(ctx, memoryStoresByScopeKey, stores)
+}
+
+// MemoryStoresByScopeFromContext retrieves per-scope memory stores from context.
+func MemoryStoresByScopeFromContext(ctx context.Context) (MemoryStoresByScope, bool) {
+	if ctx == nil {
+		return MemoryStoresByScope{}, false
+	}
+	stores, ok := ctx.Value(memoryStoresByScopeKey).(MemoryStoresByScope)
+	return stores, ok
+}
+
+// MemoryDeleteAuthorizer checks whether the current caller may delete a memory
+// from the requested scope.
+type MemoryDeleteAuthorizer func(ctx context.Context, entry *MemorySearchResult, scope string) error
+
+// WithMemoryDeleteAuthorizer returns a new context containing a memory delete authorization function.
+func WithMemoryDeleteAuthorizer(ctx context.Context, fn MemoryDeleteAuthorizer) context.Context {
+	return context.WithValue(ctx, memoryDeleteAuthorizerKey, fn)
+}
+
+// MemoryDeleteAuthorizerFromContext retrieves the memory delete authorizer from context.
+func MemoryDeleteAuthorizerFromContext(ctx context.Context) MemoryDeleteAuthorizer {
+	if ctx == nil {
+		return nil
+	}
+	fn, _ := ctx.Value(memoryDeleteAuthorizerKey).(MemoryDeleteAuthorizer)
+	return fn
 }
 
 // WithFlowStore returns a new context containing a tenant-scoped FlowStore.

--- a/pkg/tools/declarations.go
+++ b/pkg/tools/declarations.go
@@ -44,7 +44,7 @@ func GetAllFlowToolDeclarations() []ToolDeclaration {
 	// Fleet tools (2)
 	decls = append(decls, fleetToolDeclarations()...)
 
-	// Memory tools (3)
+	// Memory tools (4)
 	decls = append(decls, memoryToolDeclarations()...)
 
 	// Skill lookup tool (1)
@@ -210,6 +210,7 @@ func memoryToolDeclarations() []ToolDeclaration {
 		{Name: "memory_save", Description: "Save durable facts to persistent memory", Category: "memory"},
 		{Name: "memory_search", Description: "Search memory for relevant knowledge", Category: "memory"},
 		{Name: "memory_get", Description: "Read full memory file content by path", Category: "memory"},
+		{Name: "memory_delete", Description: "Delete an existing memory by exact ID", Category: "memory"},
 	}
 }
 

--- a/pkg/tools/memory_delete.go
+++ b/pkg/tools/memory_delete.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SAP/astonish/pkg/store"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// MemoryDeleteArgs defines the arguments for the memory_delete tool.
+type MemoryDeleteArgs struct {
+	ID    string `json:"id" jsonschema:"The exact memory ID to delete. Get this from memory_search results."`
+	Scope string `json:"scope,omitempty" jsonschema:"Memory tier containing the ID: personal, team, or org. Use the scope from memory_search results when available. Defaults to the current save tier."`
+}
+
+// MemoryDeleteResult is returned after deleting a memory.
+type MemoryDeleteResult struct {
+	Deleted bool   `json:"deleted"`
+	ID      string `json:"id,omitempty"`
+	Scope   string `json:"scope,omitempty"`
+	Message string `json:"message"`
+}
+
+// MemoryDelete creates the memory_delete handler. In platform mode it routes to
+// the tenant-scoped memory store from the tool context.
+func MemoryDelete() func(ctx tool.Context, args MemoryDeleteArgs) (MemoryDeleteResult, error) {
+	return func(ctx tool.Context, args MemoryDeleteArgs) (MemoryDeleteResult, error) {
+		if strings.TrimSpace(args.ID) == "" {
+			return MemoryDeleteResult{}, fmt.Errorf("id is required")
+		}
+
+		return platformMemoryDeleteWithExplicitStore(ctx, args, nil)
+	}
+}
+
+func memoryStoreForDeleteScope(ctx tool.Context, scope string) store.MemoryStore {
+	if stores, ok := store.MemoryStoresByScopeFromContext(ctx); ok {
+		switch scope {
+		case string(store.MemoryScopePersonal):
+			return stores.Personal
+		case string(store.MemoryScopeTeam):
+			return stores.Team
+		case string(store.MemoryScopeOrg):
+			return stores.Org
+		}
+	}
+	if activeScope := store.MemoryScopeFromContext(ctx); activeScope == "" || scope == string(activeScope) {
+		return store.MemoryStoreFromContext(ctx)
+	}
+	return nil
+}
+
+func platformMemoryDeleteWithExplicitStore(ctx tool.Context, args MemoryDeleteArgs, memStore store.MemoryStore) (MemoryDeleteResult, error) {
+	id := strings.TrimSpace(args.ID)
+	scope := strings.TrimSpace(strings.ToLower(args.Scope))
+	if scope == "" {
+		scope = string(store.MemoryScopeFromContext(ctx))
+	}
+	if scope == "" {
+		scope = string(store.MemoryScopeTeam)
+	}
+	if scope != string(store.MemoryScopePersonal) && scope != string(store.MemoryScopeTeam) && scope != string(store.MemoryScopeOrg) {
+		return MemoryDeleteResult{}, fmt.Errorf("invalid scope %q: must be personal, team, or org", args.Scope)
+	}
+
+	if memStore == nil {
+		memStore = memoryStoreForDeleteScope(ctx, scope)
+	}
+	if memStore == nil {
+		return MemoryDeleteResult{
+			Deleted: false,
+			ID:      id,
+			Scope:   scope,
+			Message: "Memory delete is not available for that scope.",
+		}, nil
+	}
+
+	existing, err := memStore.Get(ctx, id)
+	if err != nil {
+		return MemoryDeleteResult{}, fmt.Errorf("failed to get memory: %w", err)
+	}
+	if existing == nil {
+		return MemoryDeleteResult{
+			Deleted: false,
+			ID:      id,
+			Scope:   scope,
+			Message: "Memory not found.",
+		}, nil
+	}
+
+	if authorizer := store.MemoryDeleteAuthorizerFromContext(ctx); authorizer != nil {
+		if err := authorizer(ctx, existing, scope); err != nil {
+			return MemoryDeleteResult{}, err
+		}
+	} else if createdBy := strings.TrimSpace(existing.CreatedBy); createdBy != "" {
+		userID := store.UserIDFromContext(ctx)
+		if userID == "" || createdBy != userID {
+			return MemoryDeleteResult{}, fmt.Errorf("permission denied: memory was created by a different user")
+		}
+	}
+
+	if err := memStore.Delete(ctx, id); err != nil {
+		return MemoryDeleteResult{}, fmt.Errorf("failed to delete memory: %w", err)
+	}
+
+	return MemoryDeleteResult{
+		Deleted: true,
+		ID:      id,
+		Scope:   scope,
+		Message: fmt.Sprintf("Deleted memory %s from %s memory.", id, scope),
+	}, nil
+}
+
+// PlatformMemoryDelete deletes a memory using the store.MemoryStore interface.
+func PlatformMemoryDelete(memStore store.MemoryStore) func(ctx tool.Context, args MemoryDeleteArgs) (MemoryDeleteResult, error) {
+	return func(ctx tool.Context, args MemoryDeleteArgs) (MemoryDeleteResult, error) {
+		if strings.TrimSpace(args.ID) == "" {
+			return MemoryDeleteResult{}, fmt.Errorf("id is required")
+		}
+		if memStore == nil {
+			return MemoryDeleteResult{
+				Deleted: false,
+				Message: "Memory delete is not available.",
+			}, nil
+		}
+		return platformMemoryDeleteWithExplicitStore(ctx, args, memStore)
+	}
+}
+
+// NewMemoryDeleteTool creates the memory_delete tool.
+// In platform mode, the tool checks the context for a PG-backed MemoryStore
+// injected by ChatRunner.InjectMemoryStoresWithScope and deletes there.
+func NewMemoryDeleteTool() (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name: "memory_delete",
+		Description: "Delete an existing memory by exact ID. Use memory_search first to find the ID and scope. " +
+			"Only delete memories the user explicitly asks to remove or clearly identifies as obsolete or incorrect. " +
+			"Deletion targets the result's memory tier when scope is provided.",
+	}, MemoryDelete())
+}
+
+// NewPlatformMemoryDeleteTool creates the memory_delete tool for platform mode.
+func NewPlatformMemoryDeleteTool(memStore store.MemoryStore) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name: "memory_delete",
+		Description: "Delete an existing memory by exact ID. Use memory_search first to find the ID and scope. " +
+			"Only delete memories the user explicitly asks to remove or clearly identifies as obsolete or incorrect.",
+	}, PlatformMemoryDelete(memStore))
+}

--- a/pkg/tools/memory_delete_test.go
+++ b/pkg/tools/memory_delete_test.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/store"
+)
+
+type memoryDeleteFakeStore struct {
+	entries   map[string]*store.MemorySearchResult
+	deletedID string
+	deleteErr error
+}
+
+func (m *memoryDeleteFakeStore) Search(context.Context, string, int, float64) ([]store.MemorySearchResult, error) {
+	return nil, nil
+}
+
+func (m *memoryDeleteFakeStore) SearchByCategory(context.Context, string, int, float64, string) ([]store.MemorySearchResult, error) {
+	return nil, nil
+}
+
+func (m *memoryDeleteFakeStore) Add(context.Context, store.MemoryEntry) error { return nil }
+
+func (m *memoryDeleteFakeStore) Get(_ context.Context, id string) (*store.MemorySearchResult, error) {
+	if m.entries == nil {
+		return nil, nil
+	}
+	return m.entries[id], nil
+}
+
+func (m *memoryDeleteFakeStore) Update(context.Context, string, string, string) error { return nil }
+
+func (m *memoryDeleteFakeStore) Delete(_ context.Context, id string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deletedID = id
+	delete(m.entries, id)
+	return nil
+}
+
+func (m *memoryDeleteFakeStore) List(context.Context, string, int, int) ([]store.MemorySearchResult, error) {
+	return nil, nil
+}
+
+func (m *memoryDeleteFakeStore) ListBySession(context.Context, string) ([]store.MemorySearchResult, error) {
+	return nil, nil
+}
+
+func (m *memoryDeleteFakeStore) Count() int   { return len(m.entries) }
+func (m *memoryDeleteFakeStore) Close() error { return nil }
+
+func TestMemoryDeleteDeletesOwnedMemory(t *testing.T) {
+	fake := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{
+		"mem-1": {ID: "mem-1", CreatedBy: "user-1", Scope: "team"},
+	}}
+	ctx := &memorySearchToolCtx{Context: store.WithUserID(
+		store.WithMemoryScope(store.WithMemoryStore(context.Background(), fake), store.MemoryScopeTeam),
+		"user-1",
+	)}
+
+	result, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "mem-1", Scope: "team"})
+	if err != nil {
+		t.Fatalf("MemoryDelete failed: %v", err)
+	}
+	if !result.Deleted || result.ID != "mem-1" || result.Scope != "team" {
+		t.Fatalf("result = %#v, want deleted mem-1 from team", result)
+	}
+	if fake.deletedID != "mem-1" {
+		t.Fatalf("deletedID = %q, want mem-1", fake.deletedID)
+	}
+}
+
+func TestMemoryDeleteRejectsAuthorizerDenial(t *testing.T) {
+	fake := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{
+		"mem-1": {ID: "mem-1", CreatedBy: "user-1", Scope: "team"},
+	}}
+	ctx := &memorySearchToolCtx{Context: store.WithMemoryDeleteAuthorizer(
+		store.WithMemoryScope(store.WithMemoryStore(context.Background(), fake), store.MemoryScopeTeam),
+		func(context.Context, *store.MemorySearchResult, string) error {
+			return errors.New("permission denied by policy")
+		},
+	)}
+
+	_, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "mem-1", Scope: "team"})
+	if err == nil || !strings.Contains(err.Error(), "permission denied by policy") {
+		t.Fatalf("err = %v, want authorizer denial", err)
+	}
+	if fake.deletedID != "" {
+		t.Fatalf("deletedID = %q, want no delete", fake.deletedID)
+	}
+}
+
+func TestMemoryDeleteRejectsDifferentCreatorWithoutAuthorizer(t *testing.T) {
+	fake := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{
+		"mem-1": {ID: "mem-1", CreatedBy: "user-2", Scope: "team"},
+	}}
+	ctx := &memorySearchToolCtx{Context: store.WithUserID(
+		store.WithMemoryScope(store.WithMemoryStore(context.Background(), fake), store.MemoryScopeTeam),
+		"user-1",
+	)}
+
+	_, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "mem-1", Scope: "team"})
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("err = %v, want permission denied", err)
+	}
+	if fake.deletedID != "" {
+		t.Fatalf("deletedID = %q, want no delete", fake.deletedID)
+	}
+}
+
+func TestMemoryDeleteDeletesExplicitScopeStore(t *testing.T) {
+	personal := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{}}
+	team := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{
+		"mem-1": {ID: "mem-1", CreatedBy: "user-1", Scope: "team"},
+	}}
+	ctx := &memorySearchToolCtx{Context: store.WithUserID(
+		store.WithMemoryScope(
+			store.WithMemoryStoresByScope(context.Background(), store.MemoryStoresByScope{Personal: personal, Team: team}),
+			store.MemoryScopePersonal,
+		),
+		"user-1",
+	)}
+
+	result, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "mem-1", Scope: "team"})
+	if err != nil {
+		t.Fatalf("MemoryDelete failed: %v", err)
+	}
+	if !result.Deleted || team.deletedID != "mem-1" || personal.deletedID != "" {
+		t.Fatalf("result = %#v, team deleted = %q, personal deleted = %q", result, team.deletedID, personal.deletedID)
+	}
+}
+
+func TestMemoryDeleteNotFound(t *testing.T) {
+	fake := &memoryDeleteFakeStore{entries: map[string]*store.MemorySearchResult{}}
+	ctx := &memorySearchToolCtx{Context: store.WithMemoryScope(store.WithMemoryStore(context.Background(), fake), store.MemoryScopeTeam)}
+
+	result, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "missing"})
+	if err != nil {
+		t.Fatalf("MemoryDelete failed: %v", err)
+	}
+	if result.Deleted || result.Message != "Memory not found." {
+		t.Fatalf("result = %#v, want not found without delete", result)
+	}
+}
+
+func TestMemoryDeletePropagatesDeleteError(t *testing.T) {
+	fake := &memoryDeleteFakeStore{
+		entries:   map[string]*store.MemorySearchResult{"mem-1": {ID: "mem-1", CreatedBy: "user-1"}},
+		deleteErr: errors.New("database unavailable"),
+	}
+	ctx := &memorySearchToolCtx{Context: store.WithUserID(store.WithMemoryStore(context.Background(), fake), "user-1")}
+
+	_, err := MemoryDelete()(ctx, MemoryDeleteArgs{ID: "mem-1"})
+	if err == nil || !strings.Contains(err.Error(), "database unavailable") {
+		t.Fatalf("err = %v, want wrapped delete error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a main-thread memory_delete tool that deletes memories by exact ID and scope.
- Route deletes through tenant-scoped memory stores with request-scoped authorization for personal, team, and org memory.
- Keep sub-agents from mutating memory and update docs/guidance for the new tool.

## Tests
- go test ./pkg/agent ./pkg/tools ./pkg/store ./pkg/api ./pkg/launcher