### PR TITLE
docs: update Code Mode documentation to reflect current modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ astonish chat -p anthropic -m claude-4  # Specific provider/model
 astonish chat --resume                 # Resume last session
 ```
 
-### Local code mode
+### Code Mode
 
-`astonish code` turns the binary into a local coding tool — like Claude Code, OpenCode, or Grok CLI. It runs the agent loop **in-process** and executes its built-in tools directly on your machine, in the current directory. No daemon, no server, and no login required.
+Your AI pair programmer that understands your entire codebase before writing a single line. `astonish code` runs locally — no daemon, no server, no login — executing the full agent loop in-process with direct access to your machine. Think Claude Code, Codex, or Cursor, but with a pre-computed knowledge graph that makes it **genuinely faster and smarter**.
 
 ```bash
 astonish code                          # Start coding in the current directory
@@ -142,32 +142,42 @@ astonish code -C ./my-project          # Operate in a specific directory
 astonish code --auto-approve           # Bypass tool & folder authorization prompts (a.k.a. --yolo)
 ```
 
-Tools run with your own permissions (no sandbox). Safety comes from two authorization prompts: **file-modifying / command-running tools ask before executing** (read-only inspection runs freely), and **access to paths outside the project directory asks first**. Each prompt offers **Allow**, **Always Allow** (for the rest of the turn/session), or **Deny** — use ↑/↓ and Enter, with the cursor defaulting to **Allow**. Use `--auto-approve` / `--yolo` to bypass both prompts.
+**Why it's different: codegraph-powered navigation.** While other coding agents grep and read files hoping to find the right context, Astonish queries a [pre-computed knowledge graph](https://github.com/colbymchenry/codegraph) of your repository — symbols, call edges, dependencies, blast radius — all resolved in 1–4 calls. The agent knows exactly what to read, what to change, and what else will break. No wasted tokens exploring. No missed callers. No half-baked plans.
 
 **Three operating modes** — cycle with `shift+tab`:
 
 | Mode | Border | Behavior |
 |------|--------|----------|
-| **Normal** | gray | Full tool access with authorization prompts |
-| **Plan** | orange | Read-only investigation; produces structured plans without changing files |
-| **Graph Plan** | cyan | Codegraph-driven planning — 4-phase flow using a pre-computed knowledge graph |
+| **Normal** | gray | Full tool access — the agent reads, writes, builds, and tests |
+| **Plan** | amber | Graph-optimized planning — investigates the codebase read-only, then produces a structured, dependency-first execution plan |
+| **Ask** | green | Research-only Q&A — explore architecture, ask questions, discuss approaches without changing anything |
 
-**Graph-Optimized Plan mode** is the standout efficiency feature. It uses [codegraph](https://github.com/colbymchenry/codegraph) — a pre-computed knowledge graph of your repository (symbols, call edges, dependencies, blast radius) — to drive a phased planning flow:
+#### Plan Mode — Think Before You Act
 
-1. **GRAPH** — Query the knowledge graph. Most structural questions resolve in 1–4 calls.
-2. **READ** — Read exactly the files the graph identified.
-3. **GAP** — Fill genuine gaps with grep/find/code_references (only if needed).
-4. **PLAN** — Record the finalized, dependency-first plan.
+The killer feature. Instead of jumping straight into edits, Plan mode uses the codegraph to map out the full blast radius of a change before touching a single file:
 
-The result: plans that are faster (fewer tool calls), cheaper (lower token usage), and more complete (full blast-radius coverage) than free-form investigation. Plans persist to a session `PLAN.md` that survives context compaction.
+1. **GRAPH** — Query the knowledge graph for symbols, callers, and dependencies.
+2. **READ** — Read only the files the graph identified as relevant.
+3. **GAP** — Fill genuine gaps with grep/find/references (only if the graph couldn't answer).
+4. **PLAN** — Produce a finalized, dependency-first execution plan with per-phase verification.
 
-Code mode opens even if you haven't picked a model yet. Type `/model` inside the app to choose a provider and model; the selection is saved to your Astonish config (`~/.config/astonish/config.yaml`) and reused next time. If you have no providers configured, type `/provider` to add one (name, type, and API key) — code mode manages providers entirely in the config file and never needs a database.
+The result: plans that are **faster** (fewer tool calls), **cheaper** (lower token usage), and **more complete** (nothing left orphaned or unwired). Plans persist to a session `PLAN.md` that survives context compaction — pick up exactly where you left off.
 
-Code mode follows the [AGENTS.md](https://agents.md) convention: on startup it loads `AGENTS.md` (or `CLAUDE.md` as a fallback) from your project — walking up from the working directory to the repo root, nearest file winning — plus a global `~/.config/astonish/AGENTS.md`, and feeds them to the agent as project guidance.
+#### Ask Mode — Understand Before You Decide
 
-Your conversations are saved to disk and kept **separate per project directory** (and separate from Studio chat sessions). Each `astonish code` run starts a fresh session, but your earlier conversations in that directory are never lost — type `/sessions` to browse and resume a previous session. Sessions started in a different directory won't appear, so each project keeps its own history.
+Sometimes you need answers, not changes. Ask mode gives the agent full read-only access to your codebase — files, search, codegraph, memory — but disables all mutating tools. Use it to understand architecture, trace data flows, discuss tradeoffs, or ask "how does X work?" before committing to an approach.
 
-Additional code-mode features: `/rollback` reverts both the conversation and file changes to any earlier point. When logged in to a platform, press `Ctrl+\` to switch between local code (orange accent) and platform chat (blue accent) within the same TUI.
+---
+
+**Safety by default.** Tools run with your own permissions (no sandbox). File-modifying and command-running tools ask before executing; access to paths outside the project directory asks first. Each prompt offers **Allow**, **Always Allow**, or **Deny**. Use `--auto-approve` / `--yolo` to bypass both prompts when you trust the agent fully.
+
+**Zero-config startup.** Code mode opens even without a configured model. Type `/model` to choose a provider and model (saved to `~/.config/astonish/config.yaml`), or `/provider` to add one from scratch — no database needed.
+
+**Project-aware context.** On startup, Astonish loads `AGENTS.md` (or `CLAUDE.md` as fallback) from your project — walking up from the working directory to the repo root — plus a global `~/.config/astonish/AGENTS.md`. Your conventions, build commands, and project rules are always in context.
+
+**Per-project history.** Conversations are saved to disk and kept separate per project directory. Type `/sessions` to browse and resume any previous session. `/rollback` reverts both the conversation and file changes to any earlier point.
+
+**Dual-backend switching.** When logged in to a platform, press `Ctrl+\` to switch between local code (orange accent) and platform chat (blue accent) within the same TUI — your local coding agent and your team's collective intelligence, one keystroke apart.
 
 ---
 

--- a/docs/architecture/terminal-app.md
+++ b/docs/architecture/terminal-app.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Astonish ships a **fullscreen terminal chat app** comparable to Claude Code, OpenCode, and Grok Build CLI. It has two entry points that share the same `pkg/tui` presentation layer:
+Astonish ships a **fullscreen terminal chat app** comparable to Claude Code, Codex, OpenCode, and Grok Build. It has two entry points that share the same `pkg/tui` presentation layer:
 
 - **`astonish chat`** — platform-backed. Even a local installation requires authentication (`astonish login <url>`); the agent runs on the platform and the TUI streams Studio SSE.
 - **`astonish code`** — **local code mode**. The single binary runs the agent loop **in-process** and executes its compiled-in tools directly on the host filesystem in the working directory. There is no daemon, no HTTP, and no login. This is the Claude-Code-style local coding path.
@@ -61,7 +61,7 @@ If `client.IsRemoteMode()` is false (no `~/.config/astonish/remote.yaml` / login
 
 ## Code mode (local, in-process)
 
-`astonish code` runs the entire agent locally in the same process, like Claude Code / OpenCode / Grok CLI. It reuses the same `pkg/tui` presentation and event model as platform chat; only the backend differs.
+`astonish code` runs the entire agent locally in the same process, like Claude Code / Codex / OpenCode / Grok Build. It reuses the same `pkg/tui` presentation and event model as platform chat; only the backend differs.
 
 **Flow:** `cmd/astonish/code.go:handleCodeCommand` → `launcher.RunCodeTUI` →
 
@@ -356,7 +356,7 @@ Starting a new chat (`/new`, `ctrl+n`, or deleting the active session) clears an
 
 ### Graph-Optimized Plan mode (code mode only)
 
-`shift+tab` cycles a **third** mode after Plan: **Normal → Plan → Graph Plan → Normal** (composer border cyan, label `Graph Plan`). Like Plan mode it is a **no-changes** mode — `write_file` / `edit_file` / `shell_command` are blocked in every phase — but instead of free-form investigation it enforces a fixed **"plan-for-the-plan"** flow driven by [codegraph](https://github.com/colbymchenry/codegraph), an external knowledge-graph tool exposed over MCP as the read-only `codegraph_explore` query tool. Codegraph pre-computes symbols, call edges, dependencies and blast-radius, so most structural questions resolve in 1–4 calls instead of many broad `grep_search` / `find_files` passes — faster, cheaper, more complete plans.
+`shift+tab` cycles through three modes: **Normal → Plan → Ask → Normal** (Plan mode: composer border amber, label `Plan`; Ask mode: composer border green, label `Ask`). Plan mode is a **no-changes** mode — `write_file` / `edit_file` / `shell_command` are blocked in every phase — and it enforces a fixed **"plan-for-the-plan"** flow driven by [codegraph](https://github.com/colbymchenry/codegraph), an external knowledge-graph tool exposed over MCP as the read-only `codegraph_explore` query tool. Codegraph pre-computes symbols, call edges, dependencies and blast-radius, so most structural questions resolve in 1–4 calls instead of many broad `grep_search` / `find_files` passes — faster, cheaper, more complete plans. Ask mode is a **research-only** mode — all mutating tools are disabled and the agent answers questions using read-only tools only.
 
 **Phased gate.** A per-session phase state machine (`pkg/agent/graph_plan_state.go`, `GraphPlanState`) tracks the current phase; the phase determines the runtime allow-list. The model advances phases via three always-allowed **transition tools** (`gplan_reads`, `gplan_gaps`, `gplan_finalize`) that only mutate phase state. Enforcement is a `BeforeToolCallback` in `pkg/agent/chat_agent_run.go` (the same mechanism as the Plan-mode gate), so the model *physically cannot* call `grep_search` in the Graph phase. Blocked tools return a `blocked_graph_plan` **result** (not an error), with phase-aware guidance (`GraphPlanBlockedMessage`) so the model self-corrects and advances phases legitimately.
 

--- a/docs/plan-mode-enforcement-summary.md
+++ b/docs/plan-mode-enforcement-summary.md
@@ -199,8 +199,8 @@ UI-only change.
 
 ## Graph-Optimized Plan mode (code mode only)
 
-Graph-Optimized Plan is a **third mode** alongside Normal and Plan. `shift+tab` cycles
-**Normal → Plan → Graph Plan → Normal**. Like Plan mode it is a **no-changes** mode
+Graph-Optimized Plan is now simply called **Plan mode** in the UI. `shift+tab` cycles
+**Normal → Plan → Ask → Normal**. Like the old Plan mode it is a **no-changes** mode
 (`write_file` / `edit_file` / `shell_command` are blocked in every phase), but instead of a
 free-form investigation it enforces a fixed **"plan-for-the-plan"** flow driven by
 [**codegraph**](https://github.com/colbymchenry/codegraph) — an external knowledge-graph tool
@@ -295,7 +295,7 @@ gplan_* tools → tools.graphPlanAdvanceCallback → chatAgent.GetActiveGraphPla
 | `pkg/launcher/tui_code.go` | Bootstrap invocation, phase reset, active-graph-plan wiring, downgrade |
 | `pkg/config/standard_servers.go` | Keyless non-web `codegraph` entry + `FixedEnv` support |
 | `pkg/tui/backend/backend.go` | `GraphPlanMode bool` on `TurnOptions` |
-| `pkg/tui/app.go` | 3-way `togglePlanMode` cycle; `graphPlanModeSystemContext` mirror; "Graph Plan" label (cyan) |
+| `pkg/tui/app.go` | 3-way `togglePlanMode` cycle; `graphPlanModeSystemContext` mirror; "Plan" label (amber) |
 
 ### Tests (Graph-Optimized Plan)
 
@@ -303,6 +303,6 @@ gplan_* tools → tools.graphPlanAdvanceCallback → chatAgent.GetActiveGraphPla
   phase-aware blocked message, prompt discipline, `SafeTools` membership.
 - `pkg/agent/graph_plan_state_test.go` — transitions incl. `graph→gap` skip, reset, per-session isolation.
 - `pkg/tools/graph_plan_tool_test.go` — transition tools advance phases; empty-gaps skip to plan.
-- `pkg/tui/plan_mode_test.go` — 3-way cycle, `turnOptions` for Graph Plan, "Graph Plan" composer label.
+- `pkg/tui/plan_mode_test.go` — 3-way cycle (Normal → Plan → Ask → Normal), `turnOptions` for Plan/Ask, composer labels.
 - `pkg/config/mcp_config_test.go` — codegraph always injected, survives web filter, not persisted to `mcp_config.json`.
 

--- a/docs/website/docs/cli/code.md
+++ b/docs/website/docs/cli/code.md
@@ -1,6 +1,6 @@
 # Astonish Code
 
-`astonish code` turns the Astonish binary into a **local coding tool** — like Claude Code, OpenCode, or Grok CLI. It runs the agent loop **in-process** and executes its built-in tools directly on your machine, in the current directory. No daemon, no server, no login required.
+Your AI pair programmer that understands your entire codebase before writing a single line. `astonish code` runs the full agent loop **locally and in-process** — executing tools directly on your machine, in the current directory. No daemon, no server, no login required. Think Claude Code, Codex, or Cursor, but with a pre-computed knowledge graph that makes it genuinely faster and smarter.
 
 ```bash
 astonish code                          # Start coding in the current directory
