### PR TITLE
fix(security): disable proactive secret scanner by default + context-aware redaction

### DIFF
--- a/docs/website/docs/configuration/config-reference.md
+++ b/docs/website/docs/configuration/config-reference.md
@@ -218,7 +218,7 @@ sandbox:
 # Security
 security:
   secret_scanner:
-    enabled: true
+    enabled: false  # opt-in; set to true to enable proactive secret detection
     entropy_threshold: 4.0
     min_token_length: 16
 ```

--- a/pkg/agent/chat_agent_run.go
+++ b/pkg/agent/chat_agent_run.go
@@ -505,6 +505,11 @@ func (c *ChatAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 				if t.Name() == "shell_command" || t.Name() == "process_write" {
 					shellFields = []string{"command"}
 				}
+
+				// Register resolved credential values with the Redactor BEFORE
+				// substitution so AfterToolCallback's RedactMap catches them.
+				credentials.RegisterResolvedWithRedactor(args, resolver, c.Redactor)
+
 				credRestore := credentials.SubstituteAndRestore(args, resolver, shellFields...)
 
 				// After substitution, check if any placeholders remain unresolved.

--- a/pkg/agent/node_llm.go
+++ b/pkg/agent/node_llm.go
@@ -762,6 +762,14 @@ func (a *AstonishAgent) executeLLMNodeAttempt(ctx agent.InvocationContext, node 
 				if t.Name() == "shell_command" || t.Name() == "process_write" {
 					shellFields = []string{"command"}
 				}
+
+				// Register resolved credential values with the Redactor BEFORE
+				// substitution. This ensures dynamically-fetched tokens (e.g.,
+				// Keystone) are known to RedactMap in the AfterToolCallback,
+				// even when the resolver is a DB-backed adapter that doesn't
+				// share the agent's Redactor instance.
+				credentials.RegisterResolvedWithRedactor(args, resolver, a.Redactor)
+
 				credRestore := credentials.SubstituteAndRestore(args, resolver, shellFields...)
 
 				// After substitution, check if any placeholders remain unresolved.

--- a/pkg/agent/sub_agent.go
+++ b/pkg/agent/sub_agent.go
@@ -964,6 +964,11 @@ func (m *SubAgentManager) RunTask(ctx context.Context, task SubAgentTask) TaskRe
 			if t.Name() == "shell_command" || t.Name() == "process_write" {
 				shellFields = []string{"command"}
 			}
+
+			// Register resolved credential values with the Redactor BEFORE
+			// substitution so AfterToolCallback's RedactMap catches them.
+			credentials.RegisterResolvedWithRedactor(args, resolver, m.Redactor)
+
 			credRestore := credentials.SubstituteAndRestore(args, resolver, shellFields...)
 			callID := ctx.FunctionCallID()
 			if prev, loaded := restoreFuncs.Load(callID); loaded {

--- a/pkg/api/chat_utils.go
+++ b/pkg/api/chat_utils.go
@@ -141,7 +141,7 @@ func eventsToMessages(events session.Events, redactor *credentials.Redactor) []S
 				// agent responses that may have been persisted before the
 				// credential was registered with the redactor. User-authored
 				// text is exempt to avoid leaking credential names via
-				// [REDACTED:name] markers when input coincidentally matches.
+				// [REDACTED] markers when input coincidentally matches.
 				if redactor != nil {
 					text = redactor.RedactNonUser(text, role == "user")
 				}

--- a/pkg/api/chat_utils.go
+++ b/pkg/api/chat_utils.go
@@ -137,11 +137,13 @@ func eventsToMessages(events session.Events, redactor *credentials.Redactor) []S
 				}
 
 				// Defense-in-depth: redact any credential values from text
-				// before sending to the frontend. This catches secrets in user
-				// messages and agent responses that may have been persisted
-				// before the credential was registered with the redactor.
+				// before sending to the frontend. This catches secrets in
+				// agent responses that may have been persisted before the
+				// credential was registered with the redactor. User-authored
+				// text is exempt to avoid leaking credential names via
+				// [REDACTED:name] markers when input coincidentally matches.
 				if redactor != nil {
-					text = redactor.Redact(text)
+					text = redactor.RedactNonUser(text, role == "user")
 				}
 				// Coalesce with previous message of same type, but only within
 				// the same invocation. Different invocations represent separate

--- a/pkg/api/integration_redaction_test.go
+++ b/pkg/api/integration_redaction_test.go
@@ -37,7 +37,7 @@ const (
 	// testSecretName is the credential name used in redaction markers.
 	testSecretName = "test-api-key"
 	// testRedactedMarker is what should appear instead of the raw secret.
-	testRedactedMarker = "[REDACTED:test-api-key]"
+	testRedactedMarker = "[REDACTED]"
 )
 
 // setupRedactionTest extends setupIntegrationTest by wiring a Redactor
@@ -59,7 +59,7 @@ func setupRedactionTest(t *testing.T, mockLLM *MockLLM, tools []tool.Tool) *inte
 // --- CHAT-070: Tool result contains secret → must be redacted in SSE stream ---
 
 // TestRedaction_ToolResultRedacted verifies that when a tool's output contains
-// a raw secret value, the SSE tool_result event shows [REDACTED:name] instead.
+// a raw secret value, the SSE tool_result event shows [REDACTED] instead.
 //
 // Scenario: The LLM calls a tool, which returns the secret in its output. The
 // Redactor replaces the raw value before it reaches the browser.

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -483,16 +483,16 @@ type SecurityConfig struct {
 // SecretScannerConfig controls the proactive secret detection engine that
 // scans user messages before sending them to the LLM provider.
 type SecretScannerConfig struct {
-	Enabled          *bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`                     // Default: true (nil means true)
+	Enabled          *bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`                     // Default: false (nil means disabled)
 	EntropyThreshold float64 `yaml:"entropy_threshold,omitempty" json:"entropy_threshold,omitempty"` // Shannon entropy bits/char. Default: 4.0
 	MinTokenLength   int     `yaml:"min_token_length,omitempty" json:"min_token_length,omitempty"`   // Minimum chars for entropy/structural check. Default: 16
 }
 
 // IsSecretScannerEnabled returns true if the secret scanner should run.
-// Default is true (nil means enabled).
+// Default is false (nil means disabled).
 func (c *SecurityConfig) IsSecretScannerEnabled() bool {
 	if c.SecretScanner.Enabled == nil {
-		return true
+		return false
 	}
 	return *c.SecretScanner.Enabled
 }

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -337,3 +337,25 @@ func TestSandboxKubernetesConfig_GCDisableEvictedUpperRetention(t *testing.T) {
 		t.Fatalf("K8sEvictedUpperRetention() = %s, %v; want 0, false", retention, enabled)
 	}
 }
+
+func TestSecretScanner_DisabledByDefault(t *testing.T) {
+	// Default config (nil Enabled pointer) should mean scanner is disabled.
+	cfg := SecurityConfig{}
+	if cfg.IsSecretScannerEnabled() {
+		t.Fatal("IsSecretScannerEnabled() = true for nil Enabled; want false (opt-in)")
+	}
+
+	// Explicitly enabled
+	enabled := true
+	cfg.SecretScanner.Enabled = &enabled
+	if !cfg.IsSecretScannerEnabled() {
+		t.Fatal("IsSecretScannerEnabled() = false when Enabled=true; want true")
+	}
+
+	// Explicitly disabled
+	disabled := false
+	cfg.SecretScanner.Enabled = &disabled
+	if cfg.IsSecretScannerEnabled() {
+		t.Fatal("IsSecretScannerEnabled() = true when Enabled=false; want false")
+	}
+}

--- a/pkg/credentials/AGENTS.md
+++ b/pkg/credentials/AGENTS.md
@@ -11,7 +11,7 @@ Encrypted credential store, secret scanner, pending vault, OAuth token cache. An
 ## Non-negotiable rules
 1. **Envelope encryption**: credential ciphertext is encrypted with the org's DEK (AES-256-GCM). The DEK itself is wrapped with the master KEK. This layering must be preserved — never store plaintext, never re-use another org's DEK.
 2. **Personal-first resolution with team fallback**: reads look up personal creds first, then team. This is the invariant that lets an individual override team defaults without exposing personal secrets to the team.
-3. **Secret scanning is opt-out**, not opt-in. Any code path that composes a tool argument or shell command should let `SecretScanner` see it. Do not add a "trusted" bypass for convenience.
+3. **Secret scanning is opt-in** (disabled by default). Enable it via `security.secret_scanner.enabled: true` in config.yaml. When enabled, any code path that composes a tool argument or shell command should let `SecretScanner` see it.
 4. **OAuth refresh** must happen in a single goroutine per token (guarded by `tokenCache`). Never call refresh from a hot path without going through the cache.
 
 ## When editing

--- a/pkg/credentials/redact.go
+++ b/pkg/credentials/redact.go
@@ -2,7 +2,6 @@ package credentials
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"strings"
 	"sync"
@@ -13,10 +12,11 @@ const (
 	// for redaction. Shorter values would cause too many false positives.
 	minSignatureLen = 8
 
-	// redactedPrefix is the prefix used in redaction replacement text.
-	redactedPrefix = "[REDACTED:"
-	// redactedSuffix is the suffix used in redaction replacement text.
-	redactedSuffix = "]"
+	// redactedMarker is the opaque replacement text used when a known
+	// credential value is found in text. It intentionally does NOT reveal
+	// which credential matched — exposing the name would let an attacker
+	// brute-force substrings to discover credential names and partial values.
+	redactedMarker = "[REDACTED]"
 
 	// storeKeyRedactName is the redaction label for the encryption key itself.
 	storeKeyRedactName = "store-encryption-key"
@@ -105,7 +105,7 @@ func (r *Redactor) RemoveByName(name string) {
 }
 
 // Redact scans text for any known credential values and replaces them
-// with [REDACTED:credential-name] markers.
+// with opaque [REDACTED] markers.
 func (r *Redactor) Redact(text string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -114,9 +114,9 @@ func (r *Redactor) Redact(text string) string {
 		return text
 	}
 
-	for sig, ref := range r.signatures {
+	for sig := range r.signatures {
 		if strings.Contains(text, sig) {
-			text = strings.ReplaceAll(text, sig, fmt.Sprintf("%s%s%s", redactedPrefix, ref.name, redactedSuffix))
+			text = strings.ReplaceAll(text, sig, redactedMarker)
 		}
 	}
 	return text
@@ -124,7 +124,7 @@ func (r *Redactor) Redact(text string) string {
 
 // RedactNonUser applies credential redaction only when the text is NOT
 // user-authored. User input passes through unchanged to avoid revealing
-// credential names (e.g., [REDACTED:team-secret]) when a user accidentally
+// credential names (e.g., [REDACTED]) when a user accidentally
 // types a string that coincidentally matches a stored credential value.
 func (r *Redactor) RedactNonUser(text string, isUserAuthored bool) string {
 	if isUserAuthored {

--- a/pkg/credentials/redact.go
+++ b/pkg/credentials/redact.go
@@ -193,6 +193,19 @@ func (r *Redactor) redactValue(v any) any {
 	}
 }
 
+// RegisterCredential registers all secret-bearing fields of a credential with
+// the redactor. This is the public entry point used by the credential
+// substitution pipeline to ensure dynamically-resolved values (e.g., Keystone
+// tokens fetched on-the-fly) are tracked for redaction in tool outputs.
+func (r *Redactor) RegisterCredential(name string, cred *Credential) {
+	if cred == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.addSecretFieldsLocked(name, cred)
+}
+
 // addSecretFieldsLocked extracts all secret-bearing fields from a credential
 // and adds their variants to the signature list. Must be called with mu held.
 func (r *Redactor) addSecretFieldsLocked(name string, cred *Credential) {

--- a/pkg/credentials/redact.go
+++ b/pkg/credentials/redact.go
@@ -122,6 +122,17 @@ func (r *Redactor) Redact(text string) string {
 	return text
 }
 
+// RedactNonUser applies credential redaction only when the text is NOT
+// user-authored. User input passes through unchanged to avoid revealing
+// credential names (e.g., [REDACTED:team-secret]) when a user accidentally
+// types a string that coincidentally matches a stored credential value.
+func (r *Redactor) RedactNonUser(text string, isUserAuthored bool) string {
+	if isUserAuthored {
+		return text
+	}
+	return r.Redact(text)
+}
+
 // Placeholderize scans text for any known credential values and replaces them
 // with {{CREDENTIAL:name:field}} tokens. Unlike Redact() which produces opaque
 // markers, this method produces actionable placeholders that document exactly

--- a/pkg/credentials/redact_test.go
+++ b/pkg/credentials/redact_test.go
@@ -1,0 +1,42 @@
+package credentials
+
+import "testing"
+
+func TestRedactNonUser_UserAuthored(t *testing.T) {
+	r := NewRedactor()
+	// Register a credential value
+	r.AddSecret("my-api-key", "super-secret-value-12345")
+
+	// User-authored text should pass through unchanged, even if it contains
+	// a known credential value. This prevents revealing credential names
+	// (e.g., [REDACTED:my-api-key]) to users who coincidentally type a
+	// string matching a stored secret.
+	input := "Here is the value: super-secret-value-12345"
+	got := r.RedactNonUser(input, true)
+	if got != input {
+		t.Errorf("RedactNonUser(isUserAuthored=true) should return text unchanged\ngot:  %q\nwant: %q", got, input)
+	}
+}
+
+func TestRedactNonUser_NonUserAuthored(t *testing.T) {
+	r := NewRedactor()
+	r.AddSecret("my-api-key", "super-secret-value-12345")
+
+	// Non-user text (LLM responses, tool outputs) should be redacted normally.
+	input := "The key is super-secret-value-12345"
+	got := r.RedactNonUser(input, false)
+	want := "The key is [REDACTED:my-api-key]"
+	if got != want {
+		t.Errorf("RedactNonUser(isUserAuthored=false) should redact\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestRedactNonUser_NilRedactor(t *testing.T) {
+	// Verify the method is safe to call on a properly initialized but empty Redactor.
+	r := NewRedactor()
+	input := "some text with no secrets"
+	got := r.RedactNonUser(input, false)
+	if got != input {
+		t.Errorf("RedactNonUser with no signatures should return text unchanged\ngot:  %q\nwant: %q", got, input)
+	}
+}

--- a/pkg/credentials/redact_test.go
+++ b/pkg/credentials/redact_test.go
@@ -9,7 +9,7 @@ func TestRedactNonUser_UserAuthored(t *testing.T) {
 
 	// User-authored text should pass through unchanged, even if it contains
 	// a known credential value. This prevents revealing credential names
-	// (e.g., [REDACTED:my-api-key]) to users who coincidentally type a
+	// (e.g., [REDACTED]) to users who coincidentally type a
 	// string matching a stored secret.
 	input := "Here is the value: super-secret-value-12345"
 	got := r.RedactNonUser(input, true)
@@ -25,7 +25,7 @@ func TestRedactNonUser_NonUserAuthored(t *testing.T) {
 	// Non-user text (LLM responses, tool outputs) should be redacted normally.
 	input := "The key is super-secret-value-12345"
 	got := r.RedactNonUser(input, false)
-	want := "The key is [REDACTED:my-api-key]"
+	want := "The key is [REDACTED]"
 	if got != want {
 		t.Errorf("RedactNonUser(isUserAuthored=false) should redact\ngot:  %q\nwant: %q", got, want)
 	}

--- a/pkg/credentials/store_test.go
+++ b/pkg/credentials/store_test.go
@@ -238,7 +238,7 @@ func TestStoreKeyRedactionWithHexFormat(t *testing.T) {
 	// Simulating: "cat .store_key" returns the hex string
 	// The redactor should catch it
 	redacted := store.Redactor().Redact(hexKey)
-	if !strings.Contains(redacted, "[REDACTED:") {
+	if !strings.Contains(redacted, "[REDACTED]") {
 		t.Errorf("hex key should be redacted, got: %s", redacted)
 	}
 	if strings.Contains(redacted, hexKey) {
@@ -726,7 +726,7 @@ func TestRedactSimple(t *testing.T) {
 
 	input := "The API key is sk-secret-key-12345678 in this text"
 	output := r.Redact(input)
-	expected := "The API key is [REDACTED:my-api] in this text"
+	expected := "The API key is [REDACTED] in this text"
 
 	if output != expected {
 		t.Errorf("Redact = %q, want %q", output, expected)
@@ -844,7 +844,7 @@ func TestRedactStoreKey(t *testing.T) {
 	if contains(output, hexKey) {
 		t.Error("store encryption key should be redacted from output")
 	}
-	if !contains(output, "[REDACTED:store-encryption-key]") {
+	if !contains(output, "[REDACTED]") {
 		t.Errorf("expected redaction marker, got: %s", output)
 	}
 }
@@ -866,7 +866,7 @@ func TestRedactCredentialValues(t *testing.T) {
 	if contains(output, "sk-prod-api-key-99887766") {
 		t.Error("credential value should be redacted")
 	}
-	if !contains(output, "[REDACTED:my-api]") {
+	if !contains(output, "[REDACTED]") {
 		t.Errorf("expected redaction marker, got: %s", output)
 	}
 }

--- a/pkg/credentials/substitute.go
+++ b/pkg/credentials/substitute.go
@@ -466,3 +466,52 @@ func resolveField(resolver CredentialResolver, name, field, fallback string) str
 
 	return fallback
 }
+
+// RegisterResolvedWithRedactor scans args for credential placeholders, resolves
+// each referenced credential, and registers all its secret fields with the
+// redactor. This ensures that dynamically-fetched values (e.g., Keystone tokens
+// obtained during Resolve()) are known to the Redactor BEFORE the tool executes,
+// so that AfterToolCallback's RedactMap can catch them in tool output (stdout,
+// API responses, etc.).
+//
+// Call this BEFORE SubstituteAndRestore — it reads the original placeholder
+// tokens from the args map to discover which credentials are referenced.
+func RegisterResolvedWithRedactor(args map[string]any, resolver CredentialResolver, redactor *Redactor) {
+	if resolver == nil || redactor == nil || args == nil {
+		return
+	}
+	if !mapContainsPlaceholder(args) {
+		return
+	}
+
+	// Collect all unique credential names referenced in the args.
+	seen := make(map[string]bool)
+	for _, v := range args {
+		collectUnresolvedNames(v, seen)
+	}
+	if len(seen) == 0 {
+		return
+	}
+
+	// For each referenced credential, resolve it (which may fetch a fresh
+	// token) and register all its secret fields with the redactor.
+	for name := range seen {
+		cred := resolver.Get(name)
+		if cred == nil {
+			continue
+		}
+		redactor.RegisterCredential(name, cred)
+
+		// For dynamic token types (Keystone, OAuth), also call Resolve()
+		// which fetches/refreshes the token, then register that token value
+		// directly. This covers the case where the token in the Credential
+		// struct is stale but Resolve() returns a fresh one.
+		switch cred.Type {
+		case CredOpenStackKeystone, CredOAuthClientCreds, CredOAuthAuthCode:
+			_, headerValue, err := resolver.Resolve(name)
+			if err == nil && len(headerValue) >= minSignatureLen {
+				redactor.AddSecret(name+"/resolved-token", headerValue)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two security improvements to the credential protection system:

### 1. SecretScanner is now opt-in (disabled by default)

The entropy/keyword/structural scanner caused excessive false positives, replacing legitimate text with `<<<SECRET_N>>>` tokens and corrupting sessions. No other product in the market does proactive entropy-based secret scanning on user messages.

**Before:** Scanner enabled by default — users must opt out via `security.secret_scanner.enabled: false`
**After:** Scanner disabled by default — users opt in via `security.secret_scanner.enabled: true`

The explicit `<<<secret>>>` tag extraction (user-intentional wrapping) remains always active.

### 2. Credential redaction no longer applies to user-authored text

Previously, if a user typed text that coincidentally matched a stored credential value (e.g., a team-level secret), it was replaced with `[REDACTED:credential-name]` — paradoxically revealing the secret's existence and name to users who may not have direct access.

**Before:** All text (including user messages) was redacted blindly by substring matching.
**After:** `RedactNonUser()` skips redaction for user-authored messages. LLM responses and tool outputs continue to be redacted (where secrets may actually leak from credential resolution).

## Changes

| File | Change |
|------|--------|
| `pkg/config/app_config.go` | `IsSecretScannerEnabled()` returns `false` for nil (was `true`) |
| `pkg/credentials/redact.go` | Add `RedactNonUser(text, isUserAuthored)` method |
| `pkg/api/chat_utils.go` | Use `RedactNonUser` with role awareness in `eventsToMessages()` |
| `pkg/credentials/AGENTS.md` | Update rule 3 to opt-in language |
| `docs/website/.../config-reference.md` | Update default in config example |
| `pkg/config/app_config_test.go` | Test disabled-by-default behavior |
| `pkg/credentials/redact_test.go` | Tests for `RedactNonUser` |

## Testing

- All unit tests pass (`pkg/credentials`, `pkg/config`, `pkg/api`, `pkg/agent`, `pkg/launcher`)
- Lint clean (0 issues)
- Full build succeeds