### PR TITLE
fix: apply platform web search to every chat request

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,9 @@ docs/website/build
 docs/website/.docusaurus
 
 # Local binaries and test artifacts.
-# Keep astonish-linux-* in context: docker/incus, docker/astonish, and
-# docker/sandbox-openshell COPY the host-cross-compiled binaries.
+# Keep astonish-linux-* and astonish-sandbox-entrypoint in context:
+# docker/incus, docker/astonish, docker/sandbox-base, and
+# docker/sandbox-openshell COPY the host-built artifacts.
 astonish
 astonish_bin
 test_bin
@@ -29,6 +30,7 @@ bin/
 *.out
 coverage.html
 recordings/
+.buildx-cache
 
 # Env / secrets / local state
 .env

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -369,6 +369,30 @@ jobs:
           npm ci
           npm run build
 
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Cross-compile Linux binaries and entrypoint
+        env:
+          VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          LDFLAGS="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=${VERSION_TAG}"
+
+          echo "Building linux/amd64..."
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-amd64 .
+
+          echo "Building linux/arm64..."
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-arm64 .
+
+          echo "Generating sandbox entrypoint..."
+          go run ./cmd/astonish-sandbox-entrypoint-script > astonish-sandbox-entrypoint
+          chmod +x astonish-sandbox-entrypoint
+          head -1 astonish-sandbox-entrypoint | grep -q '^#!/bin/sh'
+
+          ls -la astonish-linux-* astonish-sandbox-entrypoint
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -248,8 +248,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/sap/astonish:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/sap/astonish:buildcache,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -42,8 +42,9 @@ jobs:
           fi
 
   # --------------------------------------------------------------------------
-  # Build and push ghcr.io/sap/astonish (multi-arch)
-  # Uses the multi-stage Dockerfile which handles cross-compilation internally
+  # Build and push ghcr.io/sap/astonish (multi-arch).
+  # Host-cross-compiles Go binaries on the runner; Dockerfile only installs
+  # slim runtime deps (Node/uv via multi-stage COPY) and COPYs the binary.
   # --------------------------------------------------------------------------
   build-astonish:
     name: Build and push astonish
@@ -128,8 +129,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/sap/astonish:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/sap/astonish:buildcache,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -233,10 +233,10 @@ jobs:
           push-to-registry: true
 
   # --------------------------------------------------------------------------
-  # Build and push ghcr.io/sap/astonish-sandbox-base (multi-arch)
-  # Uses the multi-stage docker/sandbox-base/Dockerfile which compiles the
-  # entrypoint script generator and astonish binary internally, then produces
-  # a minimal Debian-slim runtime image with fuse-overlayfs.
+  # Build and push ghcr.io/sap/astonish-sandbox-base (multi-arch).
+  # Host-cross-compiles the agent binary + generates the entrypoint script;
+  # the Dockerfile only installs apt packages, builds treesitter, and COPY
+  # those artifacts — so apt/treesitter layers stay cached across code edits.
   # --------------------------------------------------------------------------
   build-sandbox-base:
     name: Build and push astonish-sandbox-base
@@ -265,6 +265,30 @@ jobs:
           cd web
           npm ci
           npm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Cross-compile Linux binaries and entrypoint
+        env:
+          VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          LDFLAGS="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=${VERSION_TAG}"
+
+          echo "Building linux/amd64..."
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-amd64 .
+
+          echo "Building linux/arm64..."
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o astonish-linux-arm64 .
+
+          echo "Generating sandbox entrypoint..."
+          go run ./cmd/astonish-sandbox-entrypoint-script > astonish-sandbox-entrypoint
+          chmod +x astonish-sandbox-entrypoint
+          head -1 astonish-sandbox-entrypoint | grep -q '^#!/bin/sh'
+
+          ls -la astonish-linux-* astonish-sandbox-entrypoint
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ go.work
 ./test_bin
 bin/
 astonish-linux-*
+astonish-sandbox-entrypoint
+.buildx-cache/
 
 # macOS specific files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ help:
 	@echo "Sandbox (Docker+Incus for macOS/Windows):"
 	@echo "  make build-linux       - Cross-compile Linux amd64 binary"
 	@echo "  make build-linux-arm64 - Cross-compile Linux arm64 binary"
+	@echo "  make sandbox-entrypoint - Generate astonish-sandbox-entrypoint script (host)"
 	@echo "  make docker-incus      - Build+LOAD local Incus image (native arch; tags :$(VERSION) and :latest when VERSION=dev)"
+	@echo "  make docker-sandbox-base - Build+LOAD local sandbox-base image (native arch)"
 	@echo ""
 	@echo "OpenShell Sandbox:"
 	@echo "  make docker-sandbox-openshell - Build the OpenShell sandbox image"
@@ -534,7 +536,7 @@ install: build-all
 clean:
 	@echo "Cleaning up build artifacts..."
 	rm -rf $(BINARY_NAME)
-	rm -f astonish-linux-amd64 astonish-linux-arm64
+	rm -f astonish-linux-amd64 astonish-linux-arm64 astonish-sandbox-entrypoint
 	rm -rf $(WEB_DIR)/dist
 	rm -rf $(WEB_DIR)/node_modules
 	@echo "Cleanup complete!"
@@ -545,7 +547,7 @@ update-mcp-stars:
 	GITHUB_TOKEN=$$(gh auth token) python3 scripts/update-mcp-stars.py
 	@echo "Star counts updated!"
 
-.PHONY: all help build build-ui build-all run studio studio-dev test test-unit test-integration test-e2e test-e2e-sqlite test-e2e-inspect test-e2e-inspect-stop e2e-k8s-up e2e-k8s-down install clean update-mcp-stars setup-hooks platform-init create-secrets e2e-env-up e2e-env-down e2e-env-rebuild docker-up docker-down docker-rebuild build-linux build-linux-arm64 docker-incus docker-sandbox-openshell ensure-builder push-dev push-incus-dev push-sandbox-base-dev push-sandbox-openshell-dev push-all-dev push-dev-fast push-sandbox-base-dev-fast push-incus-dev-fast push-sandbox-openshell-dev-fast push-all-dev-fast ent-generate proto-gen
+.PHONY: all help build build-ui build-all run studio studio-dev test test-unit test-integration test-e2e test-e2e-sqlite test-e2e-inspect test-e2e-inspect-stop e2e-k8s-up e2e-k8s-down install clean update-mcp-stars setup-hooks platform-init create-secrets e2e-env-up e2e-env-down e2e-env-rebuild docker-up docker-down docker-rebuild build-linux build-linux-arm64 sandbox-entrypoint docker-incus docker-sandbox-base docker-sandbox-openshell ensure-builder push-dev push-incus-dev push-sandbox-base-dev push-sandbox-openshell-dev push-all-dev push-dev-fast push-sandbox-base-dev-fast push-incus-dev-fast push-sandbox-openshell-dev-fast push-all-dev-fast ent-generate proto-gen
 
 # Docker Test Environment - isolated environment for running integration/E2E tests
 e2e-env-up:
@@ -614,13 +616,25 @@ endif
 # Cross-compile Linux binary (for macOS/Windows dev pushing into sandbox containers)
 build-linux:
 	@echo "Cross-compiling Linux amd64 binary..."
+	@# go:embed requires web/dist; create a placeholder tree if the UI has not been built.
+	@mkdir -p $(WEB_DIR)/dist
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=$(VERSION)" -o astonish-linux-amd64 .
 	@echo "Linux binary built: astonish-linux-amd64"
 
 build-linux-arm64:
 	@echo "Cross-compiling Linux arm64 binary..."
