### PR TITLE
Fix K8s sandbox session IDs for channel chats

### DIFF
--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -397,13 +397,13 @@ The entrypoint runs as PID 1 with the privilege path selected at chart-install t
    - Walk `parent_template_id` from the chosen template up to the root (`@base`), collecting each ancestor's `top_layer_id`. Reverse to obtain bottom-up order.
    - Verify every layer exists on the layers PVC at `/mnt/astonish-layers/<layer-id>/rootfs/`.
    - Reject if chain depth > `sandbox.layers.maxChainDepth` (default 20; §5.11).
-2. Generate deterministic pod name: `astn-sess-<sessionID>` (truncated to 27 chars after the prefix; DNS-1123 sanitized; `pkg/sandbox/k8s/session.go::podNameForSession`).
+2. Generate deterministic pod name: `astn-sess-<dns-safe-prefix>-<hash>` (`pkg/sandbox/k8s/session.go::podNameForSession`). The readable prefix is DNS-1123 sanitized and the hash suffix preserves uniqueness for channel session IDs that contain characters such as `:`, `@`, or `_`.
 3. Build `PodSpec`:
    - Privilege path from §10 (FUSE plugin / userns / privileged / Sysbox), driven by `sandbox.overlay.*` Helm values.
    - `imagePullPolicy` derived by `pkg/sandbox/k8s/image.go::imagePullPolicy()` (`Always` for mutable tags such as `dev`/`latest`/`edge`/`nightly`; `IfNotPresent` for digest pins and immutable tags).
    - Namespace: configured sandbox namespace (default `astonish-sandbox`).
-   - Labels: `astonish.io/{org,team,session-id,type=session,template}`; optional `astonish.io/purpose=team-template-editor` for editor sessions.
-   - Annotations: `astonish.io/created-by`, `astonish.io/created-at`, `astonish.io/layer-chain=<comma-separated-ids>`.
+   - Labels: `astonish.io/{org,team,session-id,type=session,template}`; optional `astonish.io/purpose=team-template-editor` for editor sessions. The `session-id` label is DNS-safe and may be hashed for channel sessions.
+   - Annotations: `astonish.io/created-by`, `astonish.io/created-at`, `astonish.io/session-id=<exact chat/channel session ID>`, `astonish.io/layer-chain=<comma-separated-ids>`.
    - Volumes: `layers` (RO or RW depending on purpose), `uppers` (RW), `overlay` (`emptyDir`).
    - Main container entrypoint as above; resource requests/limits from `sandbox.requests.*` and `sandbox.limits.*` (auto-derived from limits when requests are zero — see §6).
 4. **Self-heal step (Status: shipped).** Before returning, `CreateSession` verifies the pod actually exists in the cluster — not just in any cached registry entry. This protects against stale registry rows pointing at pods that were deleted out-of-band (e.g., node failure, manual `kubectl delete`); when the verification fails, the registry entry is dropped and the create proceeds normally.
@@ -414,14 +414,14 @@ The entrypoint runs as PID 1 with the privilege path selected at chart-install t
 **Start / Stop** (decision Q1(b) — evict via tar stream to the uppers PVC):
 
 - Sessions stay running while active. On idle timeout:
-  - Each session pod mounts only its own uppers PVC subdirectory (`subPath: <session-id>`) at `/mnt/astonish-uppers`. The full PVC root is not visible to the chrooted sandbox, so a session cannot enumerate or read another session's persisted upper directory through `/mnt/astonish-uppers`.
+  - Each session pod mounts only its own uppers PVC subdirectory at `/mnt/astonish-uppers`. Filesystem-safe session IDs use the session ID directly; channel IDs with punctuation (for example email thread IDs) use a deterministic `sid-<hash>` subdirectory. The full PVC root is not visible to the chrooted sandbox, so a session cannot enumerate or read another session's persisted upper directory through `/mnt/astonish-uppers`.
   - `StopSession` first marks the row `evicting`, then persists the live pod's writable layer by streaming `/var/astonish/overlay/upper` to that mounted session subdirectory via
     `tar --numeric-owner --xattrs --acls -I "zstd --adapt -T0" --exclude=/var/astonish/overlay/upper/mnt/astonish-uppers -C /var/astonish/overlay/upper -cf /mnt/astonish-uppers/upper.tar.zst.tmp . && mv .../upper.tar.zst.tmp .../upper.tar.zst`.
     Only after that capture succeeds does it delete the pod. If capture fails, the pod stays running so data is not lost.
   - The same persistence script is installed as a Kubernetes container `preStop` hook with a 90-second termination grace period. This covers manual `kubectl delete pod` and normal Kubernetes termination paths that bypass the backend's `StopSession` method.
   - Row in `sandbox_sessions` stays; status updates `evicting` → `evicted` and clears the pod binding after deletion. At eviction time, the original resolved layer chain is retained in the registry so resume does not silently fall back to plain `@base` for configured base/team-template sessions.
 - On next tool interaction, `StartSession` recreates the pod with the same `ASTONISH_SESSION_ID`; the entrypoint resume step (above) streams `/mnt/astonish-uppers/upper.tar.zst` back into the local `emptyDir` before mounting the overlay. Resume latency: 1–5 s depending on upper-layer size.
