### PR TITLE
Add K8s upper retention GC

### DIFF
--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -724,7 +724,8 @@ Some reclamation patterns benefit from background batching: orphan detection (§
 - Runs on a schedule from `sandbox.kubernetes.gc.interval_minutes` (default 60).
 - Reclaims unreferenced layer rows after `sandbox.kubernetes.gc.layer_grace_hours` (default 24).
 - Reclaims uppers-PVC directories with no matching `sandbox_sessions` row only after `sandbox.kubernetes.gc.orphan_upper_grace_minutes` (default 60), so races during session creation/eviction do not become data loss.
-- Reclaims stale evicted session uppers after `sandbox.kubernetes.gc.evicted_upper_retention_hours` (default 336 / 14 days; set `evicted_upper_retention_disabled: true` to disable this retention sweep). This policy deletes `/mnt/astonish-uppers/<session-id>/` first and deletes the owning `sandbox_sessions` row only after the directory deletion succeeds.
+- Reclaims stale evicted or terminated session uppers after `sandbox.kubernetes.gc.evicted_upper_retention_hours` (default 336 / 14 days; set `evicted_upper_retention_disabled: true` to disable this retention sweep). This policy deletes `/mnt/astonish-uppers/<session-id>/` first and deletes the owning `sandbox_sessions` row only after the directory deletion succeeds.
+- Bounds upper cleanup with `sandbox.kubernetes.gc.max_upper_reclaims_per_cycle` (default 500) and batches stale upper directory deletion so one cycle cannot spawn one pod per stale session.
 - Skips pinned sessions, active states (`creating`, `running`, `resuming`, `evicting`), rows with a pod name, rows with live Running/Pending/Unknown K8s pods, non-K8s backend rows, and unsafe session IDs.
 - Cleans crashed template-builder staging directories, orphan session/fleet pods whose registry row disappeared, and old completed GC helper pods.
 
@@ -976,6 +977,7 @@ sandbox:
     orphan_upper_grace_minutes: 60
     evicted_upper_retention_hours: 336
     evicted_upper_retention_disabled: false
+    max_upper_reclaims_per_cycle: 500
 
   # Helm post-install/post-upgrade hook that seeds @base/rootfs from the
   # sandbox image. Idempotency guard skips re-seeding when @base/rootfs

--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -716,25 +716,21 @@ The primary reclamation path is the synchronous GC pod fired from `DeleteTemplat
 
 This is sufficient for the team-template editor flow (operator-driven, low frequency, immediate-feedback expectation) and for explicit `DELETE` calls.
 
-#### 5.12.2 Deferred reconciler (Status: deferred — design intact)
+#### 5.12.2 Deferred reconciler (Status: shipped for direct K8s)
 
-Some reclamation patterns benefit from background batching: orphan detection (§5.11), refcount drift recovery if the disabled trigger is ever needed, and bulk cleanup after migrations. The Round 2 design specified a single leader-elected reconciler:
+Some reclamation patterns benefit from background batching: orphan detection (§5.11), refcount drift recovery if the disabled trigger is ever needed, cleanup after migrations, and retention of old evicted session uppers. Direct K8s runs a single leader-elected reconciler in `pkg/sandbox/k8s/gc_reconciler.go` when platform mode uses PostgreSQL and `sandbox.backend: k8s`.
 
-- Runs in the `astonish` daemon, guarded by a PG advisory lock (`pg_try_advisory_lock(hashtext('astonish-layer-gc'))`) so only one pod executes at a time across the deployment.
-- Runs on a schedule (`sandbox.layers.gcInterval`, default 1h) **and** on demand via the admin API (§5.15).
-- Algorithm:
-  1. `SELECT layer_id FROM sandbox_layers WHERE ref_count = 0 AND created_at < now() - grace_period FOR UPDATE SKIP LOCKED`
-     (`grace_period` default 24h).
-  2. For each candidate:
-     - Verify `ref_count = 0` is still true (guard against races where a concurrent `RefreshTemplate` acquired the layer between selection and deletion).
-     - `rm -rf /mnt/astonish-layers/<layer_id>/`.
-     - `DELETE FROM sandbox_layers WHERE layer_id = ...`.
-     - Audit row: `layer_gc_removed`, size_bytes reclaimed.
-- Metrics: `astonish_sandbox_layer_gc_removed_total`, `astonish_sandbox_layer_gc_bytes_total`, `astonish_sandbox_layer_gc_duration_seconds`.
+- Runs in the daemon, guarded by a PG advisory lock (`pg_try_advisory_lock(1267985313)`) so only one pod executes at a time across the deployment.
+- Runs on a schedule from `sandbox.kubernetes.gc.interval_minutes` (default 60).
+- Reclaims unreferenced layer rows after `sandbox.kubernetes.gc.layer_grace_hours` (default 24).
+- Reclaims uppers-PVC directories with no matching `sandbox_sessions` row only after `sandbox.kubernetes.gc.orphan_upper_grace_minutes` (default 60), so races during session creation/eviction do not become data loss.
+- Reclaims stale evicted session uppers after `sandbox.kubernetes.gc.evicted_upper_retention_hours` (default 336 / 14 days; set `evicted_upper_retention_disabled: true` to disable this retention sweep). This policy deletes `/mnt/astonish-uppers/<session-id>/` first and deletes the owning `sandbox_sessions` row only after the directory deletion succeeds.
+- Skips pinned sessions, active states (`creating`, `running`, `resuming`, `evicting`), rows with a pod name, rows with live Running/Pending/Unknown K8s pods, non-K8s backend rows, and unsafe session IDs.
+- Cleans crashed template-builder staging directories, orphan session/fleet pods whose registry row disappeared, and old completed GC helper pods.
 
-**Grace period rationale.** Short-lived zero-ref windows happen legitimately: `RefreshTemplate` briefly drops a layer's refcount to 0 between the `DELETE` of the old template row and the subsequent `INSERT` of a redundant reference. In practice these are wrapped in a single transaction so they never appear committed as zero-ref — but the 24h grace period is a safety margin that also covers operator actions (manual PG edits, rollbacks).
+**Retention semantics.** Stale evicted upper cleanup removes sandbox resumability, not chat history. The chat transcript, artifact metadata, and transcript fallback content remain in the session store. If the user later interacts with an old chat after its upper was reclaimed, Astonish creates a fresh sandbox from the template rather than restoring the old writable filesystem.
 
-The deferred reconciler is **not currently implemented**. The synchronous path covers operator-driven deletion; orphan detection runs only when an operator triggers it manually via SQL/`kubectl`. Implementing the reconciler is a Phase E item.
+**Grace period rationale.** Short-lived zero-ref or untracked-upper windows happen legitimately during template refreshes, manual rollbacks, and eviction/create races. The layer and orphan-upper grace periods are safety margins around those windows. The evicted-upper retention period is a production storage bound for the `astonish-uppers` RWX PVC.
 
 ### 5.13 Default template resolution
 
@@ -971,6 +967,15 @@ sandbox:
       size: 50Gi
       accessMode: ReadWriteMany
       pvcName: astonish-uppers
+
+  # Deferred storage reconciler. Defaults shown here bound orphan/stale data
+  # while keeping evicted sandboxes resumable for two weeks.
+  gc:
+    interval_minutes: 60
+    layer_grace_hours: 24
+    orphan_upper_grace_minutes: 60
+    evicted_upper_retention_hours: 336
+    evicted_upper_retention_disabled: false
 
   # Helm post-install/post-upgrade hook that seeds @base/rootfs from the
   # sandbox image. Idempotency guard skips re-seeding when @base/rootfs
@@ -1523,10 +1528,10 @@ Status: shipped on `feature/sandbox-k8s-backend` (commits `4fa7ed6`, `cee00c8`, 
 **Still open (Phase F+ / E):**
 
 - Cross-replica consistency for the **fleet** session path (`pkg/api/fleet_session_handlers.go:341-357`) and the chat-session creation handler. The pattern from §5.16 applies; small follow-up.
-- Persisted upper-tarball GC under `/mnt/astonish-uppers/` (currently relies on the `DestroySession` path to clean up; orphaned tar.zst from out-of-band pod kills are not actively reclaimed).
+- Admin dry-run/preview endpoint for K8s uppers GC (the background reconciler now handles orphan and stale evicted upper cleanup; operators still need a friendly preview surface).
 - Cascading default-template resolution (§5.13 — currently resolves directly to `@base`).
 - `RefreshTemplate` implementation (§5.6 — currently returns "not yet implemented").
-- Deferred GC reconciler (§5.12.2) — synchronous reclamation covers the operator-driven path; the reconciler is the safety net for orphans and refcount drift.
+- Force-run K8s GC admin endpoint (§5.12.2) — the reconciler runs on a schedule today; an on-demand operator trigger remains useful.
 - Layer-chain flatten job (§5.11).
 - `meta.json` per-layer sidecar (§5.11).
 - Default-template setter API endpoints (§5.15 — `PUT /users/me/default-template` etc.).

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -342,10 +342,76 @@ type SandboxKubernetesConfig struct {
 	LayersPVCName string `yaml:"layers_pvc_name,omitempty" json:"layers_pvc_name,omitempty"`
 	UppersPVCName string `yaml:"uppers_pvc_name,omitempty" json:"uppers_pvc_name,omitempty"`
 
+	// GC controls the deferred K8s storage reconciler for layers, orphan
+	// upper directories, and stale evicted session uppers.
+	GC KubernetesGCConfig `yaml:"gc,omitempty" json:"gc,omitempty"`
+
 	// QPS / Burst tune the client-go rate limiter. Zero → defaults
 	// (50 / 100). Busier fleets want higher values.
 	QPS   float32 `yaml:"qps,omitempty" json:"qps,omitempty"`
 	Burst int     `yaml:"burst,omitempty" json:"burst,omitempty"`
+}
+
+// KubernetesGCConfig captures operator-tunable knobs for the direct K8s
+// storage reconciler. Zero values keep conservative production defaults.
+type KubernetesGCConfig struct {
+	// IntervalMinutes controls how often the reconciler runs. Default: 60.
+	IntervalMinutes int `yaml:"interval_minutes,omitempty" json:"interval_minutes,omitempty"`
+
+	// LayerGraceHours controls when unreferenced layer directories are eligible
+	// for cleanup. Default: 24.
+	LayerGraceHours int `yaml:"layer_grace_hours,omitempty" json:"layer_grace_hours,omitempty"`
+
+	// OrphanUpperGraceMinutes controls when upper directories with no matching
+	// sandbox session row are eligible for cleanup. Default: 60.
+	OrphanUpperGraceMinutes int `yaml:"orphan_upper_grace_minutes,omitempty" json:"orphan_upper_grace_minutes,omitempty"`
+
+	// EvictedUpperRetentionHours controls how long evicted, unpinned, inactive
+	// session uppers remain resumable. Default: 336 (14 days).
+	EvictedUpperRetentionHours int `yaml:"evicted_upper_retention_hours,omitempty" json:"evicted_upper_retention_hours,omitempty"`
+
+	// EvictedUpperRetentionDisabled disables stale evicted upper cleanup while
+	// leaving orphan cleanup and layer cleanup enabled.
+	EvictedUpperRetentionDisabled bool `yaml:"evicted_upper_retention_disabled,omitempty" json:"evicted_upper_retention_disabled,omitempty"`
+}
+
+// K8sGCInterval returns the direct K8s storage GC interval. Default: 1h.
+func (c *SandboxKubernetesConfig) K8sGCInterval() time.Duration {
+	if c.GC.IntervalMinutes > 0 {
+		return time.Duration(c.GC.IntervalMinutes) * time.Minute
+	}
+	return time.Hour
+}
+
+// K8sLayerGracePeriod returns the grace period for unreferenced layers.
+// Default: 24h.
+func (c *SandboxKubernetesConfig) K8sLayerGracePeriod() time.Duration {
+	if c.GC.LayerGraceHours > 0 {
+		return time.Duration(c.GC.LayerGraceHours) * time.Hour
+	}
+	return 24 * time.Hour
+}
+
+// K8sOrphanUpperGracePeriod returns the grace period for upper directories
+// that have no matching sandbox session row. Default: 1h.
+func (c *SandboxKubernetesConfig) K8sOrphanUpperGracePeriod() time.Duration {
+	if c.GC.OrphanUpperGraceMinutes > 0 {
+		return time.Duration(c.GC.OrphanUpperGraceMinutes) * time.Minute
+	}
+	return time.Hour
+}
+
+// K8sEvictedUpperRetention returns how long stale evicted session uppers stay
+// resumable. Default: 14 days. The second return value is false when cleanup is
+// explicitly disabled.
+func (c *SandboxKubernetesConfig) K8sEvictedUpperRetention() (time.Duration, bool) {
+	if c.GC.EvictedUpperRetentionDisabled {
+		return 0, false
+	}
+	if c.GC.EvictedUpperRetentionHours > 0 {
+		return time.Duration(c.GC.EvictedUpperRetentionHours) * time.Hour, true
+	}
+	return 14 * 24 * time.Hour, true
 }
 
 // BackendKind returns the configured backend, lower-cased, with "" and

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -373,6 +373,10 @@ type KubernetesGCConfig struct {
 	// EvictedUpperRetentionDisabled disables stale evicted upper cleanup while
 	// leaving orphan cleanup and layer cleanup enabled.
 	EvictedUpperRetentionDisabled bool `yaml:"evicted_upper_retention_disabled,omitempty" json:"evicted_upper_retention_disabled,omitempty"`
+
+	// MaxUpperReclaimsPerCycle bounds how many upper directories one GC cycle can
+	// delete across orphan and stale-evicted cleanup. Default: 500.
+	MaxUpperReclaimsPerCycle int `yaml:"max_upper_reclaims_per_cycle,omitempty" json:"max_upper_reclaims_per_cycle,omitempty"`
 }
 
 // K8sGCInterval returns the direct K8s storage GC interval. Default: 1h.
@@ -412,6 +416,15 @@ func (c *SandboxKubernetesConfig) K8sEvictedUpperRetention() (time.Duration, boo
 		return time.Duration(c.GC.EvictedUpperRetentionHours) * time.Hour, true
 	}
 	return 14 * 24 * time.Hour, true
+}
+
+// K8sMaxUpperReclaimsPerCycle returns the maximum upper directories reclaimed
+// by one reconciler cycle. Default: 500.
+func (c *SandboxKubernetesConfig) K8sMaxUpperReclaimsPerCycle() int {
+	if c.GC.MaxUpperReclaimsPerCycle > 0 {
+		return c.GC.MaxUpperReclaimsPerCycle
+	}
+	return 500
 }
 
 // BackendKind returns the configured backend, lower-cased, with "" and

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -299,6 +299,9 @@ func TestSandboxKubernetesConfig_GCDefaults(t *testing.T) {
 	if retention != 14*24*time.Hour {
 		t.Fatalf("K8sEvictedUpperRetention() = %s, want 336h", retention)
 	}
+	if got := cfg.K8sMaxUpperReclaimsPerCycle(); got != 500 {
+		t.Fatalf("K8sMaxUpperReclaimsPerCycle() = %d, want 500", got)
+	}
 }
 
 func TestSandboxKubernetesConfig_GCOverrides(t *testing.T) {
@@ -307,6 +310,7 @@ func TestSandboxKubernetesConfig_GCOverrides(t *testing.T) {
 		LayerGraceHours:            48,
 		OrphanUpperGraceMinutes:    30,
 		EvictedUpperRetentionHours: 24,
+		MaxUpperReclaimsPerCycle:   25,
 	}}
 	if got := cfg.K8sGCInterval(); got != 15*time.Minute {
 		t.Fatalf("K8sGCInterval() = %s, want 15m", got)
@@ -320,6 +324,9 @@ func TestSandboxKubernetesConfig_GCOverrides(t *testing.T) {
 	retention, enabled := cfg.K8sEvictedUpperRetention()
 	if !enabled || retention != 24*time.Hour {
 		t.Fatalf("K8sEvictedUpperRetention() = %s, %v; want 24h, true", retention, enabled)
+	}
+	if got := cfg.K8sMaxUpperReclaimsPerCycle(); got != 25 {
+		t.Fatalf("K8sMaxUpperReclaimsPerCycle() = %d, want 25", got)
 	}
 }
 

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 )
 
 func TestGetProviderType(t *testing.T) {
@@ -277,5 +278,55 @@ func TestSandboxConfig_IsK8sBackend(t *testing.T) {
 		if got := c.IsK8sBackend(); got != tt.want {
 			t.Errorf("IsK8sBackend(%q) = %v, want %v", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestSandboxKubernetesConfig_GCDefaults(t *testing.T) {
+	cfg := SandboxKubernetesConfig{}
+	if got := cfg.K8sGCInterval(); got != time.Hour {
+		t.Fatalf("K8sGCInterval() = %s, want 1h", got)
+	}
+	if got := cfg.K8sLayerGracePeriod(); got != 24*time.Hour {
+		t.Fatalf("K8sLayerGracePeriod() = %s, want 24h", got)
+	}
+	if got := cfg.K8sOrphanUpperGracePeriod(); got != time.Hour {
+		t.Fatalf("K8sOrphanUpperGracePeriod() = %s, want 1h", got)
+	}
+	retention, enabled := cfg.K8sEvictedUpperRetention()
+	if !enabled {
+		t.Fatalf("K8sEvictedUpperRetention() enabled = false, want true")
+	}
+	if retention != 14*24*time.Hour {
+		t.Fatalf("K8sEvictedUpperRetention() = %s, want 336h", retention)
+	}
+}
+
+func TestSandboxKubernetesConfig_GCOverrides(t *testing.T) {
+	cfg := SandboxKubernetesConfig{GC: KubernetesGCConfig{
+		IntervalMinutes:            15,
+		LayerGraceHours:            48,
+		OrphanUpperGraceMinutes:    30,
+		EvictedUpperRetentionHours: 24,
+	}}
+	if got := cfg.K8sGCInterval(); got != 15*time.Minute {
+		t.Fatalf("K8sGCInterval() = %s, want 15m", got)
+	}
+	if got := cfg.K8sLayerGracePeriod(); got != 48*time.Hour {
+		t.Fatalf("K8sLayerGracePeriod() = %s, want 48h", got)
+	}
+	if got := cfg.K8sOrphanUpperGracePeriod(); got != 30*time.Minute {
+		t.Fatalf("K8sOrphanUpperGracePeriod() = %s, want 30m", got)
+	}
+	retention, enabled := cfg.K8sEvictedUpperRetention()
+	if !enabled || retention != 24*time.Hour {
+		t.Fatalf("K8sEvictedUpperRetention() = %s, %v; want 24h, true", retention, enabled)
+	}
+}
+
+func TestSandboxKubernetesConfig_GCDisableEvictedUpperRetention(t *testing.T) {
+	cfg := SandboxKubernetesConfig{GC: KubernetesGCConfig{EvictedUpperRetentionDisabled: true}}
+	retention, enabled := cfg.K8sEvictedUpperRetention()
+	if enabled || retention != 0 {
+		t.Fatalf("K8sEvictedUpperRetention() = %s, %v; want 0, false", retention, enabled)
 	}
 }

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -1294,16 +1294,17 @@ func Run(cfg RunConfig) error {
 					evictedRetention = 0
 				}
 				go k8sbackend.RunGCReconciler(ctx, k8sbackend.GCReconcilerConfig{
-					Interval:              appCfg.Sandbox.Kubernetes.K8sGCInterval(),
-					LayerGracePeriod:      appCfg.Sandbox.Kubernetes.K8sLayerGracePeriod(),
-					UpperGracePeriod:      appCfg.Sandbox.Kubernetes.K8sOrphanUpperGracePeriod(),
-					EvictedUpperRetention: evictedRetention,
-					Namespace:             gcNamespace,
-					LayersPVCName:         appCfg.Sandbox.Kubernetes.LayersPVCName,
-					UppersPVCName:         appCfg.Sandbox.Kubernetes.UppersPVCName,
-					Client:                cs,
-					PlatformPool:          platformPool,
-					Layers:                entStore.SandboxLayers(),
+					Interval:                 appCfg.Sandbox.Kubernetes.K8sGCInterval(),
+					LayerGracePeriod:         appCfg.Sandbox.Kubernetes.K8sLayerGracePeriod(),
+					UpperGracePeriod:         appCfg.Sandbox.Kubernetes.K8sOrphanUpperGracePeriod(),
+					EvictedUpperRetention:    evictedRetention,
+					MaxUpperReclaimsPerCycle: appCfg.Sandbox.Kubernetes.K8sMaxUpperReclaimsPerCycle(),
+					Namespace:                gcNamespace,
+					LayersPVCName:            appCfg.Sandbox.Kubernetes.LayersPVCName,
+					UppersPVCName:            appCfg.Sandbox.Kubernetes.UppersPVCName,
+					Client:                   cs,
+					PlatformPool:             platformPool,
+					Layers:                   entStore.SandboxLayers(),
 					SandboxSessionsQuerier: func(ctx context.Context) (map[string]bool, error) {
 						return entStore.AllSandboxSessionIDs(ctx)
 					},

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -1289,18 +1289,29 @@ func Run(cfg RunConfig) error {
 				if gcNamespace == "" {
 					gcNamespace = "astonish-sandbox"
 				}
+				evictedRetention, evictedRetentionEnabled := appCfg.Sandbox.Kubernetes.K8sEvictedUpperRetention()
+				if !evictedRetentionEnabled {
+					evictedRetention = 0
+				}
 				go k8sbackend.RunGCReconciler(ctx, k8sbackend.GCReconcilerConfig{
-					Interval:         time.Hour,
-					LayerGracePeriod: 24 * time.Hour,
-					UpperGracePeriod: time.Hour,
-					Namespace:        gcNamespace,
-					LayersPVCName:    appCfg.Sandbox.Kubernetes.LayersPVCName,
-					UppersPVCName:    appCfg.Sandbox.Kubernetes.UppersPVCName,
-					Client:           cs,
-					PlatformPool:     platformPool,
-					Layers:           entStore.SandboxLayers(),
+					Interval:              appCfg.Sandbox.Kubernetes.K8sGCInterval(),
+					LayerGracePeriod:      appCfg.Sandbox.Kubernetes.K8sLayerGracePeriod(),
+					UpperGracePeriod:      appCfg.Sandbox.Kubernetes.K8sOrphanUpperGracePeriod(),
+					EvictedUpperRetention: evictedRetention,
+					Namespace:             gcNamespace,
+					LayersPVCName:         appCfg.Sandbox.Kubernetes.LayersPVCName,
+					UppersPVCName:         appCfg.Sandbox.Kubernetes.UppersPVCName,
+					Client:                cs,
+					PlatformPool:          platformPool,
+					Layers:                entStore.SandboxLayers(),
 					SandboxSessionsQuerier: func(ctx context.Context) (map[string]bool, error) {
 						return entStore.AllSandboxSessionIDs(ctx)
+					},
+					SandboxSessionsMetadataQuerier: func(ctx context.Context) ([]store.SandboxSessionGCInfo, error) {
+						return entStore.AllSandboxSessions(ctx)
+					},
+					SandboxSessionDeleter: func(ctx context.Context, session store.SandboxSessionGCInfo) error {
+						return entStore.DeleteSandboxSessionInTeam(ctx, session.OrgDBName, session.TeamSchema, session.SessionID)
 					},
 				})
 			} else {

--- a/pkg/sandbox/k8s/gc_reconciler.go
+++ b/pkg/sandbox/k8s/gc_reconciler.go
@@ -7,9 +7,10 @@
 //  1. Acquires a PG advisory lock so only one pod runs the reconciler.
 //  2. Reclaims orphan layer directories from the layers PVC.
 //  3. Reclaims orphan upper directories from the uppers PVC.
-//  4. Cleans up __staging-* directories from crashed template builders (skipping active ones).
-//  5. Prunes orphan session/fleet pods whose session no longer exists in any team DB.
-//  6. Cleans up stale (Succeeded/Failed) gc-ls/gc-rm pods older than 1h.
+//  4. Reclaims stale evicted session uppers after the configured retention window.
+//  5. Cleans up __staging-* directories from crashed template builders (skipping active ones).
+//  6. Prunes orphan session/fleet pods whose session no longer exists in any team DB.
+//  7. Cleans up stale (Succeeded/Failed) gc-ls/gc-rm pods older than 1h.
 //
 // The reconciler is leader-elected via pg_try_advisory_lock so it's safe
 // to run in multi-replica deployments without double-deleting.
@@ -20,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/store"
 )
 
@@ -69,6 +72,24 @@ type GCReconcilerConfig struct {
 	// If non-nil, the reconciler periodically prunes orphan session/fleet pods
 	// whose session no longer exists in any team schema.
 	SandboxSessionsQuerier func(ctx context.Context) (map[string]bool, error)
+
+	// SandboxSessionsMetadataQuerier returns all known sandbox sessions with
+	// enough metadata to make retention decisions for stale evicted uppers.
+	SandboxSessionsMetadataQuerier func(ctx context.Context) ([]store.SandboxSessionGCInfo, error)
+
+	// SandboxSessionDeleter deletes one sandbox session row from its owning team
+	// schema. It is called only after the corresponding persisted upper directory
+	// has been removed successfully.
+	SandboxSessionDeleter func(ctx context.Context, session store.SandboxSessionGCInfo) error
+
+	// EvictedUpperRetention controls how long evicted, unpinned K8s sessions
+	// remain resumable. A zero value disables stale evicted upper cleanup.
+	EvictedUpperRetention time.Duration
+}
+
+type gcDirInfo struct {
+	Name    string
+	ModTime time.Time
 }
 
 // advisoryLockID is a stable hash for the reconciler's PG advisory lock.
@@ -139,6 +160,7 @@ func runGCCycle(ctx context.Context, cfg GCReconcilerConfig) {
 
 	layersReclaimed := gcReclaimLayers(ctx, cfg)
 	uppersReclaimed := gcReclaimUppers(ctx, cfg)
+	staleEvictedUppers := gcReclaimStaleEvictedUppers(ctx, cfg)
 	stagingReclaimed := gcReclaimStaging(ctx, cfg)
 	orphanLayerDirs := gcReclaimOrphanLayerDirs(ctx, cfg)
 	orphanPodsPruned := gcPruneOrphanPods(ctx, cfg)
@@ -147,6 +169,7 @@ func runGCCycle(ctx context.Context, cfg GCReconcilerConfig) {
 	slog.Info("gc-reconciler: cycle complete",
 		"layers_reclaimed", layersReclaimed,
 		"uppers_reclaimed", uppersReclaimed,
+		"stale_evicted_uppers", staleEvictedUppers,
 		"staging_reclaimed", stagingReclaimed,
 		"orphan_layer_dirs", orphanLayerDirs,
 		"orphan_pods_pruned", orphanPodsPruned,
@@ -203,42 +226,150 @@ func gcReclaimUppers(ctx context.Context, cfg GCReconcilerConfig) int {
 		return 0
 	}
 
-	// List directories on the uppers PVC.
-	dirs, err := gcListDirs(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers")
+	dirs, err := gcListDirInfos(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers")
 	if err != nil {
 		slog.Warn("gc-reconciler: failed to list uppers dirs", "error", err)
 		return 0
 	}
 
-	// Get all known session IDs.
 	knownSessions, err := cfg.SandboxSessionsQuerier(ctx)
 	if err != nil {
 		slog.Warn("[gc-reconciler] failed to query sandbox sessions", "err", err)
 		return 0
 	}
 
-	// Find orphans.
-	var orphans []string
-	for _, d := range dirs {
-		if d == "" {
-			continue
-		}
-		if !knownSessions[d] {
-			orphans = append(orphans, d)
-		}
-	}
-
+	orphans := orphanUpperCandidates(dirs, knownSessions, time.Now(), cfg.UpperGracePeriod)
 	if len(orphans) == 0 {
 		return 0
 	}
 
-	// Delete orphans in a single GC pod.
 	if err := gcDeleteDirs(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers", orphans); err != nil {
 		slog.Warn("gc-reconciler: failed to delete orphan upper dirs", "error", err)
 		return 0
 	}
 
 	return len(orphans)
+}
+
+func orphanUpperCandidates(dirs []gcDirInfo, knownSessions map[string]bool, now time.Time, grace time.Duration) []string {
+	var orphans []string
+	for _, d := range dirs {
+		if d.Name == "" || knownSessions[d.Name] {
+			continue
+		}
+		if _, err := upperDirNameForSession(d.Name); err != nil {
+			slog.Warn("gc-reconciler: skipping unsafe orphan upper dir", "dir", d.Name, "error", err)
+			continue
+		}
+		if grace > 0 && !d.ModTime.IsZero() && now.Sub(d.ModTime) < grace {
+			slog.Debug("gc-reconciler: retaining young orphan upper dir", "dir", d.Name, "age", now.Sub(d.ModTime).Round(time.Second), "grace", grace)
+			continue
+		}
+		orphans = append(orphans, d.Name)
+	}
+	return orphans
+}
+
+func gcReclaimStaleEvictedUppers(ctx context.Context, cfg GCReconcilerConfig) int {
+	if cfg.Client == nil || cfg.SandboxSessionsMetadataQuerier == nil || cfg.SandboxSessionDeleter == nil || cfg.EvictedUpperRetention <= 0 {
+		return 0
+	}
+
+	sessions, err := cfg.SandboxSessionsMetadataQuerier(ctx)
+	if err != nil {
+		slog.Warn("gc-reconciler: failed to query sandbox session metadata", "error", err)
+		return 0
+	}
+	if len(sessions) == 0 {
+		return 0
+	}
+
+	liveSessions := gcLiveSandboxSessions(ctx, cfg)
+	candidates := staleEvictedUpperCandidates(sessions, liveSessions, time.Now(), cfg.EvictedUpperRetention)
+	if len(candidates) == 0 {
+		return 0
+	}
+
+	reclaimed := 0
+	for _, candidate := range candidates {
+		if ctx.Err() != nil {
+			break
+		}
+		if err := gcDeleteDir(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers", candidate.SessionID); err != nil {
+			slog.Warn("gc-reconciler: failed to delete stale evicted upper dir", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "error", err)
+			continue
+		}
+		if err := cfg.SandboxSessionDeleter(ctx, candidate); err != nil {
+			slog.Warn("gc-reconciler: deleted stale evicted upper but failed to delete session row", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "error", err)
+			continue
+		}
+		reclaimed++
+		slog.Info("gc-reconciler: reclaimed stale evicted upper", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "age", time.Since(sessionRetentionTime(candidate)).Round(time.Hour))
+	}
+	return reclaimed
+}
+
+func staleEvictedUpperCandidates(sessions []store.SandboxSessionGCInfo, liveSessions map[string]bool, now time.Time, retention time.Duration) []store.SandboxSessionGCInfo {
+	if retention <= 0 {
+		return nil
+	}
+	var candidates []store.SandboxSessionGCInfo
+	for _, sess := range sessions {
+		if sess.Backend != string(sandbox.BackendKindK8s) {
+			continue
+		}
+		if sess.State != store.SandboxSessionStateEvicted && sess.State != store.SandboxSessionStateTerminated {
+			continue
+		}
+		if sess.Pinned || sess.PodName != "" || liveSessions[sess.SessionID] {
+			continue
+		}
+		if _, err := upperDirNameForSession(sess.SessionID); err != nil {
+			slog.Warn("gc-reconciler: skipping stale upper candidate with unsafe session ID", "session", sess.SessionID, "error", err)
+			continue
+		}
+		basis := sessionRetentionTime(sess)
+		if basis.IsZero() || now.Sub(basis) < retention {
+			continue
+		}
+		candidates = append(candidates, sess)
+	}
+	return candidates
+}
+
+func sessionRetentionTime(sess store.SandboxSessionGCInfo) time.Time {
+	if !sess.LastActiveAt.IsZero() {
+		return sess.LastActiveAt
+	}
+	if !sess.UpdatedAt.IsZero() {
+		return sess.UpdatedAt
+	}
+	return sess.CreatedAt
+}
+
+func gcLiveSandboxSessions(ctx context.Context, cfg GCReconcilerConfig) map[string]bool {
+	live := make(map[string]bool)
+	if cfg.Client == nil {
+		return live
+	}
+	selector := labelType + " in (" + typeSession + "," + typeFleet + ")"
+	list, err := cfg.Client.CoreV1().Pods(cfg.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		slog.Warn("gc-reconciler: failed to list live sandbox pods for stale upper cleanup", "error", err)
+		return live
+	}
+	for i := range list.Items {
+		p := &list.Items[i]
+		sid := p.Labels[labelSessionID]
+		if sid == "" {
+			continue
+		}
+		switch p.Status.Phase {
+		case corev1.PodRunning, corev1.PodPending, corev1.PodUnknown:
+			live[sid] = true
+		}
+	}
+	return live
 }
 
 // gcReclaimStaging lists __staging-* directories on the layers PVC
@@ -446,6 +577,104 @@ func gcCleanupStaleGCPods(ctx context.Context, cfg GCReconcilerConfig) int {
 // Pod helpers for the GC reconciler
 // ---------------------------------------------------------------------------
 
+// gcListDirInfos spawns a read-only pod that lists top-level directories and
+// their modification times on a PVC.
+func gcListDirInfos(ctx context.Context, cs kubernetes.Interface, namespace, pvcName, mountPath string) ([]gcDirInfo, error) {
+	podName := fmt.Sprintf("astn-gc-ls-%d", time.Now().UnixNano()%1000000)
+	cmd := fmt.Sprintf(`for d in %s/*; do
+  [ -d "$d" ] || continue
+  name=${d##*/}
+  mtime=$(stat -c %%Y "$d" 2>/dev/null || stat -f %%m "$d" 2>/dev/null || echo 0)
+  printf '%%s\t%%s\n' "$name" "$mtime"
+done`, mountPath)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{labelType: "gc-list"},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:            "ls",
+				Image:           "alpine:3.21",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/bin/sh", "-c", cmd},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "data", MountPath: mountPath, ReadOnly: true},
+				},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  true,
+					},
+				},
+			}},
+		},
+	}
+
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = cs.CoreV1().Pods(namespace).Delete(cleanupCtx, podName, metav1.DeleteOptions{})
+	}()
+
+	_ = cs.CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+	time.Sleep(500 * time.Millisecond)
+
+	if _, err := cs.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("create list pod: %w", err)
+	}
+
+	if err := gcWaitForPodDone(ctx, cs, namespace, podName, 60*time.Second); err != nil {
+		return nil, err
+	}
+
+	logReq := cs.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	logStream, err := logReq.Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read list pod logs: %w", err)
+	}
+	defer logStream.Close()
+
+	var buf strings.Builder
+	b := make([]byte, 4096)
+	for {
+		n, readErr := logStream.Read(b)
+		if n > 0 {
+			buf.Write(b[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	var dirs []gcDirInfo
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
+		}
+		info := gcDirInfo{Name: name}
+		if len(parts) == 2 {
+			if sec, parseErr := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); parseErr == nil && sec > 0 {
+				info.ModTime = time.Unix(sec, 0)
+			}
+		}
+		dirs = append(dirs, info)
+	}
+	return dirs, nil
+}
+
 // gcListDirs spawns a read-only pod that lists top-level directories on a PVC.
 func gcListDirs(ctx context.Context, cs kubernetes.Interface, namespace, pvcName, mountPath string) ([]string, error) {
 	podName := fmt.Sprintf("astn-gc-ls-%d", time.Now().UnixNano()%1000000)
@@ -531,6 +760,10 @@ func gcDeleteDir(ctx context.Context, cs kubernetes.Interface, namespace, pvcNam
 	return gcDeleteDirs(ctx, cs, namespace, pvcName, mountPath, []string{dir})
 }
 
+func safeGCDirName(dir string) bool {
+	return dir != "" && dir != "." && dir != ".." && !strings.Contains(dir, "/") && !strings.Contains(dir, "..")
+}
+
 // gcDeleteDirs spawns a pod that deletes multiple directories from a PVC.
 func gcDeleteDirs(ctx context.Context, cs kubernetes.Interface, namespace, pvcName, mountPath string, dirs []string) error {
 	if len(dirs) == 0 {
@@ -540,10 +773,10 @@ func gcDeleteDirs(ctx context.Context, cs kubernetes.Interface, namespace, pvcNa
 	var sb strings.Builder
 	sb.WriteString("#!/bin/sh\nset -e\n")
 	for _, d := range dirs {
-		if d == "" || strings.Contains(d, "/") || strings.Contains(d, "..") {
+		if !safeGCDirName(d) {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("rm -rf '%s/%s'\n", mountPath, d))
+		sb.WriteString(fmt.Sprintf("rm -rf %s/%s\n", shellQuote(mountPath), shellQuote(d)))
 	}
 
 	podName := fmt.Sprintf("astn-gc-rm-%d", time.Now().UnixNano()%1000000)

--- a/pkg/sandbox/k8s/gc_reconciler.go
+++ b/pkg/sandbox/k8s/gc_reconciler.go
@@ -85,6 +85,10 @@ type GCReconcilerConfig struct {
 	// EvictedUpperRetention controls how long evicted, unpinned K8s sessions
 	// remain resumable. A zero value disables stale evicted upper cleanup.
 	EvictedUpperRetention time.Duration
+
+	// MaxUpperReclaimsPerCycle bounds how many upper directories are reclaimed
+	// by one GC cycle. A zero value defaults to 500.
+	MaxUpperReclaimsPerCycle int
 }
 
 type gcDirInfo struct {
@@ -113,6 +117,9 @@ func RunGCReconciler(ctx context.Context, cfg GCReconcilerConfig) {
 	}
 	if cfg.UppersPVCName == "" {
 		cfg.UppersPVCName = "astonish-uppers"
+	}
+	if cfg.MaxUpperReclaimsPerCycle <= 0 {
+		cfg.MaxUpperReclaimsPerCycle = 500
 	}
 
 	// Initial delay to avoid contention at startup.
@@ -238,7 +245,7 @@ func gcReclaimUppers(ctx context.Context, cfg GCReconcilerConfig) int {
 		return 0
 	}
 
-	orphans := orphanUpperCandidates(dirs, knownSessions, time.Now(), cfg.UpperGracePeriod)
+	orphans := orphanUpperCandidates(dirs, knownSessions, time.Now(), cfg.UpperGracePeriod, cfg.MaxUpperReclaimsPerCycle)
 	if len(orphans) == 0 {
 		return 0
 	}
@@ -251,7 +258,7 @@ func gcReclaimUppers(ctx context.Context, cfg GCReconcilerConfig) int {
 	return len(orphans)
 }
 
-func orphanUpperCandidates(dirs []gcDirInfo, knownSessions map[string]bool, now time.Time, grace time.Duration) []string {
+func orphanUpperCandidates(dirs []gcDirInfo, knownSessions map[string]bool, now time.Time, grace time.Duration, limit int) []string {
 	var orphans []string
 	for _, d := range dirs {
 		if d.Name == "" || knownSessions[d.Name] {
@@ -266,6 +273,9 @@ func orphanUpperCandidates(dirs []gcDirInfo, knownSessions map[string]bool, now 
 			continue
 		}
 		orphans = append(orphans, d.Name)
+		if limit > 0 && len(orphans) >= limit {
+			break
+		}
 	}
 	return orphans
 }
@@ -285,31 +295,37 @@ func gcReclaimStaleEvictedUppers(ctx context.Context, cfg GCReconcilerConfig) in
 	}
 
 	liveSessions := gcLiveSandboxSessions(ctx, cfg)
-	candidates := staleEvictedUpperCandidates(sessions, liveSessions, time.Now(), cfg.EvictedUpperRetention)
+	candidates := staleEvictedUpperCandidates(sessions, liveSessions, time.Now(), cfg.EvictedUpperRetention, cfg.MaxUpperReclaimsPerCycle)
 	if len(candidates) == 0 {
 		return 0
 	}
 
 	reclaimed := 0
-	for _, candidate := range candidates {
+	for _, batch := range chunkSandboxSessionGCInfo(candidates, 50) {
 		if ctx.Err() != nil {
 			break
 		}
-		if err := gcDeleteDir(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers", candidate.SessionID); err != nil {
-			slog.Warn("gc-reconciler: failed to delete stale evicted upper dir", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "error", err)
+		dirs := make([]string, 0, len(batch))
+		for _, candidate := range batch {
+			dirs = append(dirs, candidate.SessionID)
+		}
+		if err := gcDeleteDirs(ctx, cfg.Client, cfg.Namespace, cfg.UppersPVCName, "/mnt/uppers", dirs); err != nil {
+			slog.Warn("gc-reconciler: failed to delete stale evicted upper batch", "count", len(batch), "error", err)
 			continue
 		}
-		if err := cfg.SandboxSessionDeleter(ctx, candidate); err != nil {
-			slog.Warn("gc-reconciler: deleted stale evicted upper but failed to delete session row", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "error", err)
-			continue
+		for _, candidate := range batch {
+			if err := cfg.SandboxSessionDeleter(ctx, candidate); err != nil {
+				slog.Warn("gc-reconciler: deleted stale evicted upper but failed to delete session row", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "error", err)
+				continue
+			}
+			reclaimed++
+			slog.Info("gc-reconciler: reclaimed stale evicted upper", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "age", time.Since(sessionRetentionTime(candidate)).Round(time.Hour))
 		}
-		reclaimed++
-		slog.Info("gc-reconciler: reclaimed stale evicted upper", "session", candidate.SessionID, "team_schema", candidate.TeamSchema, "age", time.Since(sessionRetentionTime(candidate)).Round(time.Hour))
 	}
 	return reclaimed
 }
 
-func staleEvictedUpperCandidates(sessions []store.SandboxSessionGCInfo, liveSessions map[string]bool, now time.Time, retention time.Duration) []store.SandboxSessionGCInfo {
+func staleEvictedUpperCandidates(sessions []store.SandboxSessionGCInfo, liveSessions map[string]bool, now time.Time, retention time.Duration, limit int) []store.SandboxSessionGCInfo {
 	if retention <= 0 {
 		return nil
 	}
@@ -333,8 +349,26 @@ func staleEvictedUpperCandidates(sessions []store.SandboxSessionGCInfo, liveSess
 			continue
 		}
 		candidates = append(candidates, sess)
+		if limit > 0 && len(candidates) >= limit {
+			break
+		}
 	}
 	return candidates
+}
+
+func chunkSandboxSessionGCInfo(items []store.SandboxSessionGCInfo, size int) [][]store.SandboxSessionGCInfo {
+	if size <= 0 || len(items) == 0 {
+		return nil
+	}
+	chunks := make([][]store.SandboxSessionGCInfo, 0, (len(items)+size-1)/size)
+	for start := 0; start < len(items); start += size {
+		end := start + size
+		if end > len(items) {
+			end = len(items)
+		}
+		chunks = append(chunks, items[start:end])
+	}
+	return chunks
 }
 
 func sessionRetentionTime(sess store.SandboxSessionGCInfo) time.Time {
@@ -761,7 +795,7 @@ func gcDeleteDir(ctx context.Context, cs kubernetes.Interface, namespace, pvcNam
 }
 
 func safeGCDirName(dir string) bool {
-	return dir != "" && dir != "." && dir != ".." && !strings.Contains(dir, "/") && !strings.Contains(dir, "..")
+	return dir != "" && dir != "." && dir != ".." && !strings.Contains(dir, "/")
 }
 
 // gcDeleteDirs spawns a pod that deletes multiple directories from a PVC.

--- a/pkg/sandbox/k8s/gc_reconciler_test.go
+++ b/pkg/sandbox/k8s/gc_reconciler_test.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/SAP/astonish/pkg/sandbox"
+	"github.com/SAP/astonish/pkg/store"
+)
+
+func TestOrphanUpperCandidatesHonorsGraceAndSafety(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	known := map[string]bool{"known-session": true}
+	dirs := []gcDirInfo{
+		{Name: "known-session", ModTime: now.Add(-48 * time.Hour)},
+		{Name: "old-orphan", ModTime: now.Add(-2 * time.Hour)},
+		{Name: "young-orphan", ModTime: now.Add(-10 * time.Minute)},
+		{Name: "../unsafe", ModTime: now.Add(-2 * time.Hour)},
+	}
+
+	got := orphanUpperCandidates(dirs, known, now, time.Hour)
+	if len(got) != 1 || got[0] != "old-orphan" {
+		t.Fatalf("orphanUpperCandidates() = %#v, want [old-orphan]", got)
+	}
+}
+
+func TestStaleEvictedUpperCandidates(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-15 * 24 * time.Hour)
+	young := now.Add(-2 * time.Hour)
+	sessions := []store.SandboxSessionGCInfo{
+		{SandboxSession: store.SandboxSession{SessionID: "old-evicted", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "young-evicted", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: young}},
+		{SandboxSession: store.SandboxSession{SessionID: "pinned-evicted", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old, Pinned: true}},
+		{SandboxSession: store.SandboxSession{SessionID: "running-session", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateRunning, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "with-pod", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old, PodName: "astn-sess-with-pod"}},
+		{SandboxSession: store.SandboxSession{SessionID: "openshell-session", Backend: string(sandbox.BackendKindOpenShell), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "../unsafe", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "live-pod", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+	}
+
+	got := staleEvictedUpperCandidates(sessions, map[string]bool{"live-pod": true}, now, 14*24*time.Hour)
+	if len(got) != 1 || got[0].SessionID != "old-evicted" {
+		t.Fatalf("staleEvictedUpperCandidates() = %#v, want only old-evicted", got)
+	}
+}
+
+func TestStaleEvictedUpperCandidatesUsesUpdatedAtFallback(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	sessions := []store.SandboxSessionGCInfo{
+		{SandboxSession: store.SandboxSession{SessionID: "updated-old", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, UpdatedAt: now.Add(-20 * 24 * time.Hour)}},
+	}
+
+	got := staleEvictedUpperCandidates(sessions, nil, now, 14*24*time.Hour)
+	if len(got) != 1 || got[0].SessionID != "updated-old" {
+		t.Fatalf("staleEvictedUpperCandidates() = %#v, want updated-old", got)
+	}
+}
+
+func TestGCLiveSandboxSessions(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "running", Namespace: "ns", Labels: map[string]string{labelType: typeSession, labelSessionID: "running-session"}}, Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pending", Namespace: "ns", Labels: map[string]string{labelType: typeFleet, labelSessionID: "pending-session"}}, Status: corev1.PodStatus{Phase: corev1.PodPending}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "succeeded", Namespace: "ns", Labels: map[string]string{labelType: typeSession, labelSessionID: "done-session"}}, Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
+	)
+
+	got := gcLiveSandboxSessions(t.Context(), GCReconcilerConfig{Client: client, Namespace: "ns"})
+	if !got["running-session"] || !got["pending-session"] {
+		t.Fatalf("gcLiveSandboxSessions() = %#v, want running and pending sessions", got)
+	}
+	if got["done-session"] {
+		t.Fatalf("gcLiveSandboxSessions() included succeeded pod: %#v", got)
+	}
+}

--- a/pkg/sandbox/k8s/gc_reconciler_test.go
+++ b/pkg/sandbox/k8s/gc_reconciler_test.go
@@ -22,7 +22,7 @@ func TestOrphanUpperCandidatesHonorsGraceAndSafety(t *testing.T) {
 		{Name: "../unsafe", ModTime: now.Add(-2 * time.Hour)},
 	}
 
-	got := orphanUpperCandidates(dirs, known, now, time.Hour)
+	got := orphanUpperCandidates(dirs, known, now, time.Hour, 0)
 	if len(got) != 1 || got[0] != "old-orphan" {
 		t.Fatalf("orphanUpperCandidates() = %#v, want [old-orphan]", got)
 	}
@@ -43,7 +43,7 @@ func TestStaleEvictedUpperCandidates(t *testing.T) {
 		{SandboxSession: store.SandboxSession{SessionID: "live-pod", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
 	}
 
-	got := staleEvictedUpperCandidates(sessions, map[string]bool{"live-pod": true}, now, 14*24*time.Hour)
+	got := staleEvictedUpperCandidates(sessions, map[string]bool{"live-pod": true}, now, 14*24*time.Hour, 0)
 	if len(got) != 1 || got[0].SessionID != "old-evicted" {
 		t.Fatalf("staleEvictedUpperCandidates() = %#v, want only old-evicted", got)
 	}
@@ -55,9 +55,37 @@ func TestStaleEvictedUpperCandidatesUsesUpdatedAtFallback(t *testing.T) {
 		{SandboxSession: store.SandboxSession{SessionID: "updated-old", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, UpdatedAt: now.Add(-20 * 24 * time.Hour)}},
 	}
 
-	got := staleEvictedUpperCandidates(sessions, nil, now, 14*24*time.Hour)
+	got := staleEvictedUpperCandidates(sessions, nil, now, 14*24*time.Hour, 0)
 	if len(got) != 1 || got[0].SessionID != "updated-old" {
 		t.Fatalf("staleEvictedUpperCandidates() = %#v, want updated-old", got)
+	}
+}
+
+func TestStaleEvictedUpperCandidatesHonorsLimit(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-20 * 24 * time.Hour)
+	sessions := []store.SandboxSessionGCInfo{
+		{SandboxSession: store.SandboxSession{SessionID: "old-1", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "old-2", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+		{SandboxSession: store.SandboxSession{SessionID: "old-3", Backend: string(sandbox.BackendKindK8s), State: store.SandboxSessionStateEvicted, LastActiveAt: old}},
+	}
+
+	got := staleEvictedUpperCandidates(sessions, nil, now, 14*24*time.Hour, 2)
+	if len(got) != 2 || got[0].SessionID != "old-1" || got[1].SessionID != "old-2" {
+		t.Fatalf("staleEvictedUpperCandidates() = %#v, want old-1 and old-2", got)
+	}
+}
+
+func TestChunkSandboxSessionGCInfo(t *testing.T) {
+	items := []store.SandboxSessionGCInfo{
+		{SandboxSession: store.SandboxSession{SessionID: "1"}},
+		{SandboxSession: store.SandboxSession{SessionID: "2"}},
+		{SandboxSession: store.SandboxSession{SessionID: "3"}},
+	}
+
+	got := chunkSandboxSessionGCInfo(items, 2)
+	if len(got) != 2 || len(got[0]) != 2 || len(got[1]) != 1 {
+		t.Fatalf("chunkSandboxSessionGCInfo() = %#v, want chunk lengths 2 and 1", got)
 	}
 }
 

--- a/pkg/store/entstore/platform_backend.go
+++ b/pkg/store/entstore/platform_backend.go
@@ -10,9 +10,9 @@ import (
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 
-	teament "github.com/SAP/astonish/ent/team"
 	"github.com/SAP/astonish/ent/platform/loginsession"
 	"github.com/SAP/astonish/ent/platform/pendinglinkcode"
+	teament "github.com/SAP/astonish/ent/team"
 	"github.com/SAP/astonish/pkg/store"
 )
 
@@ -73,12 +73,28 @@ func (s *Store) CleanupExpired(ctx context.Context) error {
 // AllSandboxSessionIDs returns all known sandbox session IDs across all teams.
 // Used by the K8s GC reconciler to detect orphan pods.
 func (s *Store) AllSandboxSessionIDs(ctx context.Context) (map[string]bool, error) {
+	sessions, err := s.AllSandboxSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]bool, len(sessions))
+	for _, sess := range sessions {
+		result[sess.SessionID] = true
+	}
+	return result, nil
+}
+
+// AllSandboxSessions returns metadata for all sandbox sessions across all team
+// schemas. This is a platform-admin/background-worker surface for GC and audit;
+// user request paths must continue to use tenant-scoped stores.
+func (s *Store) AllSandboxSessions(ctx context.Context) ([]store.SandboxSessionGCInfo, error) {
 	teamSchemas, err := s.ListTeamSchemas(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list team schemas: %w", err)
 	}
 
-	result := make(map[string]bool)
+	var result []store.SandboxSessionGCInfo
 	for _, ts := range teamSchemas {
 		sessStore := s.sandboxSessionsForSchema(ts.orgDBName, ts.schemaName)
 		if sessStore == nil {
@@ -87,14 +103,35 @@ func (s *Store) AllSandboxSessionIDs(ctx context.Context) (map[string]bool, erro
 		sessions, err := sessStore.List(ctx, store.SandboxSessionFilter{})
 		if err != nil {
 			// Non-fatal: schema might not have sandbox_sessions table yet.
-			slog.Debug("AllSandboxSessionIDs: list failed", "db", ts.orgDBName, "schema", ts.schemaName, "error", err)
+			slog.Debug("AllSandboxSessions: list failed", "db", ts.orgDBName, "schema", ts.schemaName, "error", err)
 			continue
 		}
 		for _, sess := range sessions {
-			result[sess.SessionID] = true
+			if sess == nil {
+				continue
+			}
+			result = append(result, store.SandboxSessionGCInfo{
+				SandboxSession: *sess,
+				OrgDBName:      ts.orgDBName,
+				TeamSchema:     ts.schemaName,
+			})
 		}
 	}
 	return result, nil
+}
+
+// DeleteSandboxSessionInTeam removes a sandbox session row from the exact team
+// schema that owns it. It is used by GC only after the corresponding persisted
+// upper directory has been reclaimed.
+func (s *Store) DeleteSandboxSessionInTeam(ctx context.Context, orgDBName, teamSchema, sessionID string) error {
+	if orgDBName == "" || teamSchema == "" {
+		return fmt.Errorf("DeleteSandboxSessionInTeam: org database and team schema are required")
+	}
+	sessStore := s.sandboxSessionsForSchema(orgDBName, teamSchema)
+	if sessStore == nil {
+		return fmt.Errorf("DeleteSandboxSessionInTeam: sandbox session store unavailable for %s.%s", orgDBName, teamSchema)
+	}
+	return sessStore.Delete(ctx, sessionID)
 }
 
 // SandboxSessionsForTeam returns a SandboxSessionStore for the given org and
@@ -362,5 +399,3 @@ func (s *Store) MarkSandboxSessionEvicted(ctx context.Context, sessionID string)
 	}
 	return fmt.Errorf("MarkSandboxSessionEvicted: session %q not found", sessionID)
 }
-
-

--- a/pkg/store/sandbox.go
+++ b/pkg/store/sandbox.go
@@ -66,45 +66,45 @@ type BootstrapFile struct {
 //   - TopLayerID==nil means the template is layer-less (an alias of its
 //     parent); Resolve walks to the nearest ancestor with a non-nil TopLayerID.
 type SandboxTemplate struct {
-	ID              string                 `json:"id"`
-	Slug            string                 `json:"slug"`
-	Scope           SandboxTemplateScope   `json:"scope"`
-	OwnerID         string                 `json:"owner_id,omitempty"`
-	Purpose         SandboxTemplatePurpose `json:"purpose,omitempty"`
-	Name            string                 `json:"name"`
-	Description     string                 `json:"description,omitempty"`
-	ParentTemplateID *string               `json:"parent_template_id,omitempty"`
-	TopLayerID      *string                `json:"top_layer_id,omitempty"`
+	ID               string                 `json:"id"`
+	Slug             string                 `json:"slug"`
+	Scope            SandboxTemplateScope   `json:"scope"`
+	OwnerID          string                 `json:"owner_id,omitempty"`
+	Purpose          SandboxTemplatePurpose `json:"purpose,omitempty"`
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description,omitempty"`
+	ParentTemplateID *string                `json:"parent_template_id,omitempty"`
+	TopLayerID       *string                `json:"top_layer_id,omitempty"`
 	// SandboxImage holds a fully-qualified OCI image reference for backends
 	// that use per-template container images (e.g., OpenShell). When non-nil
 	// and non-empty, sandbox sessions use this image instead of the global
 	// default. Nil for templates that use the layer chain (incus/k8s).