+	@mkdir -p $(WEB_DIR)/dist
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=$(VERSION)" -o astonish-linux-arm64 .
 	@echo "Linux binary built: astonish-linux-arm64"
+
+# Emit the K8s sandbox PID-1 entrypoint script to the repo root for COPY into
+# docker/sandbox-base. Host-side so the image build does not run a Go toolchain.
+sandbox-entrypoint:
+	@echo "Generating astonish-sandbox-entrypoint..."
+	go run ./cmd/astonish-sandbox-entrypoint-script > astonish-sandbox-entrypoint
+	@chmod +x astonish-sandbox-entrypoint
+	@head -1 astonish-sandbox-entrypoint | grep -q '^#!/bin/sh'
+	@echo "Wrote astonish-sandbox-entrypoint"
 
 # Generate Go gRPC stubs from vendored NVIDIA OpenShell proto files
 proto-gen:
@@ -667,6 +681,22 @@ docker-incus:
 	fi
 	@echo "Next: docker rm -f astonish-incus && ./astonish sandbox refresh --force  (then new chat session)"
 
+# Build the K8s sandbox-base image locally (native arch). Host-builds the
+# binary + entrypoint so Docker only layers apt/treesitter + COPY.
+docker-sandbox-base: sandbox-entrypoint
+	@if [ "$(DEV_ARCH)" = "arm64" ]; then \
+		$(MAKE) build-linux-arm64; \
+	else \
+		$(MAKE) build-linux; \
+	fi
+	@echo "Building sandbox-base image (linux/$(DEV_ARCH))..."
+	docker buildx build \
+		--platform linux/$(DEV_ARCH) \
+		-f docker/sandbox-base/Dockerfile \
+		-t $(DOCKER_REGISTRY)/astonish-sandbox-base:$(VERSION) \
+		--load .
+	@echo "Image built: $(DOCKER_REGISTRY)/astonish-sandbox-base:$(VERSION)"
+
 # Build the OpenShell sandbox image (NVIDIA sandbox base + Astonish agent tools)
 docker-sandbox-openshell: build-linux
 	@echo "Building OpenShell sandbox image..."
@@ -702,13 +732,17 @@ push-incus-dev: ensure-builder build-linux build-linux-arm64
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish-incus:$(DEV_TAG)"
 
 # Build and push the sandbox base image (multi-arch).
-# Cross-compiles Go inside the Dockerfile on $BUILDPLATFORM (avoids QEMU Go 1.26 panics).
-# Requires web/dist/ for go:embed (run `make build-ui` first if missing).
-push-sandbox-base-dev: ensure-builder
+# Host-cross-compiles both arches + generates the entrypoint, then Docker only
+# runs apt + treesitter + COPY (stable layers cache across code edits).
+# Requires web/dist/ for go:embed (mkdir placeholder is enough for sandbox; full UI optional).
+push-sandbox-base-dev: ensure-builder build-linux build-linux-arm64 sandbox-entrypoint
 	@echo "Building and pushing $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG) (linux/amd64,linux/arm64)..."
+	@mkdir -p .buildx-cache/sandbox-base
 	docker buildx build --platform linux/amd64,linux/arm64 \
 		-f docker/sandbox-base/Dockerfile \
 		-t $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG) \
+		--cache-from type=local,src=.buildx-cache/sandbox-base \
+		--cache-to type=local,dest=.buildx-cache/sandbox-base,mode=max \
 		--push .
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG)"
 
@@ -739,11 +773,19 @@ push-dev-fast: ensure-builder build-linux build-linux-arm64
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish:$(DEV_TAG)"
 
 # Fast: build and push sandbox base image (single arch)
-push-sandbox-base-dev-fast: ensure-builder
+push-sandbox-base-dev-fast: ensure-builder sandbox-entrypoint
+	@if [ "$(DEV_ARCH)" = "arm64" ]; then \
+		$(MAKE) build-linux-arm64; \
+	else \
+		$(MAKE) build-linux; \
+	fi
 	@echo "Building and pushing $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG) (linux/$(DEV_ARCH) only)..."
+	@mkdir -p .buildx-cache/sandbox-base
 	docker buildx build --platform linux/$(DEV_ARCH) \
 		-f docker/sandbox-base/Dockerfile \
 		-t $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG) \
+		--cache-from type=local,src=.buildx-cache/sandbox-base \
+		--cache-to type=local,dest=.buildx-cache/sandbox-base,mode=max \
 		--push .
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish-sandbox-base:$(DEV_TAG)"
 

--- a/Makefile
+++ b/Makefile
@@ -715,9 +715,12 @@ ensure-builder:
 # Cross-compiles Go on the host to avoid QEMU segfaults with Go 1.26.
 push-dev: ensure-builder build-linux build-linux-arm64
 	@echo "Building and pushing $(DOCKER_REGISTRY)/astonish:$(DEV_TAG) (linux/amd64,linux/arm64)..."
+	@mkdir -p .buildx-cache/astonish
 	docker buildx build --platform linux/amd64,linux/arm64 \
 		-f docker/astonish/Dockerfile \
 		-t $(DOCKER_REGISTRY)/astonish:$(DEV_TAG) \
+		--cache-from type=local,src=.buildx-cache/astonish \
+		--cache-to type=local,dest=.buildx-cache/astonish,mode=max \
 		--push .
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish:$(DEV_TAG)"
 
@@ -764,11 +767,19 @@ push-all-dev: push-dev push-incus-dev push-sandbox-base-dev push-sandbox-openshe
 # DEV_ARCH is defined near the top of this Makefile.
 
 # Fast: build and push main Astonish API image (single arch)
-push-dev-fast: ensure-builder build-linux build-linux-arm64
+push-dev-fast: ensure-builder
+	@if [ "$(DEV_ARCH)" = "arm64" ]; then \
+		$(MAKE) build-linux-arm64; \
+	else \
+		$(MAKE) build-linux; \
+	fi
 	@echo "Building and pushing $(DOCKER_REGISTRY)/astonish:$(DEV_TAG) (linux/$(DEV_ARCH) only)..."
+	@mkdir -p .buildx-cache/astonish
 	docker buildx build --platform linux/$(DEV_ARCH) \
 		-f docker/astonish/Dockerfile \
 		-t $(DOCKER_REGISTRY)/astonish:$(DEV_TAG) \
+		--cache-from type=local,src=.buildx-cache/astonish \
+		--cache-to type=local,dest=.buildx-cache/astonish,mode=max \
 		--push .
 	@echo "Pushed: $(DOCKER_REGISTRY)/astonish:$(DEV_TAG)"
 

--- a/cmd/astonish-sandbox-entrypoint-script/main.go
+++ b/cmd/astonish-sandbox-entrypoint-script/main.go
@@ -3,15 +3,16 @@
 //
 // The script is the PID-1 entrypoint for sandbox pods in the K8s+Sysbox
 // backend. Its source of truth lives in pkg/sandbox/k8s.EntrypointScript;
-// this command exists so image builders (docker/sandbox-base/Dockerfile
-// and CI) can generate the script deterministically without invoking
-// the main astonish binary, which would pull in the full server + UI.
+// this command exists so image builders can generate the script
+// deterministically without invoking the main astonish binary, which
+// would pull in the full server + UI.
 //
-// Usage (Dockerfile):
+// Usage (host / Makefile — preferred; keeps Docker layers cacheable):
 //
-//	RUN go run ./cmd/astonish-sandbox-entrypoint-script \
-//	    > /usr/local/bin/astonish-sandbox-entrypoint && \
-//	    chmod +x /usr/local/bin/astonish-sandbox-entrypoint
+//	make sandbox-entrypoint
+//	# writes ./astonish-sandbox-entrypoint for COPY into docker/sandbox-base
+//
+//	go run ./cmd/astonish-sandbox-entrypoint-script > astonish-sandbox-entrypoint
 //
 // The emitted script is parameterised ONLY by the defaults baked into
 // EntrypointScriptOptions.applyDefaults; re-running with a different

