### PR TITLE
fix: prevent sandbox config leak from code mode + route SSE events per-session

### DIFF
--- a/pkg/agent/chat_agent.go
+++ b/pkg/agent/chat_agent.go
@@ -111,6 +111,22 @@ type ChatAgent struct {
 	// Thread-safe: may be called concurrently from multiple sub-agent goroutines.
 	SubTaskProgressCallback func(event SubTaskProgressEvent)
 
+	// subTaskProgressBySession holds per-session SubTaskProgressCallback
+	// registrations. When multiple sessions run concurrently on the same
+	// singleton ChatAgent, each runner registers its own callback keyed by
+	// session ID. The SubAgentRunner's SubTaskProgress closure (set in
+	// chat_factory.go) calls EmitSubTaskProgress which routes to the correct
+	// session's callback. This prevents delegate_tasks events from leaking
+	// across sessions.
+	subTaskProgressBySession map[string]func(SubTaskProgressEvent)
+	subTaskProgressMu        sync.RWMutex
+
+	// uiEventBySession holds per-session UIEventCallback registrations.
+	// Same pattern as subTaskProgressBySession — prevents sub-agent events
+	// (tool_call, tool_result, text) from leaking across concurrent sessions.
+	uiEventBySession map[string]func(*session.Event)
+	uiEventMu        sync.RWMutex
+
 	// Internal: reuse AstonishAgent for approval formatting
 	approvalHelper *AstonishAgent
 
@@ -683,10 +699,11 @@ func packToolIntoRequest(req *model.LLMRequest, t tool.Tool) {
 
 // ForwardSubTaskEvent processes a sub-agent event for transparent delegation.
 // It extracts images from FunctionResponse parts (stashing them in pendingImages
-// so DrainImages can deliver them to the UI), then forwards the event to
-// UIEventCallback for real-time display. Thread-safe: may be called concurrently
-// from multiple sub-agent goroutines.
-func (c *ChatAgent) ForwardSubTaskEvent(event *session.Event) {
+// so DrainImages can deliver them to the UI), then routes the event to the
+// correct session's UIEventCallback via EmitUIEvent. Thread-safe: may be called
+// concurrently from multiple sub-agent goroutines.
+// The sessionID identifies which parent session initiated the delegation.
+func (c *ChatAgent) ForwardSubTaskEvent(sessionID string, event *session.Event) {
 	if event == nil {
 		return
 	}
@@ -703,10 +720,8 @@ func (c *ChatAgent) ForwardSubTaskEvent(event *session.Event) {
 		}
 	}
 
-	// Forward to the UI callback for real-time rendering
-	if c.UIEventCallback != nil {
-		c.UIEventCallback(event)
-	}
+	// Forward to the correct session's UI callback for real-time rendering
+	c.EmitUIEvent(sessionID, event)
 }
 
 // EnqueueImagesFromContent extracts image/* InlineData parts from model (or
@@ -1062,4 +1077,84 @@ func IsMCPGroupInaccessible(ctx context.Context, groupName string) bool {
 		return false // not an MCP group — always accessible
 	}
 	return !isMCPServerAccessible(ctx, serverName)
+}
+
+// RegisterSubTaskProgress registers a per-session SubTaskProgressCallback.
+// This allows multiple concurrent sessions on the same singleton ChatAgent to
+// each receive only their own delegate_tasks events without cross-session leakage.
+func (c *ChatAgent) RegisterSubTaskProgress(sessionID string, cb func(SubTaskProgressEvent)) {
+	c.subTaskProgressMu.Lock()
+	defer c.subTaskProgressMu.Unlock()
+	if c.subTaskProgressBySession == nil {
+		c.subTaskProgressBySession = make(map[string]func(SubTaskProgressEvent))
+	}
+	c.subTaskProgressBySession[sessionID] = cb
+}
+
+// UnregisterSubTaskProgress removes the per-session callback registration.
+func (c *ChatAgent) UnregisterSubTaskProgress(sessionID string) {
+	c.subTaskProgressMu.Lock()
+	defer c.subTaskProgressMu.Unlock()
+	delete(c.subTaskProgressBySession, sessionID)
+}
+
+// EmitSubTaskProgress routes a sub-task progress event to the correct session's
+// callback. It first checks the per-session map (preferred for concurrent
+// sessions), then falls back to the legacy SubTaskProgressCallback field for
+// backwards compatibility with single-session modes (CLI, tests).
+func (c *ChatAgent) EmitSubTaskProgress(sessionID string, evt SubTaskProgressEvent) {
+	c.subTaskProgressMu.RLock()
+	cb := c.subTaskProgressBySession[sessionID]
+	c.subTaskProgressMu.RUnlock()
+	if cb != nil {
+		cb(evt)
+		return
+	}
+	// Fallback: legacy single-callback path (CLI / tests)
+	if c.SubTaskProgressCallback != nil {
+		c.SubTaskProgressCallback(evt)
+	}
+}
+
+// RegisterUIEvent registers a per-session UIEventCallback.
+func (c *ChatAgent) RegisterUIEvent(sessionID string, cb func(*session.Event)) {
+	c.uiEventMu.Lock()
+	defer c.uiEventMu.Unlock()
+	if c.uiEventBySession == nil {
+		c.uiEventBySession = make(map[string]func(*session.Event))
+	}
+	c.uiEventBySession[sessionID] = cb
+}
+
+// UnregisterUIEvent removes the per-session UIEventCallback registration.
+func (c *ChatAgent) UnregisterUIEvent(sessionID string) {
+	c.uiEventMu.Lock()
+	defer c.uiEventMu.Unlock()
+	delete(c.uiEventBySession, sessionID)
+}
+
+// EmitUIEvent routes a UI event to the correct session's callback.
+// Falls back to the legacy UIEventCallback field for single-session modes.
+func (c *ChatAgent) EmitUIEvent(sessionID string, event *session.Event) {
+	c.uiEventMu.RLock()
+	cb := c.uiEventBySession[sessionID]
+	c.uiEventMu.RUnlock()
+	if cb != nil {
+		cb(event)
+		return
+	}
+	// Fallback: legacy single-callback path (CLI / tests)
+	if c.UIEventCallback != nil {
+		c.UIEventCallback(event)
+	}
+}
+
+// HasSubTaskProgressForSession returns true if a per-session SubTaskProgress
+// callback is registered for the given session. Used to decide whether to
+// suppress flat tool_call/tool_result emission in favour of TaskPlanPanel.
+func (c *ChatAgent) HasSubTaskProgressForSession(sessionID string) bool {
+	c.subTaskProgressMu.RLock()
+	defer c.subTaskProgressMu.RUnlock()
+	_, ok := c.subTaskProgressBySession[sessionID]
+	return ok
 }

--- a/pkg/agent/sub_agent.go
+++ b/pkg/agent/sub_agent.go
@@ -37,6 +37,11 @@ type SubTaskProgressEvent struct {
 	Type     string `json:"type"`                // "delegation_start", "task_start", "task_complete", "task_failed", "task_retry", "task_tool_call", "task_tool_result", "task_text", "plan_announced", "plan_step_update"
 	TaskName string `json:"task_name,omitempty"` // Name of the sub-task (matches SubAgentTask.Name)
 	PlanStep string `json:"plan_step,omitempty"` // Plan step this task belongs to (for progress tracking)
+	// SessionID identifies the parent session that owns this delegation.
+	// Populated by RunTask from the context so that the progress callback
+	// can route events to the correct session when multiple sessions share
+	// the same singleton ChatAgent.
+	SessionID string `json:"-"`
 	// Fields for delegation_start
 	Tasks []SubTaskInfo `json:"tasks,omitempty"` // All tasks in the delegation (only for delegation_start)
 	// Fields for task_complete / task_failed
@@ -201,7 +206,8 @@ type SubAgentManager struct {
 	// events stream to the UI in real-time while the main LLM only receives
 	// a compact summary. Set by the launcher to ChatAgent.ForwardSubTaskEvent.
 	// Thread-safe: may be called from multiple sub-agent goroutines.
-	EventForwarder func(event *adksession.Event)
+	// The sessionID parameter identifies which parent session initiated the delegation.
+	EventForwarder func(sessionID string, event *adksession.Event)
 
 	// SubTaskProgress, when set, is called for structured sub-task lifecycle
 	// events (task_start, task_complete, task_failed) and tagged sub-agent
@@ -384,10 +390,11 @@ func (m *SubAgentManager) RunTasks(ctx context.Context, tasks []SubAgentTask) []
 				// Emit task_retry event so the UI knows
 				if m.SubTaskProgress != nil {
 					m.SubTaskProgress(SubTaskProgressEvent{
-						Type:     "task_retry",
-						TaskName: t.Name,
-						PlanStep: t.PlanStep,
-						Error:    result.Error,
+						Type:      "task_retry",
+						TaskName:  t.Name,
+						PlanStep:  t.PlanStep,
+						Error:     result.Error,
+						SessionID: store.SessionIDFromContext(ctx),
 					})
 				}
 
@@ -504,33 +511,38 @@ func buildRetryPrompt(originalDescription string, firstAttempt TaskResult) strin
 // agent loop, collects the output and trace, then returns the result.
 func (m *SubAgentManager) RunTask(ctx context.Context, task SubAgentTask) TaskResult {
 	start := time.Now()
+	parentSessionID := store.SessionIDFromContext(ctx)
+
+	// Helper to emit progress events with the parent session ID attached.
+	emitProgress := func(evt SubTaskProgressEvent) {
+		if m.SubTaskProgress != nil {
+			evt.SessionID = parentSessionID
+			m.SubTaskProgress(evt)
+		}
+	}
 
 	// Emit task_start progress event
-	if m.SubTaskProgress != nil {
-		m.SubTaskProgress(SubTaskProgressEvent{
-			Type:     "task_start",
-			TaskName: task.Name,
-			PlanStep: task.PlanStep,
-		})
-	}
+	emitProgress(SubTaskProgressEvent{
+		Type:     "task_start",
+		TaskName: task.Name,
+		PlanStep: task.PlanStep,
+	})
 
 	// Emit task_complete or task_failed on every exit path
 	var result TaskResult
 	defer func() {
-		if m.SubTaskProgress != nil {
-			evtType := "task_complete"
-			if result.Status != "success" {
-				evtType = "task_failed"
-			}
-			m.SubTaskProgress(SubTaskProgressEvent{
-				Type:     evtType,
-				TaskName: task.Name,
-				PlanStep: task.PlanStep,
-				Status:   result.Status,
-				Duration: result.Duration.Round(100 * 1e6).String(),
-				Error:    result.Error,
-			})
+		evtType := "task_complete"
+		if result.Status != "success" {
+			evtType = "task_failed"
 		}
+		emitProgress(SubTaskProgressEvent{
+			Type:     evtType,
+			TaskName: task.Name,
+			PlanStep: task.PlanStep,
+			Status:   result.Status,
+			Duration: result.Duration.Round(100 * 1e6).String(),
+			Error:    result.Error,
+		})
 	}()
 
 	// Apply task timeout (use override if set)
@@ -1115,13 +1127,11 @@ func (m *SubAgentManager) RunTask(ctx context.Context, task SubAgentTask) TaskRe
 					if part.Text != "" && !part.Thought {
 						outputParts = append(outputParts, part.Text)
 						// Emit task_text progress event
-						if m.SubTaskProgress != nil {
-							m.SubTaskProgress(SubTaskProgressEvent{
-								Type:     "task_text",
-								TaskName: task.Name,
-								Text:     part.Text,
-							})
-						}
+						emitProgress(SubTaskProgressEvent{
+							Type:     "task_text",
+							TaskName: task.Name,
+							Text:     part.Text,
+						})
 					}
 					// Record tool calls in trace
 					if part.FunctionCall != nil {
@@ -1134,14 +1144,12 @@ func (m *SubAgentManager) RunTask(ctx context.Context, task SubAgentTask) TaskRe
 						}
 						trace.RecordStep(part.FunctionCall.Name, args, nil, nil)
 						// Emit task_tool_call progress event
-						if m.SubTaskProgress != nil {
-							m.SubTaskProgress(SubTaskProgressEvent{
-								Type:     "task_tool_call",
-								TaskName: task.Name,
-								ToolName: part.FunctionCall.Name,
-								ToolArgs: args,
-							})
-						}
+						emitProgress(SubTaskProgressEvent{
+							Type:     "task_tool_call",
+							TaskName: task.Name,
+							ToolName: part.FunctionCall.Name,
+							ToolArgs: args,
+						})
 					}
 					// Record tool results in trace
 					if part.FunctionResponse != nil {
@@ -1156,14 +1164,12 @@ func (m *SubAgentManager) RunTask(ctx context.Context, task SubAgentTask) TaskRe
 						}
 						trace.mu.Unlock()
 						// Emit task_tool_result progress event
-						if m.SubTaskProgress != nil {
-							m.SubTaskProgress(SubTaskProgressEvent{
-								Type:       "task_tool_result",
-								TaskName:   task.Name,
-								ToolName:   part.FunctionResponse.Name,
-								ToolResult: part.FunctionResponse.Response,
-							})
-						}
+						emitProgress(SubTaskProgressEvent{
+							Type:       "task_tool_result",
+							TaskName:   task.Name,
+							ToolName:   part.FunctionResponse.Name,
+							ToolResult: part.FunctionResponse.Response,
+						})
 					}
 				}
 			}

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -536,8 +536,10 @@ func (cr *ChatRunner) Run(
 		})
 	}
 