@@ -37,31 +37,29 @@ On first launch, if no model is configured, type `/provider` to add an AI provid
 
 ## Operating Modes
 
-Cycle through modes with **`shift+tab`**: Normal → Plan → Graph Plan → Normal.
+Cycle through modes with **`shift+tab`**: Normal → Plan → Ask → Normal.
 
 | Mode | Composer Border | Behavior |
 |------|----------------|----------|
-| **Normal** | gray | Full tool access with authorization prompts |
-| **Plan** | orange | Read-only investigation; produces structured plans without changing files |
-| **Graph Plan** | cyan | Codegraph-driven 4-phase planning using a pre-computed knowledge graph |
+| **Normal** | gray | Full tool access — the agent reads, writes, builds, and tests |
+| **Plan** | amber | Graph-optimized planning — investigates the codebase read-only, then produces a structured, dependency-first execution plan |
+| **Ask** | green | Research-only Q&A — explore architecture, ask questions, discuss approaches without changing anything |
 
 ### Normal Mode
 
 The default operating mode. The agent has full access to all tools — file operations, shell commands, web fetching, browser automation, memory, and more. Non-read-only tools ask for authorization before executing (see [Safety Model](#safety-model)).
 
-### Plan Mode
-
-A read-only investigation mode. The agent can explore your codebase (read files, grep, search memory) but **cannot** write files, run commands, or spawn sub-agents. The runtime gate is enforced server-side — even if the model ignores the instruction, mutating tools are physically blocked.
-
-Use Plan mode when you want the agent to analyze a problem and produce a structured plan (with file lists, blast radius, and verification commands) before making any changes.
-
-### Graph-Optimized Plan Mode
+### Plan Mode — Think Before You Act
 
 ::: tip Standout Feature
-Graph-Optimized Plan mode is Astonish Code's most distinctive capability. It produces plans that are **faster** (fewer tool calls), **cheaper** (lower token usage), and **more complete** (full blast-radius coverage) than free-form investigation.
+Plan mode is Astonish Code's most distinctive capability. It produces plans that are **faster** (fewer tool calls), **cheaper** (lower token usage), and **more complete** (full blast-radius coverage) than free-form investigation.
 :::
 
-This mode uses [codegraph](https://github.com/colbymchenry/codegraph) — a pre-computed knowledge graph of your repository containing symbols, call edges, dependencies, and blast radius — to drive a **phased planning flow**. Instead of many broad `grep_search` / `find_files` passes, most structural questions resolve in 1–4 codegraph queries.
+Plan mode uses [codegraph](https://github.com/colbymchenry/codegraph) — a pre-computed knowledge graph of your repository containing symbols, call edges, dependencies, and blast radius — to drive a **phased planning flow**. Instead of many broad `grep_search` / `find_files` passes, most structural questions resolve in 1–4 codegraph queries.
+
+The agent can explore your codebase but **cannot** write files, run commands, or spawn sub-agents. The runtime gate is enforced server-side — even if the model ignores the instruction, mutating tools are physically blocked.
+
+Use Plan mode when you want the agent to map out the full blast radius of a change and produce a structured plan (with file lists, dependencies, and verification commands) before touching a single file.
 
 #### The Four Phases
 
@@ -91,7 +89,7 @@ Traditional code investigation follows a pattern like:
 4. `read_file` on 2–3 locations to confirm
 5. Repeat for each symbol...
 
-With Graph-Optimized Plan mode:
+With Plan mode:
 1. `codegraph_explore("AuthService loginUser session-manager")` → exact definitions, call graph, and blast radius in one call
 2. `gplan_reads` → read only the identified regions
 3. `announce_plan` → complete dependency-first plan
@@ -100,7 +98,7 @@ That's **3 calls instead of 15+** per symbol. Across a planning session resolvin
 
 #### Setup
 
-Graph-Optimized Plan mode requires [codegraph](https://github.com/colbymchenry/codegraph) to be installed:
+Plan mode requires [codegraph](https://github.com/colbymchenry/codegraph) to be installed for graph-powered planning:
 
 ```bash
 # Install codegraph (indexes your repository)
@@ -111,7 +109,7 @@ cd your-project
 codegraph init
 ```
 
-Codegraph is registered as a standard MCP server in Astonish — zero configuration needed. If codegraph is not installed or the project isn't indexed, Graph Plan mode gracefully **downgrades to free-form Plan mode** with a notice.
+Codegraph is registered as a standard MCP server in Astonish — zero configuration needed. If codegraph is not installed or the project isn't indexed, Plan mode gracefully **falls back to free-form planning** (read-only investigation without the phased graph flow).
 
 #### Plan Persistence
 
@@ -119,6 +117,18 @@ Plans created via `announce_plan` are written to a per-session `PLAN.md` file th
 - Survives **context compaction** — when the context window fills and old messages are summarized, the plan file persists and the agent can re-read it to resume exactly where it left off.
 - Contains a **checkbox per phase** with status (pending/running/complete/failed).
 - Records the **concrete blast radius** (affected files marked new/modify/delete), verification commands, and execution details per phase.
+
+### Ask Mode — Understand Before You Decide
+
+Sometimes you need answers, not changes. Ask mode gives the agent full read-only access to your codebase — files, search, codegraph, memory — but **disables all mutating tools**. The runtime gate is enforced server-side, just like Plan mode.
+
+Use Ask mode to:
+- **Understand architecture** — "How does the authentication flow work?"
+- **Trace data flows** — "Where does this config value get consumed?"
+- **Discuss tradeoffs** — "What are the implications of switching from REST to gRPC here?"
+- **Explore before committing** — investigate a problem space without the agent jumping into edits
+
+If you ask the agent to make changes while in Ask mode, it will remind you to switch to Normal or Plan mode (`shift+tab`).
 
 ## Safety Model
 
@@ -295,7 +305,8 @@ astonish code --debug
 
 ## Tips
 
-- Use **Graph Plan mode** (`shift+tab` twice) before large refactors — it produces complete, dependency-aware plans with blast-radius coverage.
+- Use **Plan mode** (`shift+tab`) before large refactors — it produces complete, dependency-aware plans with blast-radius coverage.
+- Use **Ask mode** (`shift+tab` twice) to explore and understand before committing to an approach.
 - Use **`@filename`** in the composer to attach file content to your message without manually pasting.
 - Press **`ctrl+o`** to expand/collapse the latest tool activity block.
 - **Drag to select** text in the transcript and it's automatically copied to your clipboard.

--- a/docs/website/docs/getting-started/choose-your-interface.md
+++ b/docs/website/docs/getting-started/choose-your-interface.md
@@ -10,7 +10,7 @@ New to Astonish? Start with **Studio** for the full visual experience, or **Asto
 
 ### Astonish Code (Local Coding Tool)
 
-A fully local, in-process coding agent — like Claude Code or OpenCode. Runs directly in your project directory with no daemon, no platform, and no login required. Tools execute with your own permissions on the host filesystem.
+A fully local, in-process coding agent — like Claude Code, Codex, or OpenCode. Runs directly in your project directory with no daemon, no platform, and no login required. Tools execute with your own permissions on the host filesystem.
 
 ```bash
 astonish code                          # Start coding in current directory
@@ -20,7 +20,8 @@ astonish code --auto-approve           # Bypass authorization prompts
 ```
 
 Features unique to code mode:
-- **Graph-Optimized Plan mode** — uses a pre-computed code knowledge graph for highly efficient, dependency-aware planning in a fraction of the tool calls
+- **Plan mode** — codegraph-powered planning that uses a pre-computed knowledge graph for highly efficient, dependency-aware plans in a fraction of the tool calls
+- **Ask mode** — research-only Q&A to explore architecture and discuss approaches without changing files
 - **Rollback** — revert both conversation and file changes to any earlier point
 - **Dual-backend switching** (`Ctrl+\`) — switch to platform chat without leaving the TUI
 - **AGENTS.md project guidance** — loads project conventions automatically


### PR DESCRIPTION
## Summary

Updates the Code Mode documentation across README and user docs to accurately reflect the current implementation.

### Changes

**Mode cycle fix:**
- Was incorrectly showing: Normal → Plan → Graph Plan → Normal
- Now correctly shows: **Normal → Plan → Ask → Normal**

**Merged Plan modes:**
- The old 'Plan Mode' (free-form read-only) and 'Graph-Optimized Plan Mode' (codegraph-driven) were shown as two separate modes, but in the code they are a single unified **Plan mode** that is always graph-based (with graceful fallback if codegraph isn't available)

**Added Ask mode documentation:**
- New research-only Q&A mode that was missing from all docs
- Read-only tools only, no changes, no plans — just answers
- Green border, cycles after Plan mode

**Naming & branding:**
- Renamed 'Local code mode' → 'Code Mode' in README
- Replaced 'Grok CLI' → 'Grok Build' (correct product name)
- Added 'Codex' to competitor reference lists
- More compelling copy highlighting codegraph as key differentiator

### Files changed
- `README.md`
- `docs/website/docs/cli/code.md`
- `docs/architecture/terminal-app.md`
- `docs/plan-mode-enforcement-summary.md`
- `docs/website/docs/getting-started/choose-your-interface.md`