--- a/cmd/astonish-sandbox-entrypoint-script/main_test.go
+++ b/cmd/astonish-sandbox-entrypoint-script/main_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 )
 
-// TestRun_EmitsCanonicalScript locks in the shape that the Dockerfile
-// step depends on: the emitted bytes must begin with the POSIX shebang
-// and contain the well-known entrypoint sentinels so a broken defaults
-// change is caught before it ships to the base image.
+// TestRun_EmitsCanonicalScript locks in the shape that the host-side
+// `make sandbox-entrypoint` step depends on: the emitted bytes must
+// begin with the POSIX shebang and contain the well-known entrypoint
+// sentinels so a broken defaults change is caught before it ships to
+// the base image.
 func TestRun_EmitsCanonicalScript(t *testing.T) {
 	var buf bytes.Buffer
 	if err := run(&buf); err != nil {

--- a/docker/astonish/Dockerfile
+++ b/docker/astonish/Dockerfile
@@ -1,34 +1,67 @@
-# Astonish Docker image
+# Astonish Docker image (API / Studio daemon)
 #
-# Go binaries are cross-compiled on the host (no QEMU needed) and copied in.
+# Go binaries are cross-compiled on the host (or CI runner) and copied in.
 # This avoids Go 1.26 segfaults when running `go mod download` under QEMU
-# user-mode emulation on Apple Silicon Macs.
+# user-mode emulation on multi-arch buildx (arm64 on amd64 runners and vice
+# versa).
 #
 # Base must be glibc (Debian), not Alpine/musl: pkg/codeintel uses purego.Dlopen,
 # which produces a dynamically linked binary needing /lib64/ld-linux-*.so.2.
 #
-# Build (multi-arch, from Makefile):
+# Runtime tooling for host-side MCP (npx / uvx when no sandbox is wired):
+#   - Node.js + npx: copied from the official multi-arch Node image (prebuilt
+#     layers — no apt install of nodejs/npm under QEMU on arm64 CI builds).
+#   - uv + uvx: copied from the official astral-sh/uv multi-arch image.
+#   - git + ca-certificates: minimal apt (small under QEMU).
+#
+# Layer order (stable → volatile) so code-only rebuilds cache deps:
+#   1. minimal apt
+#   2. node + uv binaries
+#   3. COPY astonish-linux-${TARGETARCH}
+#
+# Pins — bump intentionally; changing them invalidates the deps layers.
+#   NODE_IMAGE  node:22-bookworm-slim
+#   UV_VERSION  0.12.1  (ghcr.io/astral-sh/uv tag)
+#
+# Build (multi-arch, from Makefile / CI):
 #   make push-dev   # cross-compiles both arch binaries, then buildx pushes
 #
 # Build (single-arch, local dev):
 #   make push-dev-fast
 
+# Global build args used by FROM lines (must appear before the first FROM).
+# Buildx multi-arch builds select the matching platform variant of each image
+# automatically (no need for explicit --platform=$TARGETPLATFORM on FROM).
+ARG NODE_IMAGE=node:22-bookworm-slim
+ARG UV_VERSION=0.12.1
+
+# Prebuilt Node toolchain (multi-arch official image).
+FROM ${NODE_IMAGE} AS node
+
+# Prebuilt uv/uvx binaries (multi-arch official image).
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install certificates, Node.js (includes npx), Python3, uv (includes uvx), and git
+# Minimal system packages only — avoid apt nodejs/npm/python3-pip (slow under
+# QEMU on GitHub Actions multi-arch arm64 and inflate the image).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        nodejs \
-        npm \
-        python3 \
-        python3-pip \
         git \
-    && pip3 install uv --break-system-packages \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Official Node layout: binaries and npm/npx under /usr/local.
+COPY --from=node /usr/local /usr/local
+
+# Official uv distroless image ships /uv and /uvx at the image root.
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+# Fail the build early if a platform mismatch shipped the wrong arch binary.
+RUN node --version && npx --version && uv --version && uvx --version && git --version
 
 WORKDIR /app
 
@@ -40,9 +73,7 @@ ARG TARGETARCH
 COPY astonish-linux-${TARGETARCH} /usr/local/bin/astonish
 RUN chmod +x /usr/local/bin/astonish
 
-# Expose default port
 EXPOSE 9393
 
-# Set default entrypoint
 ENTRYPOINT ["astonish"]
 CMD ["daemon", "run"]

--- a/docker/sandbox-base/Dockerfile
+++ b/docker/sandbox-base/Dockerfile
@@ -2,52 +2,56 @@
 #
 # This is the container image every Astonish sandbox pod runs in when
 # the K8s backend is active (SandboxConfig.Backend = "k8s"). It is NOT
-# the application image (see top-level Dockerfile for that); it's a
+# the application image (see docker/astonish/Dockerfile for that); it's a
 # minimal userland that serves as PID 1 inside the sandbox pod.
 #
 # The image contains, and is RESTRICTED to:
 #
 #   1. /usr/local/bin/astonish-sandbox-entrypoint
 #        The POSIX-shell script whose source of truth is
-#        pkg/sandbox/k8s.EntrypointScript. Generated at build time via
-#        cmd/astonish-sandbox-entrypoint-script so there is no risk of
-#        drift between the backend's expectations (env vars, mount
-#        paths) and the runtime.
+#        pkg/sandbox/k8s.EntrypointScript. Generated on the host via
+#        `make sandbox-entrypoint` (cmd/astonish-sandbox-entrypoint-script)
+#        so Docker does not recompile Go on every image rebuild.
 #
 #   2. Base userland sufficient to compose the overlay in any of the
 #        three supported modes (see pkg/sandbox/k8s.OverlayMode):
 #          - tar, zstd — resume-tar extraction from the uppers PVC
-#            (§5.14).
-#          - util-linux / mount — kernel overlayfs (mount -t overlay)
-#            for nodes that can honour it (Sysbox, hostUsers: false,
-#            or privileged pods on a real kernel).
-#          - fuse-overlayfs — userspace overlay composer for nodes
-#            where kernel overlayfs is unavailable (nested LXC hosts,
-#            restricted RuntimeClass). Requires /dev/fuse, which is
-#            obtained either via a cluster device plugin
-#            (smarter-device-manager advertising smarter-devices/fuse)
-#            or via privileged: true + an in-entrypoint mknod(1).
-#          - busybox-static — minimal fallback tooling.
+#          - util-linux / mount — kernel overlayfs
+#          - fuse-overlayfs — userspace overlay composer
+#          - busybox-static — minimal fallback tooling
 #
 #   3. A tiny /sandbox skeleton where the overlay will be composed:
 #        /sandbox/rootfs  — overlay mount point (created by the entrypoint)
 #        /var/astonish/   — emptyDir mount roots (upper, work)
 #        /mnt/astonish-layers, /mnt/astonish-uppers — PVC mount roots
 #
+#   4. Host-cross-compiled astonish binary at /usr/local/bin/astonish-host
+#        plus chroot wrappers at /usr/local/bin/astonish and
+#        /usr/local/bin/astonish-shell (see below).
+#
 # What this image INTENTIONALLY does NOT contain:
 #
-#   - The Astonish daemon binary. The daemon connects to the pod from
-#     outside via the exec subresource; the entrypoint merely sleeps
-#     after composing the overlay and awaits exec sessions
-#     (§5.3 step 3). We keep this minimal so base-image updates don't
-#     require rebuilding with every Astonish release.
+#   - Language runtimes / agent tool userland (those live in overlay
+#     layers on top of this base).
+#   - A Docker-side Go toolchain. Binaries and the entrypoint script are
+#     produced on the host (same pattern as docker/astonish) so BuildKit
+#     can cache the heavy apt + treesitter layers across code changes.
 #
-#   - Any language runtimes, shells beyond /bin/sh, or user tooling.
-#     Those belong in layers composed ON TOP of this base (the @base
-#     layer plus org-wide and template-specific layers on CephFS).
+# Layer order (stable → volatile) for cache hits on routine rebuilds:
+#   1. apt packages          — changes only when this package list changes
+#   2. treesitter .so        — changes only when pkg/codeintel/native changes
+#   3. static setup/wrappers — changes only when this Dockerfile changes
+#   4. entrypoint script     — changes when overlay entrypoint source changes
+#   5. astonish-host binary  — changes on almost every agent code edit
+#
+# Prerequisites (from repo root):
+#   make build-linux              # and/or build-linux-arm64 for multi-arch
+#   make sandbox-entrypoint
+#   # web/dist must exist for go:embed (make build-ui if missing)
 #
 # Build:
-#   docker build -f docker/sandbox-base/Dockerfile -t ghcr.io/sap/astonish-sandbox-base:latest .
+#   make push-sandbox-base-dev-fast   # native arch
+#   make push-sandbox-base-dev        # multi-arch push
 #
 # Publish:
 #   The image tag MUST match SandboxKubernetesConfig.SandboxImage's
@@ -58,67 +62,10 @@
 # Reference: docs/architecture/sandbox-backends.md §§5.3, 5.14.
 
 # ---------------------------------------------------------------------------
-# Stage 1 — generate the entrypoint script with the Go helper AND build the
-# astonish daemon binary itself.
-#
-# Two artefacts, one toolchain stage, because:
-#   - We use the same Go toolchain version as the main Dockerfile so the
-#     generated script is bit-identical across builds (EntrypointScript is
-#     deterministic, but keeping toolchains aligned avoids future footguns
-#     like go fmt / string-builder behavioural drift).
-#   - Carrying astonish into the base image (Phase E §11) gives tool calls
-#     a binary to exec inside the sandbox without requiring operators to
-#     bake it into their @base layer. At overlay-compose time the
-#     entrypoint bind-mounts this binary into the overlay so BOTH the
-#     PID-1 chroot handoff AND Backend.Exec tool calls resolve to the
-#     same trusted build.
-#
-# IMPORTANT: run the Go toolchain on $BUILDPLATFORM (the native host), then
-# cross-compile for $TARGETOS/$TARGETARCH. Running `go mod download` under
-# QEMU user-mode emulation (buildx linux/amd64 on Apple Silicon) panics in
-# Go 1.26 with "growslice: len out of range" / segfaults — same fix used by
-# docker/sandbox-openshell and docker/astonish (host-side cross-compile).
-# ---------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS entrypoint-builder
-
-ARG TARGETOS=linux
-ARG TARGETARCH
-
-WORKDIR /src
-
-# Copy just the module manifests first so the dependency cache is
-# reused across source edits.
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy the entire source tree. The entrypoint-script generator needs
-# pkg/sandbox/k8s + pkg/sandbox + pkg; the astonish binary additionally
-# needs main.go, cmd/astonish/*, and every internal package it imports
-# transitively. Copying the whole tree is simpler than maintaining two
-# include lists and only costs us cache granularity — the Go build
-# below would invalidate on any source change regardless.
-COPY . .
-
-RUN CGO_ENABLED=0 go run ./cmd/astonish-sandbox-entrypoint-script \
-      > /tmp/astonish-sandbox-entrypoint && \
-    chmod +x /tmp/astonish-sandbox-entrypoint && \
-    # Sanity check — the file is non-empty and starts with the
-    # POSIX shebang; a broken generator is a build-time failure, not a
-    # runtime surprise in the cluster.
-    head -1 /tmp/astonish-sandbox-entrypoint | grep -q '^#!/bin/sh'
-
-# Build the astonish binary for the *target* platform. CGO is disabled so
-# the resulting binary is statically linked and runs in the minimal base
-# image without libc surprises. The -s -w strip flags mirror the main
-# Dockerfile; version is left as "sandbox-base" because this is an
-# infrastructure image, not a shippable daemon build.
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
-      -ldflags="-s -w -X github.com/SAP/astonish/cmd/astonish.Version=sandbox-base" \
-      -o /tmp/astonish \
-      .
-
-# ---------------------------------------------------------------------------
-# Stage 2 — native tree-sitter shared library.
+# Stage 1 — native tree-sitter shared library (target-arch C build).
+# Kept in Docker because the .so must match TARGETARCH; host cross-compile
+# of C from macOS is unreliable. This stage only invalidates when
+# pkg/codeintel/native changes.
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim AS treesitter-builder
 
@@ -138,7 +85,7 @@ COPY pkg/codeintel/native ./pkg/codeintel/native
 RUN make -C pkg/codeintel/native OUT=/tmp/libastonish-treesitter.so
 
 # ---------------------------------------------------------------------------
-# Stage 3 — final runtime image.
+# Stage 2 — final runtime image.
 #
 # Debian slim is chosen over Alpine because fuse-overlayfs binds more
 # predictably against glibc in the wild, and the resume path uses zstd
@@ -147,8 +94,6 @@ RUN make -C pkg/codeintel/native OUT=/tmp/libastonish-treesitter.so
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim
 
-# Labels make kubectl describe / docker inspect self-explanatory and
-# give image-signing tools something stable to chew on.
 LABEL org.opencontainers.image.title="astonish-sandbox-base" \
       org.opencontainers.image.description="Minimal base image for Astonish K8s sandbox pods" \
       org.opencontainers.image.source="https://github.com/SAP/astonish" \
@@ -156,25 +101,10 @@ LABEL org.opencontainers.image.title="astonish-sandbox-base" \
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Userland required by the entrypoint script across all OverlayModes:
-#   - ca-certificates: workloads often fetch HTTPS resources.
-#   - tar + zstd: resume-tar extraction in §5.14.
-#   - coreutils: mkdir, echo, tee, etc.
-#   - busybox-static: fallback tooling when a layer ships a minimal
-#       rootfs without GNU utilities.
-#   - mount + util-linux: kernel `mount -t overlay` AND the bind-mount
-#       step for the host astonish binary. mountpoint(1) lives here.
-#   - fuse-overlayfs + fuse3: userspace overlay strategy. Works on any
-#       kernel with FUSE support; no CAP_SYS_ADMIN required for the
-#       overlay mount itself — only /dev/fuse access.
-# We remove apt lists after install to keep the image small; users who
-# need additional packages should compose them into higher layers.
-#
-# Do NOT install ripgrep (or other agent tool userland) here. Tools run
-# after chroot into the composed overlay, so packages on this pod image
-# are invisible to grep_search/find_files. Ripgrep is installed into
-# @base overlay layers via CoreToolInstallCommands() / baseconfig.Render
-# (and apt-installed in docker/sandbox-openshell for the OpenShell image).
+# Userland required by the entrypoint script across all OverlayModes.
+# Do NOT install ripgrep (or other agent tool userland) here — tools run
+# after chroot into the composed overlay (see CoreToolInstallCommands /
+# baseconfig.Render).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -195,24 +125,16 @@ COPY --from=treesitter-builder /tmp/libastonish-treesitter.so /usr/lib/astonish/
 # Compatibility guard for sandbox astonish-host binaries whose ELF
 # interpreter is /lib/ld-musl-x86_64.so.1. The intended build is static
 # (CGO_ENABLED=0), but some Go/toolchain combinations still produce a
-# dynamic musl-linked binary when built from the Alpine toolchain stage.
-# The entrypoint bind-mounts astonish-host into the chroot at
-# /usr/local/bin/astonish; without this loader path, backend Exec sees
+# dynamic musl-linked binary. Without this loader path, backend Exec sees
 # exit=127 and no node handshake even though the file exists.
 RUN ln -sf x86_64-linux-gnu/ld-linux-x86-64.so.2 /lib/ld-musl-x86_64.so.1
 
 # Disable apt's privilege-drop sandbox. In the Astonish sandbox chroot,
 # everything runs as root under squash_to_root semantics, so the _apt
-# user cannot access partial-download directories. This suppresses the
-# misleading "Download is performed unsandboxed as root" warning that
-# would otherwise confuse users running `apt install` in the editor.
+# user cannot access partial-download directories.
 RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/00no-sandbox
 
-# Directory skeleton the entrypoint and pod manifest expect. Creating
-# them here (instead of relying on the kubelet to mkdir emptyDirs)
-# makes the contract explicit and surfaces misconfigurations at image-
-# build time rather than at first pod start.
-#
+# Directory skeleton the entrypoint and pod manifest expect.
 # NOTE: /var/astonish/overlay is a single emptyDir mount point.
 # The entrypoint creates upper/ and work/ subdirectories inside it at
 # runtime. They MUST share a single mount to avoid cross-device
@@ -224,74 +146,25 @@ RUN mkdir -p \
       /mnt/astonish-uppers \
     && chmod 0755 /sandbox /sandbox/rootfs /var/astonish
 
-# Pull the generated entrypoint from the builder stage.
-COPY --from=entrypoint-builder \
-     /tmp/astonish-sandbox-entrypoint \
-     /usr/local/bin/astonish-sandbox-entrypoint
-
-# Pull the astonish binary from the builder stage and install it at a
-# NON-standard path. The entrypoint bind-mounts this file into the
-# overlay as /usr/local/bin/astonish once the overlay is composed (see
-# pkg/sandbox/k8s.EntrypointScript). Using a distinct host path
-# ("-host") keeps the base-image namespace distinct from the overlay
-# namespace so tool Exec callers never accidentally run the binary
-# outside the chroot — there is nothing at /usr/local/bin/astonish in
-# the base namespace until the entrypoint has set up the bind-mount.
-#
-# Tool-call execution flow:
-#
-#   Backend.Exec(sessionID, Command: ["astonish", "node"])
-#     → kubectl exec lands in pod base namespace
-#     → /usr/local/bin/astonish resolves via the overlay bind-mount
-#       (once PID 1 has composed the overlay)
-#     → the wrapper nature of the bind-mount means the chroot is
-#       implicit: we are ALREADY in the user-namespace rooted at the
-#       overlay once the bind-mount replaces the base-image binary.
-#
-# Wait — clarification on semantics: kubectl exec does NOT inherit PID 1's
-# chroot. PID 1's `exec chroot $MOUNT_POINT ...` only affects PID 1 and
-# its descendants; new execs start in the container's original root.
-# For Backend.Exec to see the overlay, we need a second chroot. That is
-# why /usr/local/bin/astonish in the base namespace is a WRAPPER (below),
-# not the real binary. The wrapper does its own chroot before handoff.
-COPY --from=entrypoint-builder \
-     /tmp/astonish \
-     /usr/local/bin/astonish-host
-
+# ---------------------------------------------------------------------------
+# Wrappers (stable Dockerfile text — keep ABOVE binary COPY so code edits
+# do not rebuild these layers).
+# ---------------------------------------------------------------------------
 # Wrapper that routes Backend.Exec tool calls into the composed overlay.
-#
-# Why this exists:
-#   The daemon invokes tool RPCs by running `astonish node` inside the
-#   sandbox via Backend.Exec. kubectl's exec subresource places the new
-#   process in the pod's base namespace, NOT inside PID 1's chroot.
-#   Tools (read_file /tmp/foo, write_file, shell_command) must see the
-#   overlay rootfs, not the bare base image. The wrapper pivots into
-#   the overlay mount via chroot before handing off to the real binary.
-#
-# Why not bind-mount astonish-host into the overlay at
-# /usr/local/bin/astonish and skip the wrapper?
-#   That covers PID 1 handoff fine, but Backend.Exec commands landing
-#   in the base namespace still see /usr/local/bin/astonish in the base
-#   (not overlay) — so they would exec without a chroot and hit the
-#   wrong rootfs. The wrapper is the minimum that makes both paths
-#   correct without special-casing per invocation source.
-#
-# The wrapper is deliberately plain POSIX (no bash, no arrays) so
-# busybox-static covers it even if /bin/sh is unset.
+# kubectl exec lands in the pod's base namespace, NOT inside PID 1's chroot;
+# tools must see the overlay rootfs. See docs/architecture/sandbox-backends.md
+# §11 Phase E.
 RUN printf '%s\n' \
       '#!/bin/sh' \
       '# astonish (sandbox-base wrapper) — chroot into the composed overlay' \
       '# before invoking the real astonish binary at /usr/local/bin/astonish-host.' \
       '#' \
       '# DO NOT EDIT. Generated by docker/sandbox-base/Dockerfile during image build.' \
-      '# See docs/architecture/sandbox-backends.md §11 Phase E for the design note.' \
       'set -e' \
       'MOUNT_POINT=/sandbox/rootfs' \
       'BIN=/usr/local/bin/astonish-host' \
       'if [ ! -d "$MOUNT_POINT" ] || [ ! -x "$MOUNT_POINT/usr/local/bin/astonish" ]; then' \
       '  # Overlay not composed yet — fall back to the host binary directly.' \
-      '  # This keeps the image usable for one-shot diagnostics (`docker run ... astonish --help`)' \
-      '  # before PID 1 has set up the overlay.' \
       '  exec "$BIN" "$@"' \
       'fi' \
       'exec chroot "$MOUNT_POINT" /usr/local/bin/astonish "$@"' \
@@ -299,23 +172,6 @@ RUN printf '%s\n' \
     && chmod +x /usr/local/bin/astonish
 
 # Interactive shell wrapper for team-template editor sessions.
-#
-# Why this exists:
-#   The team-template editor opens an interactive PTY inside the sandbox
-#   pod. kubectl exec lands in the pod's base namespace (NOT inside PID
-#   1's chroot). The user expects to see and modify the composed overlay
-#   filesystem. Without a chroot wrapper, writes (apt install, touch,
-#   mkdir) go to the kubelet container's ephemeral layer and never reach
-#   /var/astonish/overlay/upper — causing the layer capture to produce an empty
-#   tarball.
-#
-#   astonish-shell chroots into the composed overlay and launches an
-#   interactive login shell there, mirroring the pattern of the
-#   astonish wrapper but for interactive sessions rather than tool RPCs.
-#
-# Usage from Backend.ExecInteractive:
-#   Command: ["/usr/local/bin/astonish-shell"]
-#   — or with explicit shell: ["/usr/local/bin/astonish-shell", "/bin/bash", "-l"]
 RUN printf '%s\n' \
       '#!/bin/sh' \
       '# astonish-shell — chroot into the overlay and start an interactive shell.' \
@@ -327,8 +183,6 @@ RUN printf '%s\n' \
       '  # Overlay not composed yet — fall back to a bare shell.' \
       '  exec /bin/bash -l' \
       'fi' \
-      '# If arguments are provided, use them as the command inside the chroot.' \
-      '# Otherwise default to bash -l for an interactive login session.' \
       'if [ $# -gt 0 ]; then' \
       '  exec chroot "$MOUNT_POINT" "$@"' \
       'fi' \
@@ -336,8 +190,23 @@ RUN printf '%s\n' \
       > /usr/local/bin/astonish-shell \
     && chmod +x /usr/local/bin/astonish-shell
 
-# Default to the entrypoint; the pod manifest can override via command/
-# args if a particular test needs to skip overlay composition. In
-# normal operation, the kubelet starts PID 1 here which sets up the
-# overlay then execs into the workload via chroot (§5.3 step 3).
+# ---------------------------------------------------------------------------
+# Volatile host-built artifacts (invalidate only these on routine rebuilds).
+# ---------------------------------------------------------------------------
+# Do not give TARGETARCH a default — BuildKit ignores platform injection when
+# a default is set, which ships the wrong-arch binary in multi-arch images.
+ARG TARGETARCH
+
+# Generated on the host: make sandbox-entrypoint
+COPY astonish-sandbox-entrypoint /usr/local/bin/astonish-sandbox-entrypoint
+RUN chmod +x /usr/local/bin/astonish-sandbox-entrypoint && \
+    head -1 /usr/local/bin/astonish-sandbox-entrypoint | grep -q '^#!/bin/sh'
+
+# Host-cross-compiled agent binary (make build-linux / build-linux-arm64).
+# Installed at a NON-standard path; the entrypoint bind-mounts it into the
+# overlay as /usr/local/bin/astonish once the overlay is composed.
+COPY astonish-linux-${TARGETARCH} /usr/local/bin/astonish-host
+RUN chmod +x /usr/local/bin/astonish-host
+
+# Default to the entrypoint; the pod manifest can override via command/args.
 ENTRYPOINT ["/usr/local/bin/astonish-sandbox-entrypoint"]

--- a/docs/architecture/api-studio.md
+++ b/docs/architecture/api-studio.md
@@ -111,6 +111,18 @@ The Studio UI is built with React 19, Vite 7, and Tailwind CSS 4. Key components
 
 MCP tools are cached with background refresh to avoid slow MCP server queries on every request. The cache is warmed at startup and refreshed periodically.
 
+### API container image (`docker/astonish`)
+
+The published `ghcr.io/sap/astonish` image is the Studio/daemon runtime (not a sandbox). CI and Makefile host-cross-compile `astonish-linux-{amd64,arm64}` and only `COPY` the binary into the image.
+
+Runtime tools needed for **host-side** stdio MCP (`npx` / `uvx` when no sandbox is wired) are layered as prebuilt multi-arch artifacts rather than `apt install nodejs npm` + `pip install uv`:
+
+- Node 22 + npm/npx from the official `node:22-bookworm-slim` image
+- `uv` / `uvx` from `ghcr.io/astral-sh/uv` (pinned version in the Dockerfile)
+- Minimal apt: `ca-certificates`, `git`
+
+This avoids installing Node under QEMU on GitHub Actions multi-arch `linux/arm64` builds (the previous dominant cost in beta image jobs). Deps layers stay stable across code-only rebuilds; only the binary `COPY` invalidates. CI also uses a registry build cache at `ghcr.io/sap/astonish:buildcache`.
+
 ## Key Files
 
 | File | Purpose |

--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -1435,12 +1435,17 @@ artefacts:
   dev-cluster example. In-process validation lives at
   `pkg/sandbox/k8s/manifest_deploy_test.go`; an opt-in integration
   test (`-tags integration`) shells out to `kubectl apply --dry-run=server`.
-- `docker/sandbox-base/Dockerfile`: two-stage build of the
-  `astonish-sandbox-base` image, baking the generated PID-1 overlay
-  composer at `/usr/local/bin/astonish-sandbox-entrypoint`.
+- `docker/sandbox-base/Dockerfile`: cache-friendly runtime image for
+  `astonish-sandbox-base`. Host-cross-compiles the agent binary
+  (`make build-linux` / `build-linux-arm64`) and generates the PID-1
+  entrypoint (`make sandbox-entrypoint`); Docker only installs apt
+  packages, builds the treesitter `.so`, and `COPY`s those artifacts.
+  Layer order is stable→volatile (apt → treesitter → wrappers →
+  entrypoint → binary) so routine code edits only rebuild the last
+  COPY layers.
 - `cmd/astonish-sandbox-entrypoint-script`: standalone Go helper that
-  emits `pkg/sandbox/k8s.EntrypointScript` to stdout (used by the
-  Dockerfile).
+  emits `pkg/sandbox/k8s.EntrypointScript` to stdout (used by
+  `make sandbox-entrypoint` and CI before the image build).
 - `astonish sandbox k8s-smoke` subcommand: end-to-end probe that runs
   CreateSession → Exec → PushFile → PullFile → SessionState → Stop →
   Destroy against the cluster pointed at by the operator's kubeconfig.
@@ -1458,12 +1463,12 @@ artefacts:
   build the backend through `BackendFromAppConfig` and wrap the
   tool set with `WrapToolsWithPool`. Chat and fleet keep the
   concrete Incus pool verbatim (out of scope for this pass).
-- `docker/sandbox-base/Dockerfile` bakes a statically-linked
-  `astonish` binary into the base image and installs a chroot
-  wrapper at `/usr/local/bin/astonish`; the entrypoint bind-mounts
-  the host-layer binary over the overlay's wrapper before PID-1
-  handoff so both the chroot entry and subsequent `Backend.Exec`
-  tool calls resolve to the same trusted build.
+- `docker/sandbox-base/Dockerfile` installs the host-built binary at
+  `/usr/local/bin/astonish-host` and a chroot wrapper at
+  `/usr/local/bin/astonish`; the entrypoint bind-mounts the host-layer
+  binary over the overlay's wrapper before PID-1 handoff so both the
+  chroot entry and subsequent `Backend.Exec` tool calls resolve to the
+  same trusted build.
 
 Deferred to Phase E (intentionally out of scope for Phase D):
 

--- a/pkg/agent/chat_agent.go
+++ b/pkg/agent/chat_agent.go
@@ -80,6 +80,10 @@ type ChatAgent struct {
 	searchToolsResults []string    // tool names found via search_tools calls within current turn
 	searchToolsMu      sync.Mutex  // protects searchToolsResults
 
+	// toolsMu protects Tools / SystemPrompt.Tools when a late-configured
+	// platform tool (e.g. perplexity_web_search) is added after init.
+	toolsMu sync.Mutex
+
 	// Self-management callbacks
 	SelfMDRefresher func() // Called after config changes to regenerate SELF.md
 
@@ -237,6 +241,48 @@ func (c *ChatAgent) RegisterSearchToolsResults(toolNames []string) {
 	c.searchToolsMu.Lock()
 	defer c.searchToolsMu.Unlock()
 	c.searchToolsResults = append(c.searchToolsResults, toolNames...)
+}
+
+// EnsureMainThreadTool adds t to the agent's static tool list if missing.
+// Used when platform web search is configured after the singleton agent was
+// first initialized (or pre-warmed without tenant web settings).
+func (c *ChatAgent) EnsureMainThreadTool(t tool.Tool) {
+	if c == nil || t == nil {
+		return
+	}
+	name := t.Name()
+	c.toolsMu.Lock()
+	defer c.toolsMu.Unlock()
+	for _, existing := range c.Tools {
+		if existing != nil && existing.Name() == name {
+			return
+		}
+	}
+	c.Tools = append(c.Tools, t)
+	if c.SystemPrompt != nil {
+		for _, existing := range c.SystemPrompt.Tools {
+			if existing != nil && existing.Name() == name {
+				return
+			}
+		}
+		c.SystemPrompt.Tools = append(c.SystemPrompt.Tools, t)
+	}
+}
+
+// HasMainThreadTool reports whether a tool with the given name is already
+// registered on the agent.
+func (c *ChatAgent) HasMainThreadTool(name string) bool {
+	if c == nil || name == "" {
+		return false
+	}
+	c.toolsMu.Lock()
+	defer c.toolsMu.Unlock()
+	for _, existing := range c.Tools {
+		if existing != nil && existing.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // AutoInjectMissingToolCallback returns an OnToolErrorCallback that recovers

--- a/pkg/agent/chat_agent_run.go
+++ b/pkg/agent/chat_agent_run.go
@@ -226,6 +226,17 @@ func (c *ChatAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 			if po.SkillIndex != "" {
 				promptBuilder.SkillIndex = po.SkillIndex
 			}
+			// Platform/team web tools: always take the per-request values when set
+			// so every user sees the platform-selected search tool, not whatever
+			// was baked into the singleton agent at first init/pre-warm.
+			if po.WebSearchAvailable != nil {
+				promptBuilder.WebSearchAvailable = *po.WebSearchAvailable
+				promptBuilder.WebSearchToolName = po.WebSearchToolName
+			}
+			if po.WebExtractAvailable != nil {
+				promptBuilder.WebExtractAvailable = *po.WebExtractAvailable
+				promptBuilder.WebExtractToolName = po.WebExtractToolName
+			}
 		}
 
 		// Per-team tool restrictions: filter disabled tools from the prompt builder

--- a/pkg/agent/chat_agent_test.go
+++ b/pkg/agent/chat_agent_test.go
@@ -1205,3 +1205,22 @@ func TestChatAgent_AutoInjectMissingToolCallback(t *testing.T) {
 		t.Errorf("searchToolsResults = %v, want [run_drill]", ca.searchToolsResults)
 	}
 }
+
+func TestEnsureMainThreadTool_AddsOnce(t *testing.T) {
+	ca := &ChatAgent{
+		Tools:        nil,
+		SystemPrompt: &SystemPromptBuilder{},
+	}
+	toolA := mockTool{name: "perplexity_web_search"}
+	ca.EnsureMainThreadTool(toolA)
+	ca.EnsureMainThreadTool(toolA)
+	if !ca.HasMainThreadTool("perplexity_web_search") {
+		t.Fatal("expected tool to be registered")
+	}
+	if len(ca.Tools) != 1 {
+		t.Fatalf("expected single registration, got %d", len(ca.Tools))
+	}
+	if len(ca.SystemPrompt.Tools) != 1 {
+		t.Fatalf("expected system prompt tools to include tool once, got %d", len(ca.SystemPrompt.Tools))
+	}
+}

--- a/pkg/agent/system_prompt_builder.go
+++ b/pkg/agent/system_prompt_builder.go
@@ -92,6 +92,14 @@ type PromptOverrides struct {
 	// sessions to ensure critical tools (e.g., save_sandbox_template, save_fleet_plan)
 	// remain available across all turns of a multi-turn guided conversation.
 	PinnedToolGroups []string
+
+	// Web search/extract are resolved per request from the platform→team cascade
+	// so a singleton ChatAgent re-inited without tenant context still advertises
+	// the platform-selected tools for every user. Nil pointers mean "leave builder as-is".
+	WebSearchAvailable  *bool
+	WebSearchToolName   string
+	WebExtractAvailable *bool
+	WebExtractToolName  string
 }
 
 type promptOverridesKey struct{}

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -1076,6 +1076,13 @@ func StudioChatHandler(w http.ResponseWriter, r *http.Request) {
 		runner.InjectMCPServerStores(svc.PlatformMCPServers, svc.MCPServers, svc.TeamMCPServers)
 	}
 
+	// Per-request web search: platform General/WebSearchTool must apply to every
+	// user, not only the browser session that first pre-warmed the singleton agent.
+	// Also late-bind the Perplexity tool if it was configured after agent init.
+	if appCfg := effectiveAppConfig(r); appCfg != nil {
+		applyPerRequestWebSearch(runner, chatAgent, appCfg)
+	}
+
 	// Inject tenant-scoped network policy stores into the runner context so that
 	// denial detection can auto-approve/deny based on configured rules rather
 	// than always prompting the user.
@@ -1825,6 +1832,58 @@ func sessionProviderHasCredential(ctx context.Context, svc *store.Services, name
 		}
 	}
 	return false
+}
+
+// applyPerRequestWebSearch publishes the cascade-selected web tools into the
+// runner prompt and ensures the Perplexity tool is registered when selected.
+// This closes the gap where a singleton ChatAgent pre-warmed before platform
+// web settings were saved (or with a different tenant context) would leave
+// some browser sessions without web search while others worked.
+func applyPerRequestWebSearch(runner *ChatRunner, chatAgent *agent.ChatAgent, appCfg *config.AppConfig) {
+	if runner == nil || appCfg == nil {
+		return
+	}
+
+	searchOK, searchServer, searchTool := IsWebSearchConfiguredWith(appCfg)
+	extractOK, extractServer, extractTool := IsWebExtractConfiguredWith(appCfg)
+
+	searchName := ""
+	searchAvailable := false
+	if searchOK && searchTool != "" {
+		searchTool = strings.ReplaceAll(searchTool, "-", "_")
+		if searchServer == "perplexity" {
+			if appCfg.PerplexityWebSearch.Provider != "" && appCfg.PerplexityWebSearch.Model != "" {
+				searchAvailable = true
+				searchName = searchTool
+			}
+		} else if searchServer != "" {
+			// MCP standard web search (Tavily/Brave/Firecrawl): advertise when
+			// selected. Tool presence is handled by MCP merge/filter + ToolIndex.
+			searchAvailable = true
+			searchName = searchTool
+		}
+	}
+
+	extractName := ""
+	extractAvailable := false
+	if extractOK && extractTool != "" {
+		extractAvailable = true
+		extractName = strings.ReplaceAll(extractTool, "-", "_")
+		_ = extractServer
+	}
+
+	runner.InjectWebSearchPrompt(searchAvailable, searchName, extractAvailable, extractName)
+
+	// Late-bind Perplexity onto the main thread if selected but missing from the
+	// singleton agent (common after config change without a full process restart).
+	if searchAvailable && searchServer == "perplexity" && chatAgent != nil && !chatAgent.HasMainThreadTool("perplexity_web_search") {
+		if t, err := tools.NewPerplexityWebSearchTool(appCfg, provider.GetProvider); err != nil {
+			slog.Warn("failed to late-bind perplexity_web_search tool", "error", err)
+		} else {
+			chatAgent.EnsureMainThreadTool(t)
+			slog.Info("late-bound perplexity_web_search onto chat agent for platform web search")
+		}
+	}
 }
 
 // resolveSessionEffectiveModel returns the effective provider/model for a

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -248,6 +248,25 @@ func (cr *ChatRunner) InjectSkillIndex(index string) {
 	}
 }
 
+// InjectWebSearchPrompt sets per-request web search/extract availability from the
+// effective platform→team cascade. The singleton ChatAgent may have been
+// pre-warmed without the latest platform WebSearchTool; this keeps every user's
+// prompt honest about which search tool is selected.
+func (cr *ChatRunner) InjectWebSearchPrompt(searchAvailable bool, searchToolName string, extractAvailable bool, extractToolName string) {
+	po := agent.PromptOverridesFromContext(cr.ctx)
+	var newPO agent.PromptOverrides
+	if po != nil {
+		newPO = *po
+	}
+	searchAvail := searchAvailable
+	extractAvail := extractAvailable
+	newPO.WebSearchAvailable = &searchAvail
+	newPO.WebSearchToolName = searchToolName
+	newPO.WebExtractAvailable = &extractAvail
+	newPO.WebExtractToolName = extractToolName
+	cr.ctx = agent.WithPromptOverrides(cr.ctx, &newPO)
+}
+
 // InjectSchedulerStore adds a team-scoped scheduler store to the runner's context
 // so that the schedule_job and list_scheduled_jobs tools can operate on team jobs.
 // Must be called before Run().

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -793,6 +793,10 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		"announce_plan":      true,
 		"resolve_credential": true,
 		"skill_lookup":       true,
+		// Platform web search must be main-thread always-on. If it only lives in
+		// the "web" group, ToolIndex may never inject it and the agent claims
+		// "no web search tools" even when General selects Perplexity.
+		"perplexity_web_search": true,
 	}
 
 	var mainThreadTools []tool.Tool