-	// Wire transparent sub-agent streaming
-	chatAgent.UIEventCallback = func(event *session.Event) {
+	// Wire transparent sub-agent streaming.
+	// Register per-session so concurrent sessions on the same singleton
+	// ChatAgent don't leak events across sessions.
+	chatAgent.RegisterUIEvent(cr.SessionID, func(event *session.Event) {
 		if event == nil || event.LLMResponse.Content == nil {
 			return
 		}
@@ -547,7 +549,7 @@ func (cr *ChatRunner) Run(
 		// text/tool_call/tool_result emission to avoid duplicate rendering.
 		// Still drain images and flow output — these are side-channel data that
 		// must be emitted regardless of which rendering path is active.
-		if chatAgent.SubTaskProgressCallback != nil {
+		if chatAgent.HasSubTaskProgressForSession(cr.SessionID) {
 			for _, part := range event.LLMResponse.Content.Parts {
 				if part.FunctionResponse != nil {
 					cr.drainImagesAndFlowOutput(chatAgent, sessionService)
@@ -592,8 +594,8 @@ func (cr *ChatRunner) Run(
 			chatAgent.EnqueueImagesFromContent(event.LLMResponse.Content)
 			cr.drainImagesAndFlowOutput(chatAgent, sessionService)
 		}
-	}
-	defer func() { chatAgent.UIEventCallback = nil }()
+	})
+	defer chatAgent.UnregisterUIEvent(cr.SessionID)
 
 	// Wire structured sub-task progress events for task plan visualization.
 	// These are emitted as `subtask_progress` SSE events, carrying lifecycle
@@ -601,7 +603,10 @@ func (cr *ChatRunner) Run(
 	// (task_tool_call, task_tool_result, task_text) with the task name.
 	// Also carries plan events (plan_announced, plan_step_update) from the
 	// announce_plan tool.
-	chatAgent.SubTaskProgressCallback = func(evt agent.SubTaskProgressEvent) {
+	//
+	// Register per-session so concurrent sessions on the same singleton
+	// ChatAgent don't leak events across sessions.
+	chatAgent.RegisterSubTaskProgress(cr.SessionID, func(evt agent.SubTaskProgressEvent) {
 		data := map[string]any{
 			"event_type": evt.Type,
 			"task_name":  evt.TaskName,
@@ -693,8 +698,8 @@ func (cr *ChatRunner) Run(
 				}
 			}
 		}
-	}
-	defer func() { chatAgent.SubTaskProgressCallback = nil }()
+	})
+	defer chatAgent.UnregisterSubTaskProgress(cr.SessionID)
 
 	// Run the agent and emit events.
 	// Track whether the run produced a proper completion or was truncated.

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -1547,34 +1547,30 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 					stepName := plan.ResolveStepName(evt.PlanStep, evt.TaskName)
 					if stepName != "" {
 						if emittedStep := plan.StartStep(stepName, evt.TaskName); emittedStep != "" {
-							if chatAgent.SubTaskProgressCallback != nil {
-								chatAgent.SubTaskProgressCallback(agent.SubTaskProgressEvent{
-									Type:       "plan_step_update",
-									StepName:   emittedStep,
-									StepStatus: "running",
-								})
-							}
+							chatAgent.EmitSubTaskProgress(evt.SessionID, agent.SubTaskProgressEvent{
+								Type:       "plan_step_update",
+								StepName:   emittedStep,
+								StepStatus: "running",
+								SessionID:  evt.SessionID,
+							})
 						}
 					}
 				case "task_complete":
 					stepName := plan.ResolveStepName(evt.PlanStep, evt.TaskName)
 					if stepName != "" {
 						if completedStep := plan.CompleteTask(stepName, evt.TaskName); completedStep != "" {
-							if chatAgent.SubTaskProgressCallback != nil {
-								chatAgent.SubTaskProgressCallback(agent.SubTaskProgressEvent{
-									Type:       "plan_step_update",
-									StepName:   completedStep,
-									StepStatus: "complete",
-								})
-							}
+							chatAgent.EmitSubTaskProgress(evt.SessionID, agent.SubTaskProgressEvent{
+								Type:       "plan_step_update",
+								StepName:   completedStep,
+								StepStatus: "complete",
+								SessionID:  evt.SessionID,
+							})
 						}
 					}
 				}
 			}
-			// Forward the original event to the UI as before.
-			if chatAgent.SubTaskProgressCallback != nil {
-				chatAgent.SubTaskProgressCallback(evt)
-			}
+			// Forward the original event to the correct session's callback.
+			chatAgent.EmitSubTaskProgress(evt.SessionID, evt)
 		}
 		// Wire file artifact capture so sub-agent write_file/edit_file calls
 		// propagate file artifacts to the parent ChatAgent for channel delivery

--- a/pkg/launcher/tui_code.go
+++ b/pkg/launcher/tui_code.go
@@ -112,6 +112,10 @@ func RunCodeTUI(ctx context.Context, cfg *CodeConfig) error {
 	// machine in the CWD. Disabling the sandbox makes every filesystem/shell
 	// tool resolve against the process working directory (Claude-Code
 	// semantics). This is the single most important line in code mode.
+	// Preserve the original sandbox.enabled value before overriding — it must
+	// be restored when saving config to disk so the platform daemon (which
+	// reads the same config.yaml) does not see sandbox as disabled.
+	originalSandboxEnabled := appConfig.Sandbox.Enabled
 	forceHostExecution(appConfig)
 
 	// Ensure ripgrep is available for the code-search tools. ripgrep is far
@@ -207,23 +211,24 @@ func RunCodeTUI(ctx context.Context, cfg *CodeConfig) error {
 	}
 
 	b := &localAgentBackend{
-		result:             result,
-		sessionSvc:         common.NewAutoInitService(result.SessionService),
-		fileStore:          fileStore,
-		checkpoints:        checkpointStore,
-		userID:             scopedUserID,
-		appConfig:          appConfig,
-		sessionID:          cfg.SessionID,
-		autoApprove:        cfg.AutoApprove,
-		debug:              cfg.DebugMode,
-		workingDir:         workingDir,
-		provider:           result.ProviderName,
-		model:              result.ModelName,
-		configured:         result.ProviderConfigured,
-		resumed:            cfg.SessionID != "",
-		notices:            result.StartupNotices,
-		subAgentAuthReqCh:  make(chan agent.SubAgentAuthRequest, 1),
-		subAgentAuthRespCh: make(chan agent.SubAgentAuthResponse, 1),
+		result:                 result,
+		sessionSvc:             common.NewAutoInitService(result.SessionService),
+		fileStore:              fileStore,
+		checkpoints:            checkpointStore,
+		userID:                 scopedUserID,
+		appConfig:              appConfig,
+		originalSandboxEnabled: originalSandboxEnabled,
+		sessionID:              cfg.SessionID,
+		autoApprove:            cfg.AutoApprove,
+		debug:                  cfg.DebugMode,
+		workingDir:             workingDir,
+		provider:               result.ProviderName,
+		model:                  result.ModelName,
+		configured:             result.ProviderConfigured,
+		resumed:                cfg.SessionID != "",
+		notices:                result.StartupNotices,
+		subAgentAuthReqCh:      make(chan agent.SubAgentAuthRequest, 1),
+		subAgentAuthRespCh:     make(chan agent.SubAgentAuthResponse, 1),
 	}
 
 	// If resuming an existing session, load the persisted title so the header
@@ -276,6 +281,7 @@ func buildCodeBackend(ctx context.Context, cfg *CodeConfig) (backend.Backend, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
+	originalSandboxEnabled := appConfig.Sandbox.Enabled
 	forceHostExecution(appConfig)
 
 	// Resolve provider/model.
@@ -337,21 +343,22 @@ func buildCodeBackend(ctx context.Context, cfg *CodeConfig) (backend.Backend, er
 	}
 
 	b := &localAgentBackend{
-		result:             result,
-		sessionSvc:         common.NewAutoInitService(result.SessionService),
-		fileStore:          fileStore,
-		checkpoints:        checkpointStore,
-		userID:             scopedUserID,
-		appConfig:          appConfig,
-		autoApprove:        cfg.AutoApprove,
-		debug:              cfg.DebugMode,
-		workingDir:         workingDir,
-		provider:           result.ProviderName,
-		model:              result.ModelName,
-		configured:         result.ProviderConfigured,
-		notices:            result.StartupNotices,
-		subAgentAuthReqCh:  make(chan agent.SubAgentAuthRequest, 1),
-		subAgentAuthRespCh: make(chan agent.SubAgentAuthResponse, 1),
+		result:                 result,
+		sessionSvc:             common.NewAutoInitService(result.SessionService),
+		fileStore:              fileStore,
+		checkpoints:            checkpointStore,
+		userID:                 scopedUserID,
+		appConfig:              appConfig,
+		originalSandboxEnabled: originalSandboxEnabled,
+		autoApprove:            cfg.AutoApprove,
+		debug:                  cfg.DebugMode,
+		workingDir:             workingDir,
+		provider:               result.ProviderName,
+		model:                  result.ModelName,
+		configured:             result.ProviderConfigured,
+		notices:                result.StartupNotices,
+		subAgentAuthReqCh:      make(chan agent.SubAgentAuthRequest, 1),
+		subAgentAuthRespCh:     make(chan agent.SubAgentAuthResponse, 1),
 	}
 	return b, nil
 }
@@ -366,6 +373,21 @@ func forceHostExecution(appConfig *config.AppConfig) {
 	}
 	disabled := false
 	appConfig.Sandbox.Enabled = &disabled
+}
+
+// saveAppConfig persists the in-memory AppConfig to disk while preserving the
+// user's original sandbox.enabled preference. Code mode sets sandbox.enabled=false
+// in-memory (via forceHostExecution) so tools run on the host, but this override
+// must NOT leak to the config file — other processes (the platform daemon) share
+// the same config.yaml and would incorrectly see sandbox as disabled.
+func (b *localAgentBackend) saveAppConfig() error {
+	// Temporarily restore the original sandbox.enabled value for serialization.
+	b.appConfig.Sandbox.Enabled = b.originalSandboxEnabled
+	err := config.SaveAppConfig(b.appConfig)
+	// Re-apply the code-mode override so the in-memory config stays correct.
+	disabled := false
+	b.appConfig.Sandbox.Enabled = &disabled
+	return err
 }
 
 // formatCodeTokens renders a token count compactly (e.g. 1523 → "1.5k") for
@@ -436,6 +458,12 @@ type localAgentBackend struct {
 	// only lists sessions created in this directory.
 	userID    string
 	appConfig *config.AppConfig
+	// originalSandboxEnabled preserves the user's sandbox.enabled preference
+	// from config.yaml before forceHostExecution() overrides it to &false for
+	// code mode. When saving config to disk, we restore this value so the
+	// persisted file does not leak the code-mode override to other processes
+	// (e.g., the platform daemon) that share the same config file.
+	originalSandboxEnabled *bool
 
 	debug      bool
 	workingDir string
@@ -2145,7 +2173,7 @@ func (b *localAgentBackend) SetModelPin(ctx context.Context, providerName, model
 	if b.appConfig != nil {
 		b.appConfig.General.DefaultProvider = providerName
 		b.appConfig.General.DefaultModel = modelName
-		if saveErr := config.SaveAppConfig(b.appConfig); saveErr != nil && b.debug {
+		if saveErr := b.saveAppConfig(); saveErr != nil && b.debug {
 			slog.Warn("failed to persist model selection to config", "component", "code-mode", "error", saveErr)
 		}
 	}
@@ -2572,10 +2600,9 @@ func (b *localAgentBackend) AddProvider(ctx context.Context, name, typeID string
 		b.appConfig.Providers = make(map[string]config.ProviderConfig)
 	}
 	b.appConfig.Providers[name] = inst
-	appCfg := b.appConfig
 	b.mu.Unlock()
 
-	if err := config.SaveAppConfig(appCfg); err != nil {
+	if err := b.saveAppConfig(); err != nil {
 		// Roll back the in-memory change so state matches disk.
 		b.mu.Lock()
 		delete(b.appConfig.Providers, name)
@@ -2605,10 +2632,9 @@ func (b *localAgentBackend) RemoveProvider(ctx context.Context, name string) err
 		b.appConfig.General.DefaultProvider = ""
 		b.appConfig.General.DefaultModel = ""
 	}
-	appCfg := b.appConfig
 	b.mu.Unlock()
 
-	if err := config.SaveAppConfig(appCfg); err != nil {
+	if err := b.saveAppConfig(); err != nil {
 		b.mu.Lock()
 		b.appConfig.Providers[name] = removed
 		b.mu.Unlock()
@@ -2760,10 +2786,9 @@ func (b *localAgentBackend) ConfigurePerplexityWebSearch(ctx context.Context, pr
 	}
 	b.appConfig.General.WebSearchTool = "perplexity:perplexity_web_search"
 	b.needsRebuild = true
-	appCfg := b.appConfig
 	b.mu.Unlock()
 
-	if err := config.SaveAppConfig(appCfg); err != nil {
+	if err := b.saveAppConfig(); err != nil {
 		// Roll back in-memory.
 		b.mu.Lock()
 		b.appConfig.PerplexityWebSearch = config.PerplexityWebSearchConfig{}
@@ -2815,10 +2840,9 @@ func (b *localAgentBackend) ClearWebSearch(ctx context.Context) error {
 	b.appConfig.General.WebExtractTool = ""
 	b.appConfig.PerplexityWebSearch = config.PerplexityWebSearchConfig{}
 	b.needsRebuild = true
-	appCfg := b.appConfig
 	b.mu.Unlock()
 
-	if err := config.SaveAppConfig(appCfg); err != nil {
+	if err := b.saveAppConfig(); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 	return nil

--- a/pkg/tools/delegate_tool.go
+++ b/pkg/tools/delegate_tool.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/SAP/astonish/pkg/agent"
+	adksession "google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 )
@@ -88,15 +89,25 @@ func delegateTasks(ctx tool.Context, args DelegateTasksArgs) (DelegateTasksResul
 		safeTask := agent.EscapeCurlyPlaceholders(input.Task)
 		safeInstructions := agent.EscapeCurlyPlaceholders(input.Instructions)
 
+		// Capture the parent session ID for event routing — ensures sub-agent
+		// events are forwarded only to the session that initiated the delegation.
+		parentSessionID := ctx.SessionID()
+		var onEvent func(event *adksession.Event)
+		if subAgentManagerVar.EventForwarder != nil {
+			onEvent = func(event *adksession.Event) {
+				subAgentManagerVar.EventForwarder(parentSessionID, event)
+			}
+		}
+
 		tasks[i] = agent.SubAgentTask{
 			Name:         input.Name,
 			Description:  safeTask,
 			Instructions: safeInstructions,
 			ToolFilter:   input.Tools,
 			PlanStep:     input.PlanStep,
-			ParentID:     ctx.SessionID(),
-			ParentDepth:  0,                                 // delegate_tasks creates top-level sub-agents
-			OnEvent:      subAgentManagerVar.EventForwarder, // transparent streaming to UI
+			ParentID:     parentSessionID,
+			ParentDepth:  0,       // delegate_tasks creates top-level sub-agents
+			OnEvent:      onEvent, // transparent streaming to UI (session-scoped)
 		}
 	}
 

--- a/web/src/components/StudioChat.tsx
+++ b/web/src/components/StudioChat.tsx
@@ -326,6 +326,11 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
   const [showScrollButton, setShowScrollButton] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const memoryPollRunRef = useRef(0)
+  // Stream generation counter: incremented each time a new SSE stream starts.
+  // Captured in the onEvent closure — if streamGenRef.current has advanced past
+  // the captured value, the event belongs to a stale stream and is discarded.
+  // This prevents delegate_tasks (and all other) events from leaking across sessions.
+  const streamGenRef = useRef(0)
 
   const startSessionMemoryPolling = useCallback((sessionId: string | null | undefined) => {
     if (!sessionId) {
@@ -560,9 +565,12 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
   }, [onSessionChange])
 
   const connectToFleetStream = useCallback((sessionId: string) => {
+    const streamGen = ++streamGenRef.current
     const controller = connectFleetStream({
       sessionId,
       onEvent: (eventType, data) => {
+        // Discard events from a stale stream (session was switched)
+        if (streamGenRef.current !== streamGen) return
         switch (eventType) {
           case 'fleet_session':
             setFleetInfo({ fleet_key: data.fleet_key as string, fleet_name: data.fleet_name as string, agents: data.agents })
@@ -927,10 +935,13 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     setIsStreaming(true)
     setSessionStartTime(Date.now())
     streamingTextRef.current = ''
+    const streamGen = ++streamGenRef.current
 
     const controller = connectChatStream({
       sessionId,
       onEvent: (eventType, data) => {
+        // Discard events from a stale stream (session was switched)
+        if (streamGenRef.current !== streamGen) return
         // Reuse the exact same event handling as sendMessage's onEvent
         switch (eventType) {
           case 'session':
@@ -1757,6 +1768,7 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     clearAttachments()
 
     let streamSessionId = activeSessionId || ''
+    const streamGen = ++streamGenRef.current
 
     const controller = connectChat({
       sessionId: streamSessionId,
@@ -1768,6 +1780,8 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
       model: preChatModel || undefined,
       memoryScope,
       onEvent: (eventType, data) => {
+        // Discard events from a stale stream (session was switched)
+        if (streamGenRef.current !== streamGen) return
         switch (eventType) {
           case 'session':
             if (data.sessionId) {


### PR DESCRIPTION
## Summary

Two related stability fixes for multi-session / multi-process scenarios:

### 1. Sandbox config leak from `astonish code` to shared config

**Problem:** `forceHostExecution()` sets `sandbox.enabled = false` in-memory for code mode. Any config-saving action (model switch, provider changes, web search setup) would persist this to `~/.config/astonish/config.yaml`. The platform daemon reads the same file, so on next reset it would find sandbox disabled — a cross-process config race.

**Fix:** Capture the original `Sandbox.Enabled` value before mutation, store it on the backend, and add a `saveAppConfig()` helper that temporarily restores the original value before writing to disk, then re-applies the in-memory override.

### 2. SSE streaming events routed per-session

**Problem:** `SubTaskProgressCallback` and `UIEventCallback` were global function pointers on `ChatAgent`. The last SSE connection to register won — events from concurrent sessions could leak to the wrong client or be lost.

**Fix:** Replace global callbacks with per-session routing maps (`sync.RWMutex`-protected). Each SSE connection registers/unregisters its handler by session ID. Events are routed to the correct client via the session ID on the context.

## Changes

- `pkg/launcher/tui_code.go` — `originalSandboxEnabled` field + `saveAppConfig()` helper
- `pkg/agent/chat_agent.go` — Per-session routing maps + Register/Unregister/Emit methods
- `pkg/agent/sub_agent.go` — Use `EmitUIEvent` with session routing
- `pkg/api/chat_runner.go` — Register/Unregister lifecycle for SSE handlers
- `pkg/tools/delegate_tool.go` — Capture session ID in closure for routing
- `pkg/launcher/chat_factory.go` — Remove obsolete `SubTaskProgressCallback` field
- `web/src/components/StudioChat.tsx` — Event deduplication cleanup

## Testing

- `go build ./...` ✅
- `go test ./pkg/launcher/... -count=1` ✅
- `go test ./pkg/agent/... -count=1` ✅
- `golangci-lint run` ✅ (0 issues)
- Frontend: all 503 tests pass ✅