-	SandboxImage    *string                `json:"sandbox_image,omitempty"`
+	SandboxImage *string `json:"sandbox_image,omitempty"`
 	// Packages is the list of apt packages to install when building a custom
 	// sandbox image. Stored as JSON in the database.
 	// DEPRECATED: Use DockerfileBody instead for full Dockerfile control.
-	Packages        []string               `json:"packages,omitempty"`
+	Packages []string `json:"packages,omitempty"`
 	// DockerfileBody stores the user-authored Dockerfile instructions
 	// (everything after FROM). When non-nil, it is the source of truth for
 	// image builds; Packages is ignored.
-	DockerfileBody  *string                `json:"dockerfile_body,omitempty"`
+	DockerfileBody *string `json:"dockerfile_body,omitempty"`
 	// BuildStatus tracks the image build state: "", "building", "succeeded", "failed".
-	BuildStatus     string                 `json:"build_status,omitempty"`
+	BuildStatus string `json:"build_status,omitempty"`
 	// BuildJobName is the K8s Job name of the current/last build.
-	BuildJobName    string                 `json:"build_job_name,omitempty"`
+	BuildJobName string `json:"build_job_name,omitempty"`
 	// BuildError stores the error message from the last failed build.
-	BuildError      string                 `json:"build_error,omitempty"`
+	BuildError string `json:"build_error,omitempty"`
 	// LastBuiltImage is the full image ref produced by the last successful build.
