### PR TITLE
fix: ensure codegraph index on every turn, show progress in status line

### DIFF
--- a/pkg/launcher/tui_code.go
+++ b/pkg/launcher/tui_code.go
@@ -842,20 +842,12 @@ func (b *localAgentBackend) RunTurn(ctx context.Context, message string, opts ba
 			return resp
 		}
 	}
-	// Graph-Optimized Plan mode: best-effort ensure the .codegraph/ index exists
-	// so the codegraph MCP server can answer queries. If unavailable, a notice
-	// tells the model to call gplan_gaps to skip the graph phase — but the gate
-	// still runs in all cases. We never downgrade to a different mode here.
+	// Graph-Optimized Plan mode setup.
 	planMode := opts.PlanMode
 	graphPlan := opts.GraphPlanMode
 	askMode := opts.AskMode
 	systemContext := opts.SystemContext
 	if graphPlan {
-		if notice := EnsureCodegraph(ctx, b.workingDir, func(msg string) {
-			emit("system", map[string]any{"content": msg})
-		}); notice != "" {
-			emit("system", map[string]any{"content": notice})
-		}
 		gp := chatAgent.GetOrCreateGraphPlanState(sessionID)
 		gp.Reset()
 		chatAgent.SetActiveGraphPlan(gp)
@@ -912,6 +904,16 @@ func (b *localAgentBackend) RunTurn(ctx context.Context, message string, opts ba
 					emit("session_title", map[string]any{"title": title, "sessionId": sessionID})
 				})
 			}
+		}
+
+		// Ensure the .codegraph/ index exists so the codegraph MCP server can
+		// answer codegraph_explore queries. This runs on every turn but is a
+		// fast no-op when the index already exists (single os.Stat). On first
+		// run it indexes the project and shows progress in the status line.
+		if notice := EnsureCodegraph(ctx, b.workingDir, func(msg string) {
+			out <- events.NewStatus(msg)
+		}); notice != "" {
+			emit("system", map[string]any{"content": notice})
 		}
 
 		// Turn-boundary compaction: if the active session is over threshold,


### PR DESCRIPTION
## Summary

Ensures the `.codegraph/` index is available for the codegraph MCP server on every turn in code mode, not just when Graph-Optimized Plan mode is explicitly activated.

## Problem

The `EnsureCodegraph` call was gated behind `if graphPlan`, meaning it only ran when the user explicitly activated Graph-Optimized Plan mode (shift+tab cycling). However, the codegraph MCP server is **always** injected as a standard server — so `codegraph_explore` is always available, but the index might not exist on first use.

Additionally, `EnsureCodegraph` ran synchronously before the goroutine, which blocked the TUI from rendering any progress.

## Changes

1. **Moved `EnsureCodegraph` outside the `if graphPlan` gate** — it now runs unconditionally (fast no-op via `os.Stat` when the index already exists)
2. **Moved it into the goroutine** — the TUI gets the event channel immediately and can render progress while indexing runs
3. **Changed progress to use `NewStatus` (spinner line)** instead of `emit("system", ...)` (transcript item) — transient progress messages show in the status bar with spinner animation rather than cluttering the conversation history

## Testing

- All `TestEnsureCodegraph_*` tests pass
- `golangci-lint` passes
- Manual testing confirms spinner shows "Indexing project for code intelligence (one-time)…" on first run when `.codegraph/` doesn't exist
