### PR TITLE
feat(tools): allow http_request to reach private networks in sandbox

### DIFF
--- a/cmd/astonish/node.go
+++ b/cmd/astonish/node.go
@@ -86,6 +86,12 @@ func handleNodeCommand(args []string) error {
 	encoder := json.NewEncoder(os.Stdout)
 	scanner := bufio.NewScanner(os.Stdin)
 
+	// Inside a sandbox container, disable SSRF private-IP blocking for
+	// http_request. The sandbox's own network policy (OpenShell Landlock/seccomp,
+	// K8s NetworkPolicy, Incus network config) is the security boundary —
+	// the Go-level SSRF check is redundant and blocks legitimate internal API access.
+	tools.SetAllowPrivateNetworks(true)
+
 	// Increase scanner buffer for large tool args (e.g., write_file with big content)
 	const maxScanSize = 10 * 1024 * 1024 // 10MB
 	scanner.Buffer(make([]byte, 0, 64*1024), maxScanSize)

--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -1629,6 +1629,29 @@ Triggers that would motivate adding the warm pool:
 - Workload shift toward short-lived sessions (seconds to low-minutes), producing churn that stresses CNI IP allocation or kubelet pod-creation throughput.
 - Cost/performance trade-off in managed environments where pod startup is slower than bare-metal K3s.
 
+## 14.1 Network Access: SSRF Protection and Private Networks
+
+When tools run **inside a sandbox container**, the sandbox's own network policy (OpenShell Landlock/seccomp, K8s NetworkPolicy, Incus network config) is the security boundary. The Go-level SSRF protection (`checkSSRF()` in `pkg/tools/web_fetch.go`) that blocks requests to private/loopback IPs is therefore **automatically disabled** inside the sandbox node process (`cmd/astonish/node.go`).
+
+This means:
+- **`http_request`** can reach internal/corporate APIs (e.g., OpenStack, internal microservices) when running inside a sandbox — the sandbox network policy controls what is reachable.
+- **`web_fetch`** retains SSRF protection regardless of mode (it's for web content extraction, not authenticated API access).
+- **`shell_command`** (curl, wget, etc.) was never subject to SSRF checks and continues to work as before.
+
+### Personal/CLI mode (no sandbox)
+
+For users running without a sandbox (e.g., `astonish chat` on a corporate laptop with VPN access to internal APIs), SSRF protection can be disabled via config:
+
+```yaml
+# ~/.config/astonish/config.yaml
+security:
+  allow_private_networks: true
+```
+
+When this option is `true`, `http_request` can reach private/loopback IPs from the host. This is useful for accessing internal APIs that resolve to RFC1918 addresses.
+
+**Default:** `false` (SSRF protection active in personal/CLI mode).
+
 ## 15. References
 
 - `docs/architecture/sandbox.md` -- current Incus-based implementation.

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -476,7 +476,8 @@ func (c *SandboxOpenShellConfig) OpenShellIdleTimeout() time.Duration {
 
 // SecurityConfig controls security features like proactive secret detection.
 type SecurityConfig struct {
-	SecretScanner SecretScannerConfig `yaml:"secret_scanner,omitempty" json:"secret_scanner,omitempty"`
+	SecretScanner        SecretScannerConfig `yaml:"secret_scanner,omitempty" json:"secret_scanner,omitempty"`
+	AllowPrivateNetworks bool                `yaml:"allow_private_networks" json:"allow_private_networks,omitempty"`
 }
 
 // SecretScannerConfig controls the proactive secret detection engine that
@@ -494,6 +495,15 @@ func (c *SecurityConfig) IsSecretScannerEnabled() bool {
 		return true
 	}
 	return *c.SecretScanner.Enabled
+}
+
+// IsPrivateNetworkAllowed returns true if SSRF private-IP blocking is disabled.
+// Safe to call on a nil receiver.
+func (s *SecurityConfig) IsPrivateNetworkAllowed() bool {
+	if s == nil {
+		return false
+	}
+	return s.AllowPrivateNetworks
 }
 
 // StorageConfig controls the data storage backend.
@@ -1480,6 +1490,34 @@ type A2AConfig struct {
 	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty"`
 	// TaskTTL is how long completed tasks are retained. Default: "72h".
 	TaskTTL string `yaml:"task_ttl,omitempty" json:"task_ttl,omitempty"`
+	// DefaultAudience is the expected "aud" claim in incoming A2A JWTs when not overridden per-issuer.
+	DefaultAudience string `yaml:"default_audience,omitempty" json:"default_audience,omitempty"`
+	// AutoLinkByEmail enables automatic user linking by matching the token's email claim.
+	AutoLinkByEmail bool `yaml:"auto_link_by_email,omitempty" json:"auto_link_by_email,omitempty"`
+	// RequireActorClaim requires the "act" claim in incoming JWTs for delegation flows.
+	RequireActorClaim bool `yaml:"require_actor_claim,omitempty" json:"require_actor_claim,omitempty"`
+	// TrustedIssuers lists the trusted token issuers for A2A authentication.
+	TrustedIssuers []TrustedIssuerConfig `yaml:"trusted_issuers,omitempty" json:"trusted_issuers,omitempty"`
+	// AllowedAgents lists the allowed A2A agents.
+	AllowedAgents []AllowedAgentConfig `yaml:"allowed_agents,omitempty" json:"allowed_agents,omitempty"`
+}
+
+// TrustedIssuerConfig holds YAML configuration for a trusted A2A token issuer.
+type TrustedIssuerConfig struct {
+	Name      string `yaml:"name" json:"name"`
+	Issuer    string `yaml:"issuer" json:"issuer"`
+	JWKSURL   string `yaml:"jwks_url" json:"jwks_url"`
+	Audience  string `yaml:"audience" json:"audience"`
+	UserClaim string `yaml:"user_claim,omitempty" json:"user_claim,omitempty"` // default: "sub"
+}
+
+// AllowedAgentConfig holds YAML configuration for an allowed A2A agent.
+type AllowedAgentConfig struct {
+	Name      string `yaml:"name" json:"name"`
+	ActorSub  string `yaml:"actor_sub" json:"actor_sub"`
+	Issuer    string `yaml:"issuer" json:"issuer"` // references TrustedIssuerConfig.Name
+	RateLimit int    `yaml:"rate_limit,omitempty" json:"rate_limit,omitempty"`
+	MaxTasks  int    `yaml:"max_tasks,omitempty" json:"max_tasks,omitempty"`
 }
 
 // IsA2AEnabled returns true if the A2A channel is explicitly enabled.

--- a/pkg/tools/http_request.go
+++ b/pkg/tools/http_request.go
@@ -94,7 +94,7 @@ func httpRequest(ctx context.Context, args HttpRequestArgs) (HttpRequestResult, 
 		return HttpRequestResult{}, fmt.Errorf("only http and https URLs are supported, got %q", parsedURL.Scheme)
 	}
 
-	if !httpReqSkipSSRF {
+	if !httpReqSkipSSRF && !httpReqAllowPrivateNetworks {
 		if err := checkSSRF(parsedURL.Hostname()); err != nil {
 			return HttpRequestResult{}, err
 		}

--- a/pkg/tools/http_request_test.go
+++ b/pkg/tools/http_request_test.go
@@ -746,3 +746,52 @@ func TestHttpRequest_MutuallyExclusiveBody(t *testing.T) {
 		t.Fatalf("expected mutual exclusion error, got %v", err)
 	}
 }
+
+// --- AllowPrivateNetworks tests ---
+
+func TestHttpRequest_AllowPrivateNetworks(t *testing.T) {
+	// Enable the production toggle — simulates running inside a sandbox container.
+	SetAllowPrivateNetworks(true)
+	defer SetAllowPrivateNetworks(false)
+
+	// Requests to private IPs should NOT be blocked by SSRF.
+	// They will fail with connection errors (no server listening), but the error
+	// must NOT be "private/loopback" — that would mean SSRF is still active.
+	// Use a 1-second timeout so tests don't hang waiting for unreachable IPs.
+	privateURLs := []string{
+		"http://10.0.0.1:8080/api",
+		"http://192.168.1.1/api",
+		"http://172.16.0.1/api",
+		"http://127.0.0.1:19999/api",
+	}
+
+	for _, u := range privateURLs {
+		t.Run(u, func(t *testing.T) {
+			_, err := HttpRequest(nil, HttpRequestArgs{URL: u, Timeout: 1})
+			if err == nil {
+				t.Fatal("expected connection error, got nil")
+			}
+			if strings.Contains(err.Error(), "private/loopback") {
+				t.Errorf("SSRF should be bypassed but got: %v", err)
+			}
+			// The error should be a connection error (refused/timeout), not SSRF block
+			if !strings.Contains(err.Error(), "request failed") {
+				t.Errorf("expected 'request failed' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestHttpRequest_SSRFStillActiveByDefault(t *testing.T) {
+	// Ensure that without SetAllowPrivateNetworks, SSRF protection is still active.
+	// This guards against accidentally leaving the toggle on.
+	SetAllowPrivateNetworks(false)
+
+	_, err := HttpRequest(nil, HttpRequestArgs{URL: "http://10.0.0.1/api"})
+	if err == nil {
+		t.Fatal("expected SSRF error, got nil")
+	}
+	if !strings.Contains(err.Error(), "private/loopback") {
+		t.Errorf("expected SSRF block, got: %v", err)
+	}
+}

--- a/pkg/tools/internal.go
+++ b/pkg/tools/internal.go
@@ -845,6 +845,11 @@ func GetInternalTools() ([]tool.Tool, error) {
 			// in pkg/codeintel reads ASTONISH_TREESITTER_LIB.
 			_ = os.Setenv("ASTONISH_TREESITTER_LIB", appCfg.CodeIntel.LibraryPath)
 		}
+		// Honor security.allow_private_networks for personal/CLI mode (no sandbox).
+		// In sandbox mode this is set unconditionally by the node process.
+		if appCfg.Security.IsPrivateNetworkAllowed() {
+			SetAllowPrivateNetworks(true)
+		}
 	}
 
 	var codeIntelTools []tool.Tool

--- a/pkg/tools/web_fetch.go
+++ b/pkg/tools/web_fetch.go
@@ -152,6 +152,22 @@ func checkSSRF(hostname string) error {
 	return nil
 }
 
+// --- SSRF bypass for sandbox / config ---
+
+// httpReqAllowPrivateNetworks is the production toggle to disable SSRF checks.
+// Set to true by the in-container node process (sandbox provides network isolation)
+// or when the user explicitly sets security.allow_private_networks in config.
+var httpReqAllowPrivateNetworks bool
+
+// SetAllowPrivateNetworks enables or disables SSRF private-IP blocking for
+// http_request. When true, requests to private/loopback IPs are allowed.
+// This is set automatically inside sandbox containers (where the sandbox
+// provides its own network isolation) and can be enabled via config for
+// personal/CLI mode on corporate networks.
+func SetAllowPrivateNetworks(allow bool) {
+	httpReqAllowPrivateNetworks = allow
+}
+
 // fetchURL performs the HTTP GET with timeout, redirect limits, and body size limits.
 func fetchURL(rawURL string) (body, finalURL, contentType string, statusCode int, err error) {
 	redirectCount := 0


### PR DESCRIPTION
## Summary

When running inside a sandbox container, the Go-level SSRF protection (`checkSSRF`) is now **automatically disabled** since the sandbox's own network policy provides isolation. This fixes `http_request` timing out on internal/corporate APIs while `curl` in the same sandbox succeeds.

## Problem

`http_request` with credential integration was timing out when calling internal corporate APIs (e.g., OpenStack Compute at `compute-3.qa-de-1.cloud.sap`), while `curl` via `shell_command` in the same sandbox container succeeded. The root cause: Go's `checkSSRF()` function uses `net.LookupHost()` which may resolve differently from the system resolver used by curl, or the hostname resolves to a private IP that gets blocked.

## Changes

| File | Change |
|------|--------|
| `pkg/config/app_config.go` | Add `AllowPrivateNetworks bool` field + `IsPrivateNetworkAllowed()` method to `SecurityConfig` |
| `pkg/tools/web_fetch.go` | Add `httpReqAllowPrivateNetworks` variable + `SetAllowPrivateNetworks()` function |
| `pkg/tools/http_request.go` | Modified SSRF check to respect the new toggle |
| `cmd/astonish/node.go` | Call `tools.SetAllowPrivateNetworks(true)` at node startup — **automatically disables SSRF inside sandbox containers** |
| `pkg/tools/internal.go` | Honor `security.allow_private_networks` config for personal/CLI mode |
| `pkg/tools/http_request_test.go` | Add `TestHttpRequest_AllowPrivateNetworks` and `TestHttpRequest_SSRFStillActiveByDefault` |
| `docs/architecture/sandbox-backends.md` | Add §14.1 documenting the behavior |

## Behavior

- **Sandbox mode** (platform/Studio): SSRF is automatically disabled inside the container — the sandbox network policy is the security boundary
- **Personal/CLI mode** (no sandbox): SSRF remains active by default. Users can opt-in with:
  ```yaml
  security:
    allow_private_networks: true
  ```
- **`web_fetch`** retains SSRF protection in all modes (it's for web content extraction, not authenticated API access)

## Testing

- `TestHttpRequest_AllowPrivateNetworks` — verifies private IPs are reachable when toggle is on
- `TestHttpRequest_SSRFStillActiveByDefault` — guards against accidental bypass
- Existing `TestHttpRequest_SSRFProtection` continues to pass (default behavior unchanged)