--- a/pkg/sandbox/AGENTS.md
+++ b/pkg/sandbox/AGENTS.md
@@ -59,7 +59,9 @@ The k8s/OpenShell sandbox images (`docker/sandbox-base/Dockerfile`, `docker/sand
 - `/usr/local/bin/astonish-host` — the real binary copied into the base image.
 - `/usr/local/bin/astonish` — a wrapper that chroots into the composed overlay before exec'ing the real binary. **All Exec calls (from Astonish and kubectl exec both) rely on this wrapper.**
 - `/usr/local/bin/astonish-shell` — interactive wrapper for team-admin interactive shells.
-- The pod entrypoint (generated at build time via `cmd/astonish-sandbox-entrypoint-script`) composes the overlay (overlayfs / fuse-overlayfs / tar-resume depending on node capabilities) at `/sandbox/rootfs` and keeps PID 1 running.
+- The pod entrypoint (generated on the host via `make sandbox-entrypoint` / `cmd/astonish-sandbox-entrypoint-script`, then `COPY`ed into the image) composes the overlay (overlayfs / fuse-overlayfs / tar-resume depending on node capabilities) at `/sandbox/rootfs` and keeps PID 1 running.
+
+**sandbox-base image build (cache contract):** Go is **not** compiled inside Docker. Prerequisites: `make build-linux` (and `build-linux-arm64` for multi-arch) + `make sandbox-entrypoint`. The Dockerfile keeps apt + treesitter + shell wrappers above the volatile `COPY` of entrypoint/binary so routine agent code changes only invalidate the last layers. Local rebuilds use BuildKit local cache under `.buildx-cache/sandbox-base`. Prefer `make push-sandbox-base-dev-fast` / `make docker-sandbox-base` for iteration.
 
 If you change the entrypoint, update the generator in `cmd/astonish-sandbox-entrypoint-script/` and the wrapper section of both Dockerfiles together.
 

--- a/pkg/sandbox/k8s/overlay_entrypoint.go
+++ b/pkg/sandbox/k8s/overlay_entrypoint.go
@@ -21,13 +21,14 @@
 // deployment.
 //
 // This file owns the **source of truth** for the entrypoint script.
-// The script is copied into the astonish-sandbox-base image at build
-// time (typically `go run ./cmd/astonish-sandbox-entrypoint-script >
-// /tmp/entrypoint.sh && COPY /tmp/entrypoint.sh /usr/local/bin/` in the
-// Dockerfile, or an equivalent build step). Keeping it in Go lets us
-// unit-test its shape without a CI shell harness and lets Astonish
-// evolve the runtime contract (env var names, mount paths, resume
-// semantics) in lockstep with the backend that produces those inputs.
+// Host builds emit it via `make sandbox-entrypoint` (wrapper around
+// `go run ./cmd/astonish-sandbox-entrypoint-script`); the
+// docker/sandbox-base image then COPYs the file to
+// /usr/local/bin/astonish-sandbox-entrypoint. Keeping the generator in
+// Go lets us unit-test its shape without a CI shell harness and lets
+// Astonish evolve the runtime contract (env var names, mount paths,
+// resume semantics) in lockstep with the backend that produces those
+// inputs.
 //
 // Design invariants enforced by the script:
 //

--- a/pkg/tools/perplexity_web_search.go
+++ b/pkg/tools/perplexity_web_search.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/SAP/astonish/pkg/config"
+	"github.com/SAP/astonish/pkg/provider"
+	"github.com/SAP/astonish/pkg/store"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -54,8 +56,40 @@ func NewPerplexityWebSearchTool(appCfg *config.AppConfig, llmFactory LLMFactory)
 // functionToolNewPerplexity is isolated to keep tests focused on RunPerplexityWebSearch.
 func functionToolNewPerplexity(appCfg *config.AppConfig, llmFactory LLMFactory) (tool.Tool, error) {
 	return newFunctionTool("perplexity_web_search", "Search the web using the configured Perplexity/Sonar model and return a concise sourced answer with citations.", func(ctx tool.Context, args PerplexityWebSearchArgs) (PerplexityWebSearchResult, error) {
-		return RunPerplexityWebSearch(ctx, args, appCfg, llmFactory)
+		// Prefer per-request platform cascade so every user sees the same
+		// platform Perplexity config, not a stale singleton-init snapshot.
+		return RunPerplexityWebSearch(ctx, args, resolvePerplexityAppConfig(ctx, appCfg), llmFactory)
 	})
+}
+
+// resolvePerplexityAppConfig overlays platform→team web search settings onto
+// the factory fallback config when Services are present on the tool context.
+func resolvePerplexityAppConfig(ctx context.Context, fallback *config.AppConfig) *config.AppConfig {
+	if ctx == nil {
+		return fallback
+	}
+	svc := store.FromContext(ctx)
+	if svc == nil || svc.Mode != store.ModePlatform || svc.PlatformSettings == nil {
+		return fallback
+	}
+	resolved := provider.ResolveEffectiveConfig(ctx, svc.PlatformSettings, svc.OrgSettings, svc.Settings)
+	if resolved == nil {
+		return fallback
+	}
+	if fallback == nil {
+		return resolved
+	}
+	out := *fallback
+	if resolved.General.WebSearchTool != "" {
+		out.General.WebSearchTool = resolved.General.WebSearchTool
+	}
+	if resolved.PerplexityWebSearch.Provider != "" {
+		out.PerplexityWebSearch = resolved.PerplexityWebSearch
+	}
+	if len(resolved.Providers) > 0 {
+		out.Providers = resolved.Providers
+	}
+	return &out
 }
 
 // RunPerplexityWebSearch calls the configured Perplexity/Sonar model and normalizes the result.


### PR DESCRIPTION
## Summary
- Platform-selected web search (including Perplexity) was only reliable for some browser sessions because the singleton ChatAgent baked tools/prompt at first init/pre-warm.
- **Per request**, resolve the platform→team web search selection and inject it into the system prompt for every user.
- Keep `perplexity_web_search` on the **main thread** (always available, not only via ToolIndex).
- Late-bind the Perplexity tool if the agent was initialized before platform config was saved.
- Resolve Perplexity provider/model from request-scoped Services at tool runtime.

## Why this matches the report
- Incognito (fresh SPA/session) worked; a long-lived regular browser session did not — classic singleton init skew / stale agent.
- Platform config should apply to all SSO users; per-request cascade + late-bind makes that true regardless of which session first warmed the agent.

## Test plan
- [ ] Deploy fix; keep regular browser open and open a new chat — Perplexity should be advertised without needing a new login.
- [ ] SSO user (non-admin) new chat: confirm web search tool is available when platform has Perplexity selected.
- [ ] Platform admin and SSO user both able to call `perplexity_web_search`.
- [ ] `go test ./pkg/agent ./pkg/api ./pkg/tools ./pkg/launcher`