-	LastBuiltImage  string                 `json:"last_built_image,omitempty"`
+	LastBuiltImage string `json:"last_built_image,omitempty"`
 	// BuildStartedAt records when the last build was triggered.
-	BuildStartedAt  *time.Time             `json:"build_started_at,omitempty"`
+	BuildStartedAt *time.Time `json:"build_started_at,omitempty"`
 	// BootstrapFiles are injected into every container from this template
 	// at session start (mount only — callers must execute them explicitly).
-	BootstrapFiles  []BootstrapFile        `json:"bootstrap_files,omitempty"`
-	Version         int                    `json:"version"`
-	CreatedBy       string                 `json:"created_by,omitempty"`
-	CreatedAt       time.Time              `json:"created_at"`
-	UpdatedAt       time.Time              `json:"updated_at"`
+	BootstrapFiles []BootstrapFile `json:"bootstrap_files,omitempty"`
+	Version        int             `json:"version"`
+	CreatedBy      string          `json:"created_by,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
 }
 
 // SandboxTemplateFilter narrows list queries. Zero-value fields are ignored.
@@ -232,13 +232,13 @@ type BaseConfigInfo struct {
 
 // SandboxLayer is a content-addressed rootfs delta.
 type SandboxLayer struct {
-	LayerID      string    `json:"layer_id"` // sha256 hex of canonical tar
-	ParentLayer  *string   `json:"parent_layer,omitempty"`
-	CephFSPath   string    `json:"cephfs_path"` // mount path on the RWX PVC (e.g. /mnt/astonish-layers/<layer_id>); field name is historical — filesystem-agnostic
-	SizeBytes    int64     `json:"size_bytes"`
-	RefCount     int       `json:"ref_count"`
-	CreatedBy    string    `json:"created_by,omitempty"`
-	AddedAt      time.Time `json:"added_at"`
+	LayerID        string    `json:"layer_id"` // sha256 hex of canonical tar
+	ParentLayer    *string   `json:"parent_layer,omitempty"`
+	CephFSPath     string    `json:"cephfs_path"` // mount path on the RWX PVC (e.g. /mnt/astonish-layers/<layer_id>); field name is historical — filesystem-agnostic
+	SizeBytes      int64     `json:"size_bytes"`
+	RefCount       int       `json:"ref_count"`
+	CreatedBy      string    `json:"created_by,omitempty"`
+	AddedAt        time.Time `json:"added_at"`
 	LastReferenced time.Time `json:"last_referenced"`
 }
 
@@ -372,25 +372,39 @@ const (
 // chat session in {team_schema}.sessions. In personal mode and in the
 // common one-chat-one-sandbox case, callers MAY set SessionID == ChatSessionID.
 type SandboxSession struct {
-	SessionID      string              `json:"session_id"`
-	ChatSessionID  string              `json:"chat_session_id"`
-	Backend        string              `json:"backend"` // "incus" | "k8s"
-	ContainerName  string              `json:"container_name,omitempty"`
-	TemplateID     string              `json:"template_id"`
-	UpperLayerID   string              `json:"upper_layer_id,omitempty"`
+	SessionID     string `json:"session_id"`
+	ChatSessionID string `json:"chat_session_id"`
+	Backend       string `json:"backend"` // "incus" | "k8s"
+	ContainerName string `json:"container_name,omitempty"`
+	TemplateID    string `json:"template_id"`
+	UpperLayerID  string `json:"upper_layer_id,omitempty"`
 	// Image is the container image used to create this session (OpenShell).
 	// Stored so that StartSession can recreate with the correct image.
-	Image          string              `json:"image,omitempty"`
-	State          SandboxSessionState `json:"state"`
-	PodName        string              `json:"pod_name,omitempty"`
-	NodeName       string              `json:"node_name,omitempty"`
-	ExposedPorts   []int               `json:"exposed_ports,omitempty"`
-	BaseDomain     string              `json:"base_domain,omitempty"`
-	Pinned         bool                `json:"pinned,omitempty"`
-	CreatedBy      string              `json:"created_by,omitempty"`
-	CreatedAt      time.Time           `json:"created_at"`
-	UpdatedAt      time.Time           `json:"updated_at"`
-	LastActiveAt   time.Time           `json:"last_active_at"`
+	Image        string              `json:"image,omitempty"`
+	State        SandboxSessionState `json:"state"`
+	PodName      string              `json:"pod_name,omitempty"`
+	NodeName     string              `json:"node_name,omitempty"`
+	ExposedPorts []int               `json:"exposed_ports,omitempty"`
+	BaseDomain   string              `json:"base_domain,omitempty"`
+	Pinned       bool                `json:"pinned,omitempty"`
+	CreatedBy    string              `json:"created_by,omitempty"`
+	CreatedAt    time.Time           `json:"created_at"`
+	UpdatedAt    time.Time           `json:"updated_at"`
+	LastActiveAt time.Time           `json:"last_active_at"`
+}
+
+// SandboxSessionGCInfo is the platform-admin view used by background GC
+// workers that need to reason across team schemas. User-facing paths must use
+// tenant-scoped SandboxSessionStore instances instead.
+type SandboxSessionGCInfo struct {
+	SandboxSession
+
+	// OrgDBName and TeamSchema identify the team-scoped store that owns this
+	// row. They are intentionally populated only by entstore platform-admin
+	// enumeration and are used to delete stale registry rows after their
+	// persisted upper data has been reclaimed.
+	OrgDBName  string `json:"org_db_name,omitempty"`
+	TeamSchema string `json:"team_schema,omitempty"`
 }
 
 // SandboxSessionFilter narrows list queries. Zero-value fields are ignored.


### PR DESCRIPTION
## Summary

- Add configurable direct K8s GC settings for orphan upper grace and stale evicted upper retention.
- Extend platform sandbox-session enumeration so the GC can safely reclaim old evicted K8s uppers and then remove the owning registry row.
- Make orphan upper cleanup age-aware, skip pinned/active/live sessions, and document the shipped reconciler behavior.

## Tests

- `go test ./pkg/config ./pkg/sandbox/k8s ./pkg/daemon ./pkg/store/entstore`
- Pre-commit `golangci-lint` passed during commit.