-- Isolation invariant: the persisted-upper path is derived only from the registry row's exact session ID. API callers never provide an upper path, unsafe session IDs are rejected before any pod/tar/cleanup script is built, and cleanup deletes only the validated session subdirectory.
+- Isolation invariant: the persisted-upper path is derived only from the registry row's exact session ID. API callers never provide an upper path. Session IDs containing `/`, `.` or `..` are rejected before any pod/tar/cleanup script is built; other non-path-safe IDs are mapped through the deterministic hash described above, and cleanup deletes only that validated session subdirectory.
 
 This preserves Incus's "container exists but stopped, resume later" semantics while keeping each session's upper layer isolated under its own uppers-PVC directory.
 

--- a/pkg/sandbox/k8s/backend_test.go
+++ b/pkg/sandbox/k8s/backend_test.go
@@ -399,10 +399,10 @@ func TestPodNameForSession(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
-		{"00000000-0000-0000-0000-000000000001", "astn-sess-00000000-0000-0000-0000-000"},
-		{"SESSION_with_underscores", "astn-sess-session-with-underscores"},
-		{"--trim-edges--", "astn-sess-trim-edges"},
-		{"abc", "astn-sess-abc"},
+		{"00000000-0000-0000-0000-000000000001", "astn-sess-00000000-0000-0000-0000-000000000001-7ac1b8d7010b"},
+		{"SESSION_with_underscores", "astn-sess-session-with-underscores-81caeb55f834"},
+		{"--trim-edges--", "astn-sess-trim-edges-1243165d00ee"},
+		{"abc", "astn-sess-abc-ba7816bf8f01"},
 	}
 	for _, c := range cases {
 		if got := podNameForSession(c.in); got != c.want {

--- a/pkg/sandbox/k8s/session.go
+++ b/pkg/sandbox/k8s/session.go
@@ -35,6 +35,7 @@ package k8s
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"regexp"
@@ -77,6 +78,7 @@ const (
 	annotationCreatedBy  = "astonish.io/created-by"
 	annotationCreatedAt  = "astonish.io/created-at"
 	annotationLayerChain = "astonish.io/layer-chain"
+	annotationSessionID  = "astonish.io/session-id"
 )
 
 // Volume names used inside sandbox pods.
@@ -115,33 +117,46 @@ func upperDirNameForSession(sessionID string) (string, error) {
 	if sessionID == "" {
 		return "", errors.New("session ID is required")
 	}
-	if sessionID == "." || sessionID == ".." || strings.Contains(sessionID, "/") || !safeSessionPathRE.MatchString(sessionID) {
+	if sessionID == "." || sessionID == ".." || strings.Contains(sessionID, "/") {
 		return "", fmt.Errorf("session ID %q is not safe for upper persistence", sessionID)
 	}
-	return sessionID, nil
+	if safeSessionPathRE.MatchString(sessionID) {
+		return sessionID, nil
+	}
+	return upperDirHashForSession(sessionID), nil
+}
+
+func upperDirHashForSession(sessionID string) string {
+	sum := sha256.Sum256([]byte(sessionID))
+	return fmt.Sprintf("sid-%x", sum[:16])
 }
 
 // podNameForSession returns the deterministic pod name used by the K8s
 // backend. Exposed here (rather than inlined) so that session.go,
 // exec.go, files.go, and fleet.go agree on the naming scheme.
 //
-// The scheme is "astn-sess-" + the first 27 chars of the session ID
-// (lowercased, DNS-sanitised) to stay within Kubernetes' 253-char
-// DNS-1123 limit while remaining trivially reversible for operators
-// reading kubectl output. Reference:
-// docs/architecture/sandbox-backends.md §5.3 step 2.
+// The scheme is "astn-sess-" + a readable DNS-safe prefix + a short hash
+// suffix. The hash keeps non-UUID channel sessions (for example email thread
+// IDs containing ':' and '@') from colliding after DNS sanitisation/truncation.
+// Reference: docs/architecture/sandbox-backends.md §5.3 step 2.
 func podNameForSession(sessionID string) string {
 	const prefix = "astn-sess-"
-	const maxIDLen = 27
+	const hashLen = 12
+	const maxNameLen = 63
 	clean := toDNSLabel(sessionID)
-	if len(clean) > maxIDLen {
-		clean = clean[:maxIDLen]
+	sum := sha256.Sum256([]byte(sessionID))
+	suffix := fmt.Sprintf("-%x", sum[:hashLen/2])
+	maxCleanLen := maxNameLen - len(prefix) - len(suffix)
+	if len(clean) > maxCleanLen {
+		clean = clean[:maxCleanLen]
 	}
-	// Re-trim trailing '-' in case truncation left one.
 	for len(clean) > 0 && clean[len(clean)-1] == '-' {
 		clean = clean[:len(clean)-1]
 	}
-	return prefix + clean
+	if clean == "" {
+		clean = hashDNSLabel(sessionID)
+	}
+	return prefix + clean + suffix
 }
 
 // toDNSLabel lower-cases the input and replaces any character that is
@@ -168,7 +183,22 @@ func toDNSLabel(s string) string {
 	for len(out) > 0 && out[len(out)-1] == '-' {
 		out = out[:len(out)-1]
 	}
+	if len(out) == 0 {
+		return hashDNSLabel(s)
+	}
 	return string(out)
+}
+
+func hashDNSLabel(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("h%x", sum[:8])
+}
+
+func labelValueForSession(sessionID string) string {
+	if len(sessionID) <= 63 && toDNSLabel(sessionID) == sessionID {
+		return sessionID
+	}
+	return hashDNSLabel(sessionID)
 }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +213,8 @@ func (b *K8sBackend) buildPodManifest(spec sandbox.SessionSpec) (*corev1.Pod, er
 	if spec.SessionID == "" {
 		return nil, errors.New("SessionSpec.SessionID is required")
 	}
-	if _, err := upperDirNameForSession(spec.SessionID); err != nil {
+	upperDir, err := upperDirNameForSession(spec.SessionID)
+	if err != nil {
 		return nil, err
 	}
 	if spec.TemplateID == "" {
@@ -206,7 +237,7 @@ func (b *K8sBackend) buildPodManifest(spec sandbox.SessionSpec) (*corev1.Pod, er
 
 	labels := map[string]string{
 		labelType:      typeSession,
-		labelSessionID: toDNSLabel(spec.SessionID),
+		labelSessionID: labelValueForSession(spec.SessionID),
 		labelTemplate:  toDNSLabel(spec.TemplateID),
 	}
 	if spec.OrgSlug != "" {
@@ -221,7 +252,10 @@ func (b *K8sBackend) buildPodManifest(spec sandbox.SessionSpec) (*corev1.Pod, er
 	}
 
 	annotations := map[string]string{
-		annotationCreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		annotationCreatedAt: time.Now().UTC().Format(time.RFC3339),
+		// Preserve the exact chat/channel session ID for operators. Kubernetes
+		// labels are intentionally DNS-safe and may be hashed for email threads.
+		annotationSessionID:  spec.SessionID,
 		annotationLayerChain: strings.Join(spec.LayerChain, ","),
 	}
 	if spec.UserID != "" {
@@ -267,7 +301,7 @@ func (b *K8sBackend) buildPodManifest(spec sandbox.SessionSpec) (*corev1.Pod, er
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: volumeLayers, MountPath: mountLayers, ReadOnly: spec.Labels[labelPurpose] != purposeTeamTemplateEditor},
-						{Name: volumeUppers, MountPath: mountUppers, SubPath: spec.SessionID},
+						{Name: volumeUppers, MountPath: mountUppers, SubPath: upperDir},
 						{Name: volumeOverlay, MountPath: mountOverlay},
 					},
 					Resources: buildResourceRequirements(spec.Limits),

--- a/pkg/sandbox/k8s/session_test.go
+++ b/pkg/sandbox/k8s/session_test.go
@@ -766,8 +766,8 @@ func TestStopSession_DoesNotDeletePodWhenPersistFails(t *testing.T) {
 	}
 }
 
-func TestUpperDirNameForSessionRejectsUnsafeIDs(t *testing.T) {
-	bad := []string{"", ".", "..", "../other", "abc;rm -rf /", "$(cat /secret)", "abc/def", "team session"}
+func TestUpperDirNameForSessionRejectsPathTraversalIDs(t *testing.T) {
+	bad := []string{"", ".", "..", "../other", "abc/def"}
 	for _, id := range bad {
 		if got, err := upperDirNameForSession(id); err == nil {
 			t.Fatalf("upperDirNameForSession(%q) = %q, want error", id, got)
@@ -778,11 +778,45 @@ func TestUpperDirNameForSessionRejectsUnsafeIDs(t *testing.T) {
 	}
 }
 
-func TestCreateSessionRejectsUnsafeSessionIDForUpperIsolation(t *testing.T) {
+func TestUpperDirNameForSessionHashesChannelIDs(t *testing.T) {
+	sessionID := "email:direct:rafael@example.com-a1b2c3d4"
+	got, err := upperDirNameForSession(sessionID)
+	if err != nil {
+		t.Fatalf("upperDirNameForSession(%q): %v", sessionID, err)
+	}
+	if got == sessionID || !strings.HasPrefix(got, "sid-") || !safeSessionPathRE.MatchString(got) {
+		t.Fatalf("upperDirNameForSession(%q) = %q, want safe hashed directory", sessionID, got)
+	}
+}
+
+func TestCreateSessionRejectsPathTraversalSessionIDForUpperIsolation(t *testing.T) {
 	b, _ := newBackendWithFakeClient(t)
 	_, err := b.CreateSession(context.Background(), sandbox.SessionSpec{SessionID: "../other", TemplateID: "t1"})
 	if err == nil || !strings.Contains(err.Error(), "not safe for upper persistence") {
 		t.Fatalf("CreateSession unsafe ID error = %v, want upper isolation validation", err)
+	}
+}
+
+func TestCreateSessionAcceptsEmailThreadSessionID(t *testing.T) {
+	b, cs := newBackendWithFakeClient(t)
+	ctx := context.Background()
+	sessionID := "email:direct:rafael@example.com-a1b2c3d4"
+	if _, err := b.CreateSession(ctx, sandbox.SessionSpec{SessionID: sessionID, TemplateID: "t1"}); err != nil {
+		t.Fatalf("CreateSession email session ID: %v", err)
+	}
+	pod, err := cs.CoreV1().Pods(b.cfg.Namespace).Get(ctx, podNameForSession(sessionID), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	upperDir, err := upperDirNameForSession(sessionID)
+	if err != nil {
+		t.Fatalf("upper dir: %v", err)
+	}
+	if got := pod.Spec.Containers[0].VolumeMounts[1].SubPath; got != upperDir {
+		t.Fatalf("uppers subPath = %q, want %q", got, upperDir)
+	}
+	if got := pod.Annotations[annotationSessionID]; got != sessionID {
+		t.Fatalf("session annotation = %q, want %q", got, sessionID)
 	}
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2669,9 +2669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,9 +2686,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,9 +2703,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2729,9 +2720,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2749,9 +2737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2769,9 +2754,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8643,9 +8625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8667,9 +8646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8691,9 +8667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8715,9 +8688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary
- Allow direct Kubernetes sandbox sessions to use email/channel chat session IDs by mapping non-path-safe IDs to deterministic safe upper directories.
- Add hash suffixes to K8s sandbox pod names to avoid collisions after DNS sanitization.
- Preserve the exact chat/channel session ID as a pod annotation and document the behavior.

## Tests
- go test ./pkg/sandbox/k8s ./pkg/sandbox ./pkg/channels
- git diff --check -- pkg/sandbox/k8s/session.go pkg/sandbox/k8s/session_test.go pkg/sandbox/k8s/backend_test.go docs/architecture/sandbox-backends.md