### PR TITLE
feat(a2a): Replace API-key auth with JWT/OIDC identity propagation

### DIFF
--- a/docs/architecture/a2a-auth-redesign.md
+++ b/docs/architecture/a2a-auth-redesign.md
@@ -1,0 +1,430 @@
+# A2A Authentication Redesign — Identity Propagation via OAuth 2.0 Token Exchange
+
+## Problem Statement
+
+The current A2A implementation has a fundamentally broken identity model:
+
+1. **Unconstrained impersonation**: When `AllowIdentityPropagation=true`, an external agent can claim to be ANY user by simply putting `"user_email": "anyone@company.com"` in the message metadata. No verification occurs.
+2. **Single token → all users**: One API key with propagation enabled gives access to every user's context (credentials, memory, tools, sessions).
+3. **No cryptographic proof**: Identity is asserted via a plaintext string, not a signed token from a trusted authority.
+4. **Violates Astonish's core model**: Every other channel (Telegram, Slack, Email) links a verified external identity to a specific platform user. A2A bypasses this entirely.
+
+## Design Goals
+
+1. **Same security model as other channels**: Every A2A request executes in the context of a specific, verified platform user — with their team, credentials, memory, MCP servers, and skills.
+2. **Enterprise-grade identity propagation**: External systems (like SAP Joule) can call Astonish on behalf of their authenticated users, with cryptographic proof of who the user is.
+3. **No trust in the requester's self-assertion**: Identity must be proven by a token signed by a trusted Identity Provider (IdP), not asserted in metadata.
+4. **Standards-based**: Uses OAuth 2.0 Token Exchange (RFC 8693) semantics, OpenID Connect for user identity, and the A2A protocol's native `securitySchemes` mechanism.
+5. **Multi-tenant safe**: Different organizations can configure different trusted IdPs; an agent authenticated in one org cannot access another.
+
+## Architecture Overview
+
+### Authentication Layers
+
+```
+External Agent (e.g., SAP Joule)
+    |
+    | HTTPS + Authorization: Bearer <delegated-jwt>
+    |
+    v
+┌─────────────────────────────────────────────────────────────────────┐
+│  A2A Auth Middleware                                                  │
+│                                                                       │
+│  1. Extract Bearer token from Authorization header                    │
+│  2. Determine token type (service token vs delegated user token)      │
+│  3. Validate signature against configured trusted issuers (JWKS)      │
+│  4. Extract identity:                                                 │
+│     - sub  = user identity (email or user ID)                         │
+│     - act  = calling agent/service identity (RFC 8693)                │
+│     - aud  = must include Astonish's A2A audience                     │
+│     - org/tenant = routing hint                                       │
+│  5. Resolve user via PlatformResolver (same as Telegram/Slack/Email)  │
+│  6. Inject authenticated context                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Two Authentication Modes
+
+The redesigned A2A supports two authentication modes, both producing the same outcome: a verified platform user context.
+
+#### Mode 1: Direct User Token (OIDC)
+
+The external agent holds a valid **user access token** (or ID token) from a trusted IdP that Astonish is configured to accept. This is the simplest case — the user authenticated directly with the IdP, and the agent forwards their token.
+
+```
+User authenticates with IdP (e.g., IAS, Azure AD, Okta)
+    → IdP issues JWT with sub=user@company.com, aud=astonish-a2a
+    → External agent includes this JWT in Authorization: Bearer header
+    → Astonish validates JWT signature via JWKS, extracts sub as user identity
+    → PlatformResolver maps user@company.com → platform user → team context
+```
+
+**When to use**: When the external agent can obtain a user-scoped token with Astonish as the audience. This is the standard OIDC pattern.
+
+#### Mode 2: Delegated Token (OAuth 2.0 Token Exchange / On-Behalf-Of)
+
+The external agent authenticates as a **service** (client credentials) but acts on behalf of a user. The token carries both identities using RFC 8693 `act` claim semantics.
+
+```
+External system authenticates user internally
+    → System calls its own IdP to exchange user token for a delegated token:
+       - subject_token = user's token
+       - actor_token = system's service credential
+       - audience = astonish-a2a
+    → IdP issues delegated JWT:
+       {
+         "sub": "user@company.com",      ← the user
+         "act": { "sub": "joule-prod" }, ← the acting service
+         "aud": "astonish-a2a",
+         "iss": "https://accounts.sap.com",
+         "exp": 1723620000
+       }
+    → External agent includes this JWT in Authorization: Bearer header
+    → Astonish validates:
+       1. Signature via JWKS from trusted issuer
+       2. Audience matches configured A2A audience
+       3. Actor (act.sub) is in the allowed agents list for this org
+       4. Subject (sub) resolves to a platform user
+    → PlatformResolver maps sub → platform user → team context
+```
+
+**When to use**: Enterprise integrations where the external system (Joule, Copilot, etc.) has its own authentication and acts on behalf of users who already exist in both systems.
+
+### How This Maps to SAP Joule
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  SAP Joule (BTP)                                              │
+│                                                               │
+│  1. User is authenticated via IAS (OIDC)                      │
+│  2. Joule needs to call Astonish on behalf of user            │
+│  3. Joule calls IAS token exchange:                           │
+│     - subject_token = user's IAS token                        │
+│     - client_credentials = Joule's service identity           │
+│     - audience = "astonish-a2a" (configured in IAS)           │
+│  4. IAS issues delegated JWT:                                 │
+│     { sub: "user@company.com", act: { sub: "joule" }, ... }   │
+│  5. Joule sends A2A request with this JWT                     │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           v
+┌──────────────────────────────────────────────────────────────┐
+│  Astonish A2A Server                                          │
+│                                                               │
+│  1. Validates JWT signature (IAS JWKS endpoint)               │
+│  2. Checks audience = "astonish-a2a"                          │
+│  3. Checks act.sub = "joule" is in allowed agents for org     │
+│  4. Extracts sub = "user@company.com"                         │
+│  5. PlatformResolver: email → user → org/team context         │
+│  6. Executes request as that user (same as if they used       │
+│     Studio directly)                                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Data Model
+
+### Trusted Issuer Configuration (per-org)
+
+Each organization configures which Identity Providers are trusted for A2A:
+
+```go
+// TrustedIssuer represents an IdP trusted for A2A token validation.
+type TrustedIssuer struct {
+    ID          string `json:"id"`
+    Name        string `json:"name"`            // "SAP IAS Production"
+    Issuer      string `json:"issuer"`          // "https://accounts.sap.com" (must match JWT iss)
+    JWKSURL     string `json:"jwks_url"`        // "https://accounts.sap.com/.well-known/jwks.json"
+    Audience    string `json:"audience"`        // Expected aud claim ("astonish-a2a" or custom)
+    UserClaim   string `json:"user_claim"`      // Which claim identifies the user: "sub", "email", "preferred_username"
+    OrgID       string `json:"org_id"`          // Owning organization in Astonish
+}
+```
+
+### Allowed Agent Configuration (per-org)
+
+Each org specifies which service identities (actors) are permitted to make delegated calls:
+
+```go
+// AllowedAgent represents an external service authorized to make A2A calls for an org.
+type AllowedAgent struct {
+    ID          string   `json:"id"`
+    Name        string   `json:"name"`           // "SAP Joule Production"
+    ActorSub    string   `json:"actor_sub"`      // The act.sub value to match (e.g., "joule-prod")
+    IssuerID    string   `json:"issuer_id"`      // Which trusted issuer this agent uses
+    OrgID       string   `json:"org_id"`         // Owning organization
+    RateLimit   int      `json:"rate_limit"`     // Requests per minute (0 = unlimited)
+    MaxTasks    int      `json:"max_tasks"`      // Max concurrent tasks (0 = unlimited)
+    Description string   `json:"description"`    // Human-readable description
+    Enabled     bool     `json:"enabled"`
+}
+```
+
+### User Identity Resolution
+
+The identity chain works exactly like other channels:
+
+```
+JWT sub claim (e.g., "user@company.com")
+    → UserChannelStore.GetByExternalID(ctx, "a2a", "user@company.com")
+    → UserChannel { UserID: "platform-user-123", Verified: true, Enabled: true }
+    → PlatformResolver enriches context with team-scoped stores
+```
+
+Users link their A2A identity the same way they link Telegram or Email:
+- Admin bulk-imports user mappings (email → platform user)
+- Or: if the platform user's email matches the JWT sub, auto-link on first request (configurable)
+
+### Platform Settings (DB)
+
+```go
+// PlatformA2AConfig — redesigned
+type PlatformA2AConfig struct {
+    Enabled             bool   `json:"enabled"`
+    BaseURL             string `json:"base_url,omitempty"`
+    TaskTTL             string `json:"task_ttl,omitempty"`
+    DefaultAudience     string `json:"default_audience,omitempty"`     // e.g., "astonish-a2a"
+    AutoLinkByEmail     bool   `json:"auto_link_by_email"`            // Auto-create user-channel link if email matches
+    RequireActorClaim   bool   `json:"require_actor_claim"`           // If true, reject tokens without act claim
+}
+```
+
+## Token Validation Flow
+
+```go
+func validateA2AToken(tokenStr string, orgIssuers []TrustedIssuer, allowedAgents []AllowedAgent) (*A2AIdentity, error) {
+    // 1. Parse JWT header to get kid (key ID)
+    // 2. Try each trusted issuer's JWKS to find matching key
+    // 3. Validate signature, expiry, not-before
+    // 4. Validate audience matches issuer's configured audience
+    // 5. Extract user identity from configured user_claim
+    // 6. If act claim present: validate actor is in allowed agents list
+    // 7. If no act claim and RequireActorClaim=false: treat as direct user token
+    // 8. Return resolved identity
+}
+
+type A2AIdentity struct {
+    UserIdentifier string // The user's external ID (email, sub, etc.)
+    ActorIdentifier string // The service acting on behalf (empty if direct user token)
+    Issuer         string // Which IdP issued this token
+    OrgID          string // Which org this resolves to
+}
+```
+
+## Agent Card (Updated)
+
+The Agent Card now advertises OpenID Connect as the primary auth mechanism:
+
+```json
+{
+  "name": "Astonish",
+  "url": "https://astonish.example.com/api/a2a",
+  "version": "1.0.0",
+  "securitySchemes": {
+    "oidc": {
+      "type": "openIdConnect",
+      "openIdConnectUrl": "https://astonish.example.com/.well-known/openid-configuration"
+    },
+    "bearerJWT": {
+      "type": "http",
+      "scheme": "bearer",
+      "bearerFormat": "JWT"
+    }
+  },
+  "security": [
+    { "oidc": ["a2a"] },
+    { "bearerJWT": [] }
+  ]
+}
+```
+
+Note: Astonish doesn't need to BE an OIDC provider. The `openIdConnectUrl` can point to the org's configured IdP, or we can use the simpler `bearerJWT` scheme which just says "send a JWT Bearer token" — the validation happens server-side against configured JWKS endpoints.
+
+## What Gets Removed
+
+1. **`InMemoryAgentRegistry`** — replaced by `AllowedAgent` records in the DB (persistent, per-org)
+2. **`AllowIdentityPropagation` flag** — identity is ALWAYS from the JWT; there's no "propagation" toggle
+3. **`LinkedUserID` on RegisteredAgent** — identity comes from the token, not from agent registration
+4. **Plaintext API keys (`a2a_<uuid>`)** — replaced by JWT Bearer tokens from trusted IdPs
+5. **`extractIdentityFromMetadata`** — no more trusting metadata strings
+6. **Admin endpoints for agent CRUD** — replaced by trusted issuer + allowed agent configuration (admin UI)
+
+## What Gets Added
+
+1. **JWKS client** — fetches and caches public keys from trusted issuers (with rotation support)
+2. **JWT validation** — signature verification, audience check, expiry, issuer matching
+3. **Trusted Issuer store** — per-org configuration of which IdPs to trust
+4. **Allowed Agent store** — per-org allowlist of service identities (act.sub values)
+5. **Auto-link capability** — optionally create user-channel links when JWT email matches platform user
+6. **A2A user-channel links** — users get `channel_type="a2a"` entries in UserChannels, same as telegram/email
+
+## Configuration Example
+
+### Organization Admin UI / API
+
+```
+POST /api/admin/a2a/issuers
+{
+  "name": "SAP IAS Production",
+  "issuer": "https://mycompany.accounts.ondemand.com",
+  "jwks_url": "https://mycompany.accounts.ondemand.com/oauth2/certs",
+  "audience": "astonish-a2a",
+  "user_claim": "email"
+}
+
+POST /api/admin/a2a/agents
+{
+  "name": "SAP Joule",
+  "actor_sub": "joule-prod-client-id",
+  "issuer_id": "<issuer-id-from-above>",
+  "rate_limit": 60,
+  "max_tasks": 10
+}
+```
+
+### config.yaml (for self-hosted / simple setups)
+
+```yaml
+channels:
+  a2a:
+    enabled: true
+    base_url: "https://astonish.example.com"
+    default_audience: "astonish-a2a"
+    auto_link_by_email: true
+    require_actor_claim: false  # Allow direct user tokens too
+    trusted_issuers:
+      - name: "Company IdP"
+        issuer: "https://login.company.com"
+        jwks_url: "https://login.company.com/.well-known/jwks.json"
+        audience: "astonish-a2a"
+        user_claim: "email"
+    allowed_agents:
+      - name: "Joule"
+        actor_sub: "joule-client-id"
+        issuer: "Company IdP"  # references trusted issuer by name
+```
+
+## Request Flow (Complete)
+
+### Happy Path: Joule calling Astonish on behalf of user
+
+```
+1. User is logged into SAP system, authenticated via IAS
+2. User triggers Joule action that needs Astonish capabilities
+3. Joule performs token exchange with IAS:
+   - subject_token = user's IAS access token
+   - client_credentials = Joule's service identity
+   - audience = "astonish-a2a"
+   - scope = "a2a:task"
+4. IAS issues delegated JWT:
+   {
+     "iss": "https://mycompany.accounts.ondemand.com",
+     "sub": "user@company.com",
+     "aud": "astonish-a2a",
+     "act": { "sub": "joule-prod-client-id" },
+     "exp": <now + 5min>,
+     "iat": <now>
+   }
+5. Joule sends A2A JSON-RPC request:
+   POST /api/a2a
+   Authorization: Bearer <delegated-jwt>
+   Content-Type: application/json
+
+   {
+     "jsonrpc": "2.0",
+     "id": "req-1",
+     "method": "message/send",
+     "params": {
+       "message": { "role": "user", "parts": [{"type": "text", "text": "Analyze Q3 report"}] },
+       "configuration": { "contextId": "joule-session-abc" }
+     }
+   }
+
+6. Astonish A2A Auth Middleware:
+   a. Extracts Bearer JWT
+   b. Parses header → gets kid
+   c. Fetches JWKS from IAS (cached)
+   d. Validates signature, expiry, audience
+   e. Extracts: sub="user@company.com", act.sub="joule-prod-client-id"
+   f. Looks up org by issuer → finds org "mycompany"
+   g. Checks "joule-prod-client-id" is in allowed agents for "mycompany"
+   h. Looks up UserChannel: (type="a2a", external_id="user@company.com") → user-123
+      (or auto-links if auto_link_by_email=true and user with that email exists)
+   i. Calls PlatformResolver.ResolveChannelUser → enriched context with team stores
+
+7. A2A Handler processes request in user-123's context
+   (same credentials, memory, MCP servers, skills as if they used Studio)
+
+8. Response returned as JSON-RPC result
+```
+
+### Error Cases
+
+| Scenario | Response |
+|----------|----------|
+| No Authorization header | 401 + JSON-RPC error: "Authentication required" |
+| JWT signature invalid | 401 + JSON-RPC error: "Invalid token signature" |
+| JWT expired | 401 + JSON-RPC error: "Token expired" |
+| Issuer not trusted | 403 + JSON-RPC error: "Untrusted issuer" |
+| Audience mismatch | 403 + JSON-RPC error: "Invalid audience" |
+| Actor not in allowed list | 403 + JSON-RPC error: "Agent not authorized" |
+| User not found in platform | 403 + JSON-RPC error: "User not provisioned" |
+| User channel link disabled | 403 + JSON-RPC error: "A2A access disabled for user" |
+
+## Comparison with Current Channels
+
+| Aspect | Telegram | Email | A2A (Redesigned) |
+|--------|----------|-------|------------------|
+| External ID | Telegram user ID | email address | JWT sub claim (email/ID) |
+| Verification | Bot interaction + /link | Email verification code | JWT signature from trusted IdP |
+| Link storage | UserChannel(telegram, tg_id) | UserChannel(email, addr) | UserChannel(a2a, email/sub) |
+| Auth mechanism | Telegram bot API validates sender | IMAP credentials | JWT Bearer + JWKS validation |
+| Per-user? | Yes (each TG user is distinct) | Yes (each email is distinct) | Yes (each JWT sub is distinct) |
+| Service-to-service? | N/A | N/A | Yes, via `act` claim (service acts for user) |
+
+## Migration Path
+
+1. **Phase 1**: Implement JWKS-based JWT validation alongside existing API key auth
+   - Existing API key auth continues to work (backward compat)
+   - New JWT auth available for new integrations
+   - Remove `AllowIdentityPropagation` — API key auth always uses fixed linked user
+
+2. **Phase 2**: Add trusted issuer + allowed agent configuration (DB + admin API)
+   - Org admins can configure their IdPs
+   - Users can link their A2A identity (or auto-link by email)
+
+3. **Phase 3**: Deprecate and remove API key auth
+   - All A2A auth goes through JWT
+   - API keys sunset after migration period
+
+## Security Properties
+
+1. **No trust in requester assertions**: Identity comes from cryptographically signed JWT, not from message metadata.
+2. **Audience binding**: Token must be issued specifically for Astonish (`aud` claim), preventing token reuse from other services.
+3. **Short-lived tokens**: Delegated tokens should be short-lived (5-15 min), limiting exposure window.
+4. **Actor verification**: Even with a valid user token, the acting service must be in the org's allowlist.
+5. **Per-user scoping**: Each request resolves to exactly one platform user, with their specific permissions.
+6. **Issuer isolation**: Each org configures its own trusted issuers; one org's IdP cannot authenticate users in another org.
+7. **Audit trail**: Both user (sub) and actor (act.sub) are logged, enabling "who did what on behalf of whom" auditing.
+8. **Revocation**: Tokens are validated on every request; revoking a user's account or disabling their channel link immediately blocks access.
+
+## Dependencies
+
+- **`github.com/golang-jwt/jwt/v5`** — already in use for platform auth
+- **JWKS fetching** — need a JWKS client with caching (e.g., `github.com/MicahParks/keyfunc/v3` or custom)
+- No new external IdP integration needed — Astonish validates tokens, it doesn't issue them
+
+## A2A Protocol Alignment
+
+This design aligns with the A2A v1.0 specification:
+
+1. **Agent Card `securitySchemes`**: We advertise `bearerJWT` (type: http, scheme: bearer, bearerFormat: JWT)
+2. **Transport-layer auth**: Identity is in HTTP headers, not in JSON-RPC payloads (per spec)
+3. **`tenant` field**: We can use the A2A `tenant` field as the org/team routing hint
+4. **No protocol extensions needed**: Standard A2A + standard OAuth/OIDC
+
+## Open Questions
+
+1. **JWKS cache TTL**: How aggressively to cache JWKS? Recommend 1h with forced refresh on unknown kid.
+2. **Auto-link policy**: Should auto-linking require the user to already exist, or also auto-provision? Recommend: user must exist, link is auto-created.
+3. **Fallback for simple setups**: Should we keep a simplified "shared secret JWT" mode for self-hosted instances without an external IdP? (Astonish issues its own JWTs for A2A, validated with its own key.)
+4. **Rate limiting**: Per-agent or per-user or both? Recommend: per-agent global + per-user within agent.

--- a/pkg/a2a/jwks.go
+++ b/pkg/a2a/jwks.go
@@ -1,0 +1,274 @@
+package a2a
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// JWKSClient fetches and caches JWKS (JSON Web Key Sets) from external IdP endpoints.
+// It supports multiple issuers and provides automatic cache refresh with rate limiting.
+type JWKSClient struct {
+	mu              sync.RWMutex
+	httpClient      *http.Client
+	cacheTTL        time.Duration
+	minRefreshDelay time.Duration
+	entries         map[string]*jwksEntry // URL → cached entry
+}
+
+// jwksEntry holds the cached keyset for a single JWKS URL.
+type jwksEntry struct {
+	keys        map[string]crypto.PublicKey // kid → public key
+	fetchedAt   time.Time
+	lastRefresh time.Time
+}
+
+// jwksResponse represents the JSON response from a JWKS endpoint.
+type jwksResponse struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+// jwkKey represents a single JWK in the JWKS response.
+type jwkKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	// RSA fields
+	N string `json:"n"`
+	E string `json:"e"`
+	// EC fields
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+// JWKSClientOption configures a JWKSClient.
+type JWKSClientOption func(*JWKSClient)
+
+// WithCacheTTL sets the cache time-to-live for fetched keysets.
+func WithCacheTTL(ttl time.Duration) JWKSClientOption {
+	return func(c *JWKSClient) {
+		c.cacheTTL = ttl
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for JWKS fetching.
+func WithHTTPClient(client *http.Client) JWKSClientOption {
+	return func(c *JWKSClient) {
+		c.httpClient = client
+	}
+}
+
+// WithMinRefreshDelay sets the minimum delay between forced refreshes (rate limiting).
+func WithMinRefreshDelay(d time.Duration) JWKSClientOption {
+	return func(c *JWKSClient) {
+		c.minRefreshDelay = d
+	}
+}
+
+// NewJWKSClient creates a new JWKS client with the given options.
+// Default TTL is 1 hour, default min refresh delay is 1 minute.
+func NewJWKSClient(opts ...JWKSClientOption) *JWKSClient {
+	c := &JWKSClient{
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		cacheTTL:        1 * time.Hour,
+		minRefreshDelay: 1 * time.Minute,
+		entries:         make(map[string]*jwksEntry),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// GetKey retrieves the public key for the given kid from the JWKS at jwksURL.
+// It uses a cached keyset if available and not expired. On cache miss or unknown kid,
+// it performs a forced refresh (rate-limited to once per minRefreshDelay).
+func (c *JWKSClient) GetKey(jwksURL, kid string) (crypto.PublicKey, error) {
+	// Try cache first
+	c.mu.RLock()
+	entry, exists := c.entries[jwksURL]
+	c.mu.RUnlock()
+
+	if exists && time.Since(entry.fetchedAt) < c.cacheTTL {
+		if key, ok := entry.keys[kid]; ok {
+			return key, nil
+		}
+		// kid not found in cache — try forced refresh
+		return c.refreshAndGet(jwksURL, kid)
+	}
+
+	// Cache miss or expired — fetch
+	return c.refreshAndGet(jwksURL, kid)
+}
+
+// refreshAndGet fetches the JWKS from the URL (rate-limited) and returns the key for kid.
+func (c *JWKSClient) refreshAndGet(jwksURL, kid string) (crypto.PublicKey, error) {
+	c.mu.Lock()
+
+	// Check if we already have a recent entry (another goroutine may have refreshed)
+	entry, exists := c.entries[jwksURL]
+	if exists && time.Since(entry.fetchedAt) < c.cacheTTL {
+		if key, ok := entry.keys[kid]; ok {
+			c.mu.Unlock()
+			return key, nil
+		}
+		// Check rate limit for forced refresh
+		if time.Since(entry.lastRefresh) < c.minRefreshDelay {
+			c.mu.Unlock()
+			return nil, fmt.Errorf("jwks: key %q not found at %s (refresh rate limited)", kid, jwksURL)
+		}
+	}
+
+	c.mu.Unlock()
+
+	// Fetch JWKS outside the lock
+	keys, err := c.fetchJWKS(jwksURL)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	c.mu.Lock()
+	c.entries[jwksURL] = &jwksEntry{
+		keys:        keys,
+		fetchedAt:   now,
+		lastRefresh: now,
+	}
+	c.mu.Unlock()
+
+	key, ok := keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("jwks: key %q not found at %s", kid, jwksURL)
+	}
+	return key, nil
+}
+
+// fetchJWKS performs an HTTP GET to the JWKS URL and parses the response.
+func (c *JWKSClient) fetchJWKS(jwksURL string) (map[string]crypto.PublicKey, error) {
+	resp, err := c.httpClient.Get(jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to fetch %s: %w", jwksURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwks: unexpected status %d from %s", resp.StatusCode, jwksURL)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to read response from %s: %w", jwksURL, err)
+	}
+
+	var jwks jwksResponse
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return nil, fmt.Errorf("jwks: failed to parse JWKS from %s: %w", jwksURL, err)
+	}
+
+	keys := make(map[string]crypto.PublicKey)
+	for _, k := range jwks.Keys {
+		pubKey, err := parseJWK(k)
+		if err != nil {
+			// Skip keys we can't parse (e.g., unsupported key types)
+			continue
+		}
+		keys[k.Kid] = pubKey
+	}
+
+	return keys, nil
+}
+
+// parseJWK converts a JWK JSON object to a crypto.PublicKey.
+func parseJWK(k jwkKey) (crypto.PublicKey, error) {
+	switch k.Kty {
+	case "RSA":
+		return parseRSAJWK(k)
+	case "EC":
+		return parseECJWK(k)
+	default:
+		return nil, fmt.Errorf("jwks: unsupported key type %q", k.Kty)
+	}
+}
+
+// parseRSAJWK parses an RSA JWK into an *rsa.PublicKey.
+func parseRSAJWK(k jwkKey) (*rsa.PublicKey, error) {
+	if k.N == "" || k.E == "" {
+		return nil, fmt.Errorf("jwks: RSA key missing n or e")
+	}
+
+	nBytes, err := base64URLDecode(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to decode RSA n: %w", err)
+	}
+
+	eBytes, err := base64URLDecode(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to decode RSA e: %w", err)
+	}
+
+	n := new(big.Int).SetBytes(nBytes)
+	e := new(big.Int).SetBytes(eBytes)
+
+	if !e.IsInt64() {
+		return nil, fmt.Errorf("jwks: RSA exponent too large")
+	}
+
+	return &rsa.PublicKey{
+		N: n,
+		E: int(e.Int64()),
+	}, nil
+}
+
+// parseECJWK parses an EC JWK into an *ecdsa.PublicKey.
+func parseECJWK(k jwkKey) (*ecdsa.PublicKey, error) {
+	if k.X == "" || k.Y == "" || k.Crv == "" {
+		return nil, fmt.Errorf("jwks: EC key missing x, y, or crv")
+	}
+
+	var curve elliptic.Curve
+	switch k.Crv {
+	case "P-256":
+		curve = elliptic.P256()
+	case "P-384":
+		curve = elliptic.P384()
+	case "P-521":
+		curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("jwks: unsupported EC curve %q", k.Crv)
+	}
+
+	xBytes, err := base64URLDecode(k.X)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to decode EC x: %w", err)
+	}
+
+	yBytes, err := base64URLDecode(k.Y)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to decode EC y: %w", err)
+	}
+
+	x := new(big.Int).SetBytes(xBytes)
+	y := new(big.Int).SetBytes(yBytes)
+
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}, nil
+}
+
+// base64URLDecode decodes a base64url-encoded string (without padding).
+func base64URLDecode(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}

--- a/pkg/a2a/jwks_test.go
+++ b/pkg/a2a/jwks_test.go
@@ -1,0 +1,301 @@
+package a2a
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// generateTestRSAKey creates a test RSA key pair and returns the private key and JWKS JSON.
+func generateTestRSAKey(kid string) (*rsa.PrivateKey, []byte) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	nBytes := privateKey.PublicKey.N.Bytes()
+	eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
+
+	jwks := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "RSA",
+				"kid": kid,
+				"n":   base64.RawURLEncoding.EncodeToString(nBytes),
+				"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+			},
+		},
+	}
+
+	data, err := json.Marshal(jwks)
+	if err != nil {
+		panic(err)
+	}
+	return privateKey, data
+}
+
+func TestJWKS_FetchAndParseRSAKey(t *testing.T) {
+	privateKey, jwksData := generateTestRSAKey("test-key-1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData)
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient()
+
+	key, err := client.GetKey(server.URL, "test-key-1")
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+
+	rsaKey, ok := key.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("expected *rsa.PublicKey, got %T", key)
+	}
+
+	if rsaKey.N.Cmp(privateKey.PublicKey.N) != 0 {
+		t.Error("RSA N mismatch")
+	}
+	if rsaKey.E != privateKey.PublicKey.E {
+		t.Error("RSA E mismatch")
+	}
+}
+
+func TestJWKS_CacheHit(t *testing.T) {
+	_, jwksData := generateTestRSAKey("cached-key")
+
+	var fetchCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData)
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient(WithCacheTTL(1 * time.Hour))
+
+	// First call — should fetch
+	_, err := client.GetKey(server.URL, "cached-key")
+	if err != nil {
+		t.Fatalf("first GetKey failed: %v", err)
+	}
+
+	// Second call — should use cache
+	_, err = client.GetKey(server.URL, "cached-key")
+	if err != nil {
+		t.Fatalf("second GetKey failed: %v", err)
+	}
+
+	if count := fetchCount.Load(); count != 1 {
+		t.Errorf("expected 1 HTTP fetch, got %d", count)
+	}
+}
+
+func TestJWKS_ForcedRefreshOnUnknownKid(t *testing.T) {
+	_, jwksData1 := generateTestRSAKey("key-1")
+
+	// Build JWKS with both keys for the second response
+	privateKey2, _ := generateTestRSAKey("key-2")
+	nBytes2 := privateKey2.PublicKey.N.Bytes()
+	eBytes2 := big.NewInt(int64(privateKey2.PublicKey.E)).Bytes()
+
+	jwks2 := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "RSA",
+				"kid": "key-1",
+				"n":   base64.RawURLEncoding.EncodeToString(privateKey2.PublicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey2.PublicKey.E)).Bytes()),
+			},
+			{
+				"kty": "RSA",
+				"kid": "key-2",
+				"n":   base64.RawURLEncoding.EncodeToString(nBytes2),
+				"e":   base64.RawURLEncoding.EncodeToString(eBytes2),
+			},
+		},
+	}
+	jwksData2, _ := json.Marshal(jwks2)
+
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if count == 1 {
+			w.Write(jwksData1)
+		} else {
+			w.Write(jwksData2)
+		}
+	}))
+	defer server.Close()
+
+	// Use very short min refresh delay for testing
+	client := NewJWKSClient(
+		WithCacheTTL(1*time.Hour),
+		WithMinRefreshDelay(0), // No rate limiting for test
+	)
+
+	// First call — fetches key-1
+	_, err := client.GetKey(server.URL, "key-1")
+	if err != nil {
+		t.Fatalf("first GetKey failed: %v", err)
+	}
+
+	// Second call with unknown kid — should trigger refresh
+	key, err := client.GetKey(server.URL, "key-2")
+	if err != nil {
+		t.Fatalf("GetKey for key-2 failed: %v", err)
+	}
+
+	if key == nil {
+		t.Fatal("expected non-nil key for key-2")
+	}
+
+	if count := fetchCount.Load(); count != 2 {
+		t.Errorf("expected 2 HTTP fetches, got %d", count)
+	}
+}
+
+func TestJWKS_RateLimitedRefresh(t *testing.T) {
+	_, jwksData := generateTestRSAKey("only-key")
+
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData)
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient(
+		WithCacheTTL(1*time.Hour),
+		WithMinRefreshDelay(1*time.Minute),
+	)
+
+	// First fetch
+	_, err := client.GetKey(server.URL, "only-key")
+	if err != nil {
+		t.Fatalf("first GetKey failed: %v", err)
+	}
+
+	// Try to get unknown kid — should be rate limited after first refresh
+	_, err = client.GetKey(server.URL, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent key")
+	}
+
+	// Should only have done 1 fetch (initial fetch counts, second is rate limited)
+	// Actually the initial fetch sets lastRefresh, so the second attempt is rate-limited
+	if count := fetchCount.Load(); count != 1 {
+		t.Errorf("expected 1 HTTP fetch (rate limited), got %d", count)
+	}
+}
+
+func TestJWKS_UnreachableURL(t *testing.T) {
+	client := NewJWKSClient(
+		WithHTTPClient(&http.Client{Timeout: 100 * time.Millisecond}),
+	)
+
+	_, err := client.GetKey("http://127.0.0.1:1/jwks", "any-kid")
+	if err == nil {
+		t.Fatal("expected error for unreachable URL")
+	}
+}
+
+func TestJWKS_MalformedJWKS(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"keys": "not an array"}`))
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient()
+
+	_, err := client.GetKey(server.URL, "any-kid")
+	if err == nil {
+		t.Fatal("expected error for malformed JWKS")
+	}
+}
+
+func TestJWKS_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json at all`))
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient()
+
+	_, err := client.GetKey(server.URL, "any-kid")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestJWKS_MultipleIssuers(t *testing.T) {
+	_, jwksData1 := generateTestRSAKey("issuer1-key")
+	_, jwksData2 := generateTestRSAKey("issuer2-key")
+
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData1)
+	}))
+	defer server1.Close()
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData2)
+	}))
+	defer server2.Close()
+
+	client := NewJWKSClient()
+
+	key1, err := client.GetKey(server1.URL, "issuer1-key")
+	if err != nil {
+		t.Fatalf("GetKey from issuer1 failed: %v", err)
+	}
+	if key1 == nil {
+		t.Fatal("expected non-nil key from issuer1")
+	}
+
+	key2, err := client.GetKey(server2.URL, "issuer2-key")
+	if err != nil {
+		t.Fatalf("GetKey from issuer2 failed: %v", err)
+	}
+	if key2 == nil {
+		t.Fatal("expected non-nil key from issuer2")
+	}
+
+	// Ensure they are different keys
+	rsaKey1 := key1.(*rsa.PublicKey)
+	rsaKey2 := key2.(*rsa.PublicKey)
+	if rsaKey1.N.Cmp(rsaKey2.N) == 0 {
+		t.Error("expected different keys from different issuers")
+	}
+}
+
+func TestJWKS_HTTPErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "internal error")
+	}))
+	defer server.Close()
+
+	client := NewJWKSClient()
+
+	_, err := client.GetKey(server.URL, "any-kid")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}

--- a/pkg/a2a/stores.go
+++ b/pkg/a2a/stores.go
@@ -1,0 +1,142 @@
+package a2a
+
+import (
+	"fmt"
+	"sync"
+)
+
+// TrustedIssuerStore defines CRUD operations for TrustedIssuer entities.
+type TrustedIssuerStore interface {
+	List() []TrustedIssuer
+	Create(issuer TrustedIssuer) error
+	Delete(id string) error
+	GetByIssuer(issuerURL string) (*TrustedIssuer, error)
+}
+
+// AllowedAgentStore defines CRUD operations for AllowedAgent entities.
+type AllowedAgentStore interface {
+	List() []AllowedAgent
+	Create(agent AllowedAgent) error
+	Delete(id string) error
+	GetByActorSub(actorSub string) (*AllowedAgent, error)
+}
+
+// InMemoryIssuerStore is a thread-safe in-memory store for TrustedIssuers.
+type InMemoryIssuerStore struct {
+	mu      sync.RWMutex
+	issuers []TrustedIssuer
+}
+
+// NewInMemoryIssuerStore creates a new empty InMemoryIssuerStore.
+func NewInMemoryIssuerStore() *InMemoryIssuerStore {
+	return &InMemoryIssuerStore{}
+}
+
+// List returns all trusted issuers.
+func (s *InMemoryIssuerStore) List() []TrustedIssuer {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]TrustedIssuer, len(s.issuers))
+	copy(out, s.issuers)
+	return out
+}
+
+// Create adds a new trusted issuer. Returns an error if the ID already exists.
+func (s *InMemoryIssuerStore) Create(issuer TrustedIssuer) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, existing := range s.issuers {
+		if existing.ID == issuer.ID {
+			return fmt.Errorf("trusted issuer with ID %q already exists", issuer.ID)
+		}
+	}
+	s.issuers = append(s.issuers, issuer)
+	return nil
+}
+
+// Delete removes a trusted issuer by ID. Returns an error if not found.
+func (s *InMemoryIssuerStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, issuer := range s.issuers {
+		if issuer.ID == id {
+			s.issuers = append(s.issuers[:i], s.issuers[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("trusted issuer with ID %q not found", id)
+}
+
+// GetByIssuer finds a trusted issuer by its Issuer URL (the `iss` claim value).
+// Returns nil and an error if not found.
+func (s *InMemoryIssuerStore) GetByIssuer(issuerURL string) (*TrustedIssuer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.issuers {
+		if s.issuers[i].Issuer == issuerURL {
+			result := s.issuers[i]
+			return &result, nil
+		}
+	}
+	return nil, fmt.Errorf("trusted issuer with issuer URL %q not found", issuerURL)
+}
+
+// InMemoryAgentAllowStore is a thread-safe in-memory store for AllowedAgents.
+type InMemoryAgentAllowStore struct {
+	mu     sync.RWMutex
+	agents []AllowedAgent
+}
+
+// NewInMemoryAgentAllowStore creates a new empty InMemoryAgentAllowStore.
+func NewInMemoryAgentAllowStore() *InMemoryAgentAllowStore {
+	return &InMemoryAgentAllowStore{}
+}
+
+// List returns all allowed agents.
+func (s *InMemoryAgentAllowStore) List() []AllowedAgent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]AllowedAgent, len(s.agents))
+	copy(out, s.agents)
+	return out
+}
+
+// Create adds a new allowed agent. Returns an error if the ID already exists.
+func (s *InMemoryAgentAllowStore) Create(agent AllowedAgent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, existing := range s.agents {
+		if existing.ID == agent.ID {
+			return fmt.Errorf("allowed agent with ID %q already exists", agent.ID)
+		}
+	}
+	s.agents = append(s.agents, agent)
+	return nil
+}
+
+// Delete removes an allowed agent by ID. Returns an error if not found.
+func (s *InMemoryAgentAllowStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, agent := range s.agents {
+		if agent.ID == id {
+			s.agents = append(s.agents[:i], s.agents[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("allowed agent with ID %q not found", id)
+}
+
+// GetByActorSub finds an allowed agent by its ActorSub field.
+// Returns nil and an error if not found.
+func (s *InMemoryAgentAllowStore) GetByActorSub(actorSub string) (*AllowedAgent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.agents {
+		if s.agents[i].ActorSub == actorSub {
+			result := s.agents[i]
+			return &result, nil
+		}
+	}
+	return nil, fmt.Errorf("allowed agent with actor_sub %q not found", actorSub)
+}

--- a/pkg/a2a/stores_test.go
+++ b/pkg/a2a/stores_test.go
@@ -1,0 +1,136 @@
+package a2a
+
+import (
+	"testing"
+)
+
+func TestStoresIssuerCRUD(t *testing.T) {
+	store := NewInMemoryIssuerStore()
+
+	// Initially empty.
+	if got := store.List(); len(got) != 0 {
+		t.Fatalf("expected empty list, got %d items", len(got))
+	}
+
+	// Create an issuer.
+	iss := TrustedIssuer{
+		ID:        "iss-1",
+		Name:      "Test IdP",
+		Issuer:    "https://idp.example.com",
+		JWKSURL:   "https://idp.example.com/.well-known/jwks.json",
+		Audience:  "astonish",
+		UserClaim: "email",
+		OrgID:     "org-1",
+	}
+	if err := store.Create(iss); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// List returns the issuer.
+	list := store.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(list))
+	}
+	if list[0].ID != "iss-1" {
+		t.Fatalf("expected ID iss-1, got %s", list[0].ID)
+	}
+
+	// Duplicate ID returns error.
+	if err := store.Create(iss); err == nil {
+		t.Fatal("expected error on duplicate ID, got nil")
+	}
+
+	// GetByIssuer finds it.
+	found, err := store.GetByIssuer("https://idp.example.com")
+	if err != nil {
+		t.Fatalf("GetByIssuer failed: %v", err)
+	}
+	if found.ID != "iss-1" {
+		t.Fatalf("expected ID iss-1, got %s", found.ID)
+	}
+
+	// GetByIssuer with unknown URL returns error.
+	_, err = store.GetByIssuer("https://unknown.example.com")
+	if err == nil {
+		t.Fatal("expected error for unknown issuer, got nil")
+	}
+
+	// Delete removes it.
+	if err := store.Delete("iss-1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if got := store.List(); len(got) != 0 {
+		t.Fatalf("expected empty list after delete, got %d items", len(got))
+	}
+
+	// Delete non-existent returns error.
+	if err := store.Delete("iss-1"); err == nil {
+		t.Fatal("expected error on delete of non-existent, got nil")
+	}
+}
+
+func TestStoresAgentCRUD(t *testing.T) {
+	store := NewInMemoryAgentAllowStore()
+
+	// Initially empty.
+	if got := store.List(); len(got) != 0 {
+		t.Fatalf("expected empty list, got %d items", len(got))
+	}
+
+	// Create an agent.
+	agent := AllowedAgent{
+		ID:        "agent-1",
+		Name:      "Test Agent",
+		ActorSub:  "svc://test-agent",
+		IssuerID:  "iss-1",
+		OrgID:     "org-1",
+		RateLimit: 100,
+		MaxTasks:  10,
+		Enabled:   true,
+	}
+	if err := store.Create(agent); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// List returns the agent.
+	list := store.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(list))
+	}
+	if list[0].ID != "agent-1" {
+		t.Fatalf("expected ID agent-1, got %s", list[0].ID)
+	}
+
+	// Duplicate ID returns error.
+	if err := store.Create(agent); err == nil {
+		t.Fatal("expected error on duplicate ID, got nil")
+	}
+
+	// GetByActorSub finds it.
+	found, err := store.GetByActorSub("svc://test-agent")
+	if err != nil {
+		t.Fatalf("GetByActorSub failed: %v", err)
+	}
+	if found.ID != "agent-1" {
+		t.Fatalf("expected ID agent-1, got %s", found.ID)
+	}
+
+	// GetByActorSub with unknown returns error.
+	_, err = store.GetByActorSub("svc://unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown actor_sub, got nil")
+	}
+
+	// Delete removes it.
+	if err := store.Delete("agent-1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if got := store.List(); len(got) != 0 {
+		t.Fatalf("expected empty list after delete, got %d items", len(got))
+	}
+
+	// Delete non-existent returns error.
+	if err := store.Delete("agent-1"); err == nil {
+		t.Fatal("expected error on delete of non-existent, got nil")
+	}
+}

--- a/pkg/a2a/token_validator.go
+++ b/pkg/a2a/token_validator.go
@@ -1,10 +1,22 @@
 package a2a
 
 import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	ErrTokenExpired    = errors.New("a2a: token expired")
+	ErrUntrustedIssuer = errors.New("a2a: untrusted issuer")
+	ErrInvalidAudience = errors.New("a2a: invalid audience")
+	ErrActorNotAllowed = errors.New("a2a: actor not allowed")
+	ErrMissingActClaim = errors.New("a2a: missing required act claim")
+	ErrTokenInvalid    = errors.New("a2a: token invalid")
 )
 
 // TrustedIssuer represents an IdP trusted for A2A token validation.
@@ -98,7 +110,7 @@ func (v *TokenValidator) Validate(tokenStr string) (*A2ATokenClaims, error) {
 		}
 	}
 	if matchedIssuer == nil {
-		return nil, fmt.Errorf("a2a: untrusted issuer %q", issuer)
+		return nil, fmt.Errorf("%w: %q", ErrUntrustedIssuer, issuer)
 	}
 
 	// Step 3: Fetch signing key from JWKS using `kid` and the issuer's JWKS URL.
@@ -109,16 +121,26 @@ func (v *TokenValidator) Validate(tokenStr string) (*A2ATokenClaims, error) {
 
 	// Step 4: Verify signature, expiry, not-before using jwt.Parse with the key.
 	verified, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
-		// Ensure the signing method is RS256 or ES256.
-		switch t.Method.Alg() {
-		case "RS256", "RS384", "RS512", "ES256", "ES384", "ES512":
-			return pubKey, nil
+		// Pin allowed algorithms to the key type for defense in depth
+		switch pubKey.(type) {
+		case *rsa.PublicKey:
+			if t.Method.Alg() != "RS256" && t.Method.Alg() != "RS384" && t.Method.Alg() != "RS512" {
+				return nil, fmt.Errorf("unexpected signing method %v for RSA key", t.Header["alg"])
+			}
+		case *ecdsa.PublicKey:
+			if t.Method.Alg() != "ES256" && t.Method.Alg() != "ES384" && t.Method.Alg() != "ES512" {
+				return nil, fmt.Errorf("unexpected signing method %v for EC key", t.Header["alg"])
+			}
 		default:
-			return nil, fmt.Errorf("a2a: unexpected signing method %q", t.Method.Alg())
+			return nil, fmt.Errorf("unsupported key type %T", pubKey)
 		}
+		return pubKey, nil
 	}, jwt.WithExpirationRequired())
 	if err != nil {
-		return nil, fmt.Errorf("a2a: token verification failed: %w", err)
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, fmt.Errorf("%w: %v", ErrTokenExpired, err)
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTokenInvalid, err)
 	}
 
 	verifiedClaims, ok := verified.Claims.(jwt.MapClaims)
@@ -132,7 +154,7 @@ func (v *TokenValidator) Validate(tokenStr string) (*A2ATokenClaims, error) {
 		return nil, fmt.Errorf("a2a: failed to get audience claim: %w", err)
 	}
 	if !containsString(audience, matchedIssuer.Audience) {
-		return nil, fmt.Errorf("a2a: token audience %v does not contain expected %q", audience, matchedIssuer.Audience)
+		return nil, fmt.Errorf("%w: token audience %v does not contain %q", ErrInvalidAudience, audience, matchedIssuer.Audience)
 	}
 
 	// Step 6: Extract user identity from the configured `user_claim` field.
@@ -165,14 +187,14 @@ func (v *TokenValidator) Validate(tokenStr string) (*A2ATokenClaims, error) {
 		// Verify the actor matches an AllowedAgent for this org.
 		agent := v.findAllowedAgent(actorSub, matchedIssuer.ID, matchedIssuer.OrgID)
 		if agent == nil {
-			return nil, fmt.Errorf("a2a: actor %q is not an allowed agent", actorSub)
+			return nil, fmt.Errorf("%w: %q", ErrActorNotAllowed, actorSub)
 		}
 		if !agent.Enabled {
-			return nil, fmt.Errorf("a2a: agent %q is disabled", actorSub)
+			return nil, fmt.Errorf("%w: %q (disabled)", ErrActorNotAllowed, actorSub)
 		}
 		result.ActorIdentifier = actorSub
 	} else if v.requireActorClaim {
-		return nil, fmt.Errorf("a2a: token missing required act claim")
+		return nil, ErrMissingActClaim
 	}
 
 	return result, nil

--- a/pkg/a2a/token_validator.go
+++ b/pkg/a2a/token_validator.go
@@ -1,0 +1,226 @@
+package a2a
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TrustedIssuer represents an IdP trusted for A2A token validation.
+type TrustedIssuer struct {
+	ID        string
+	Name      string
+	Issuer    string // must match JWT `iss` claim
+	JWKSURL   string
+	Audience  string // must match JWT `aud` claim
+	UserClaim string // which claim identifies the user: "sub", "email", "preferred_username"
+	OrgID     string // owning organization
+}
+
+// AllowedAgent represents an external service authorized to make A2A calls.
+type AllowedAgent struct {
+	ID        string
+	Name      string
+	ActorSub  string // must match JWT `act.sub` claim
+	IssuerID  string
+	OrgID     string
+	RateLimit int
+	MaxTasks  int
+	Enabled   bool
+}
+
+// A2ATokenClaims holds the validated identity from an A2A JWT.
+type A2ATokenClaims struct {
+	UserIdentifier  string    // extracted from configured user_claim
+	ActorIdentifier string    // from act.sub (empty if direct user token)
+	Issuer          string
+	IssuerID        string    // matched TrustedIssuer.ID
+	OrgID           string
+	ExpiresAt       time.Time
+}
+
+// TokenValidatorConfig configures the token validator.
+type TokenValidatorConfig struct {
+	Issuers           []TrustedIssuer
+	Agents            []AllowedAgent
+	RequireActorClaim bool
+}
+
+// TokenValidator validates A2A JWT tokens against configured trusted issuers.
+type TokenValidator struct {
+	jwks              *JWKSClient
+	issuers           []TrustedIssuer
+	agents            []AllowedAgent
+	requireActorClaim bool
+}
+
+// NewTokenValidator creates a new TokenValidator with the given configuration.
+func NewTokenValidator(cfg TokenValidatorConfig) *TokenValidator {
+	return &TokenValidator{
+		jwks:              NewJWKSClient(),
+		issuers:           cfg.Issuers,
+		agents:            cfg.Agents,
+		requireActorClaim: cfg.RequireActorClaim,
+	}
+}
+
+// Validate validates an A2A JWT token string and returns the extracted claims.
+func (v *TokenValidator) Validate(tokenStr string) (*A2ATokenClaims, error) {
+	// Step 1: Parse JWT without verification to extract `iss` claim and `kid` from header.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	unverified, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		return nil, fmt.Errorf("a2a: failed to parse token: %w", err)
+	}
+
+	claims, ok := unverified.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("a2a: unexpected claims type")
+	}
+
+	issuer, err := claims.GetIssuer()
+	if err != nil || issuer == "" {
+		return nil, fmt.Errorf("a2a: token missing iss claim")
+	}
+
+	kid, _ := unverified.Header["kid"].(string)
+	if kid == "" {
+		return nil, fmt.Errorf("a2a: token missing kid header")
+	}
+
+	// Step 2: Find matching TrustedIssuer by `iss` claim.
+	var matchedIssuer *TrustedIssuer
+	for i := range v.issuers {
+		if v.issuers[i].Issuer == issuer {
+			matchedIssuer = &v.issuers[i]
+			break
+		}
+	}
+	if matchedIssuer == nil {
+		return nil, fmt.Errorf("a2a: untrusted issuer %q", issuer)
+	}
+
+	// Step 3: Fetch signing key from JWKS using `kid` and the issuer's JWKS URL.
+	pubKey, err := v.jwks.GetKey(matchedIssuer.JWKSURL, kid)
+	if err != nil {
+		return nil, fmt.Errorf("a2a: failed to fetch signing key: %w", err)
+	}
+
+	// Step 4: Verify signature, expiry, not-before using jwt.Parse with the key.
+	verified, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		// Ensure the signing method is RS256 or ES256.
+		switch t.Method.Alg() {
+		case "RS256", "RS384", "RS512", "ES256", "ES384", "ES512":
+			return pubKey, nil
+		default:
+			return nil, fmt.Errorf("a2a: unexpected signing method %q", t.Method.Alg())
+		}
+	}, jwt.WithExpirationRequired())
+	if err != nil {
+		return nil, fmt.Errorf("a2a: token verification failed: %w", err)
+	}
+
+	verifiedClaims, ok := verified.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("a2a: unexpected claims type after verification")
+	}
+
+	// Step 5: Verify `aud` claim contains the issuer's configured audience.
+	audience, err := verifiedClaims.GetAudience()
+	if err != nil {
+		return nil, fmt.Errorf("a2a: failed to get audience claim: %w", err)
+	}
+	if !containsString(audience, matchedIssuer.Audience) {
+		return nil, fmt.Errorf("a2a: token audience %v does not contain expected %q", audience, matchedIssuer.Audience)
+	}
+
+	// Step 6: Extract user identity from the configured `user_claim` field.
+	userClaim := matchedIssuer.UserClaim
+	if userClaim == "" {
+		userClaim = "sub"
+	}
+	userIdentifier, _ := getStringClaim(verifiedClaims, userClaim)
+	if userIdentifier == "" {
+		return nil, fmt.Errorf("a2a: token missing user claim %q", userClaim)
+	}
+
+	// Extract expiry.
+	exp, err := verifiedClaims.GetExpirationTime()
+	if err != nil {
+		return nil, fmt.Errorf("a2a: failed to get expiration: %w", err)
+	}
+
+	result := &A2ATokenClaims{
+		UserIdentifier: userIdentifier,
+		Issuer:         issuer,
+		IssuerID:       matchedIssuer.ID,
+		OrgID:          matchedIssuer.OrgID,
+		ExpiresAt:      exp.Time,
+	}
+
+	// Step 7 & 8: Handle `act` claim.
+	actorSub := extractActorSub(verifiedClaims)
+	if actorSub != "" {
+		// Verify the actor matches an AllowedAgent for this org.
+		agent := v.findAllowedAgent(actorSub, matchedIssuer.ID, matchedIssuer.OrgID)
+		if agent == nil {
+			return nil, fmt.Errorf("a2a: actor %q is not an allowed agent", actorSub)
+		}
+		if !agent.Enabled {
+			return nil, fmt.Errorf("a2a: agent %q is disabled", actorSub)
+		}
+		result.ActorIdentifier = actorSub
+	} else if v.requireActorClaim {
+		return nil, fmt.Errorf("a2a: token missing required act claim")
+	}
+
+	return result, nil
+}
+
+// findAllowedAgent finds an AllowedAgent matching the given actor subject, issuer ID, and org ID.
+func (v *TokenValidator) findAllowedAgent(actorSub, issuerID, orgID string) *AllowedAgent {
+	for i := range v.agents {
+		a := &v.agents[i]
+		if a.ActorSub == actorSub && a.IssuerID == issuerID && a.OrgID == orgID {
+			return a
+		}
+	}
+	return nil
+}
+
+// extractActorSub extracts the `act.sub` claim from JWT MapClaims.
+// The `act` claim is a JSON object like {"sub": "service-id"}.
+func extractActorSub(claims jwt.MapClaims) string {
+	actRaw, ok := claims["act"]
+	if !ok {
+		return ""
+	}
+	actMap, ok := actRaw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	sub, _ := actMap["sub"].(string)
+	return sub
+}
+
+// getStringClaim extracts a string claim from MapClaims.
+func getStringClaim(claims jwt.MapClaims, key string) (string, bool) {
+	val, ok := claims[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := val.(string)
+	return s, ok
+}
+
+// containsString checks if a string slice contains a target string.
+func containsString(slice []string, target string) bool {
+	for _, s := range slice {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+

--- a/pkg/a2a/token_validator_test.go
+++ b/pkg/a2a/token_validator_test.go
@@ -1,0 +1,445 @@
+package a2a
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// testJWKSServer creates an httptest server that serves a JWKS containing the given RSA public key.
+func testJWKSServer(t *testing.T, kid string, pub *rsa.PublicKey) *httptest.Server {
+	t.Helper()
+
+	jwks := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "RSA",
+				"kid": kid,
+				"use": "sig",
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// signToken creates a signed JWT with the given claims and key.
+func signToken(t *testing.T, kid string, key *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	tokenStr, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return tokenStr
+}
+
+func TestTokenValidator_ValidToken(t *testing.T) {
+	// Generate RSA key pair
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+
+	// Create JWKS server
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Name:      "Test IdP",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		Agents:            []AllowedAgent{},
+		RequireActorClaim: false,
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	result, err := validator.Validate(tokenStr)
+	if err != nil {
+		t.Fatalf("expected valid token, got error: %v", err)
+	}
+
+	if result.UserIdentifier != "user-123" {
+		t.Errorf("expected UserIdentifier=user-123, got %q", result.UserIdentifier)
+	}
+	if result.Issuer != issuerURL {
+		t.Errorf("expected Issuer=%q, got %q", issuerURL, result.Issuer)
+	}
+	if result.IssuerID != "issuer-1" {
+		t.Errorf("expected IssuerID=issuer-1, got %q", result.IssuerID)
+	}
+	if result.OrgID != "org-1" {
+		t.Errorf("expected OrgID=org-1, got %q", result.OrgID)
+	}
+	if result.ActorIdentifier != "" {
+		t.Errorf("expected empty ActorIdentifier, got %q", result.ActorIdentifier)
+	}
+}
+
+func TestTokenValidator_WrongIssuer(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:      "issuer-1",
+				Issuer:  "https://trusted.example.com",
+				JWKSURL: jwksServer.URL,
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": "https://evil.example.com",
+		"aud": "some-aud",
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for wrong issuer, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestTokenValidator_WrongAudience(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  "correct-audience",
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": "wrong-audience",
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for wrong audience, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestTokenValidator_ExpiredToken(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(-time.Hour).Unix(), // expired
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestTokenValidator_ActClaimWithMatchingAgent(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		Agents: []AllowedAgent{
+			{
+				ID:       "agent-1",
+				Name:     "Test Agent",
+				ActorSub: "service-abc",
+				IssuerID: "issuer-1",
+				OrgID:    "org-1",
+				Enabled:  true,
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"act": map[string]interface{}{
+			"sub": "service-abc",
+		},
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	result, err := validator.Validate(tokenStr)
+	if err != nil {
+		t.Fatalf("expected valid token with act claim, got error: %v", err)
+	}
+
+	if result.ActorIdentifier != "service-abc" {
+		t.Errorf("expected ActorIdentifier=service-abc, got %q", result.ActorIdentifier)
+	}
+	if result.UserIdentifier != "user-123" {
+		t.Errorf("expected UserIdentifier=user-123, got %q", result.UserIdentifier)
+	}
+}
+
+func TestTokenValidator_ActClaimAgentNotAllowed(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		Agents: []AllowedAgent{
+			{
+				ID:       "agent-1",
+				Name:     "Other Agent",
+				ActorSub: "service-other",
+				IssuerID: "issuer-1",
+				OrgID:    "org-1",
+				Enabled:  true,
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"act": map[string]interface{}{
+			"sub": "service-unauthorized",
+		},
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for unauthorized agent, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestTokenValidator_NoActClaimRequireActorTrue(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		RequireActorClaim: true,
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error when act claim is required but missing, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestTokenValidator_NoActClaimRequireActorFalse(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		RequireActorClaim: false,
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	result, err := validator.Validate(tokenStr)
+	if err != nil {
+		t.Fatalf("expected valid token without act claim, got error: %v", err)
+	}
+
+	if result.UserIdentifier != "user-123" {
+		t.Errorf("expected UserIdentifier=user-123, got %q", result.UserIdentifier)
+	}
+	if result.ActorIdentifier != "" {
+		t.Errorf("expected empty ActorIdentifier, got %q", result.ActorIdentifier)
+	}
+}
+
+

--- a/pkg/a2a/token_validator_test.go
+++ b/pkg/a2a/token_validator_test.go
@@ -1,13 +1,18 @@
 package a2a
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -440,6 +445,306 @@ func TestTokenValidator_NoActClaimRequireActorFalse(t *testing.T) {
 	if result.ActorIdentifier != "" {
 		t.Errorf("expected empty ActorIdentifier, got %q", result.ActorIdentifier)
 	}
+}
+
+// =============================================================================
+// Security Attack Vector Tests
+// =============================================================================
+
+func TestTokenValidator_AlgNone(t *testing.T) {
+	// Attack: craft a token with alg:none and no signature.
+	// The validator must reject this.
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	// Manually construct a token with alg:none
+	headerJSON := `{"alg":"none","typ":"JWT","kid":"` + kid + `"}`
+	claimsJSON := fmt.Sprintf(`{"iss":"%s","aud":"%s","sub":"user-123","exp":%d}`, issuerURL, audience, time.Now().Add(time.Hour).Unix())
+	header := base64.RawURLEncoding.EncodeToString([]byte(headerJSON))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(claimsJSON))
+	tokenStr := header + "." + payload + "."
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for alg:none token, got nil")
+	}
+	t.Logf("alg:none correctly rejected: %v", err)
+}
+
+func TestTokenValidator_HS256Confusion(t *testing.T) {
+	// Attack: sign a token with HS256 using the RSA public key bytes as the HMAC secret.
+	// This is the classic algorithm confusion attack.
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	// Marshal the RSA public key to use as HMAC secret
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+
+	// Create token signed with HS256 using the public key bytes as secret
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token.Header["kid"] = kid
+	tokenStr, err := token.SignedString(pubKeyBytes)
+	if err != nil {
+		t.Fatalf("failed to sign HS256 token: %v", err)
+	}
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for HS256 confusion attack, got nil")
+	}
+	t.Logf("HS256 confusion correctly rejected: %v", err)
+}
+
+func TestTokenValidator_TamperedSignature(t *testing.T) {
+	// Attack: create a valid RS256 token, then tamper with the signature.
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "test-key-1"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	tokenStr := signToken(t, kid, privKey, claims)
+
+	// Tamper with the signature by flipping a byte
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts in JWT, got %d", len(parts))
+	}
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("failed to decode signature: %v", err)
+	}
+	// Flip the first byte
+	sigBytes[0] ^= 0xFF
+	parts[2] = base64.RawURLEncoding.EncodeToString(sigBytes)
+	tamperedToken := strings.Join(parts, ".")
+
+	_, err = validator.Validate(tamperedToken)
+	if err == nil {
+		t.Fatal("expected error for tampered signature, got nil")
+	}
+	t.Logf("tampered signature correctly rejected: %v", err)
+}
+
+func TestTokenValidator_UnknownKID(t *testing.T) {
+	// Attack: use a valid signing key but with a kid that doesn't exist in the JWKS.
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	kid := "known-key"
+	jwksServer := testJWKSServer(t, kid, &privKey.PublicKey)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	// Generate a different key and sign with an unknown kid
+	attackerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate attacker key: %v", err)
+	}
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+
+	// Sign with attacker's key using an unknown kid
+	tokenStr := signToken(t, "unknown-kid-xyz", attackerKey, claims)
+
+	_, err = validator.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for unknown kid, got nil")
+	}
+	t.Logf("unknown kid correctly rejected: %v", err)
+}
+
+func TestTokenValidator_ES256ValidToken(t *testing.T) {
+	// Happy path: validate a properly signed ES256 token.
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate EC key: %v", err)
+	}
+	kid := "ec-key-1"
+
+	// Create a JWKS server with the EC public key
+	xBytes := ecKey.PublicKey.X.Bytes()
+	yBytes := ecKey.PublicKey.Y.Bytes()
+	// Pad to 32 bytes for P-256
+	padTo32 := func(b []byte) []byte {
+		if len(b) >= 32 {
+			return b
+		}
+		padded := make([]byte, 32)
+		copy(padded[32-len(b):], b)
+		return padded
+	}
+
+	jwks := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "EC",
+				"kid": kid,
+				"use": "sig",
+				"alg": "ES256",
+				"crv": "P-256",
+				"x":   base64.RawURLEncoding.EncodeToString(padTo32(xBytes)),
+				"y":   base64.RawURLEncoding.EncodeToString(padTo32(yBytes)),
+			},
+		},
+	}
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(jwksServer.Close)
+
+	issuerURL := "https://idp.example.com"
+	audience := "astonish-api"
+
+	cfg := TokenValidatorConfig{
+		Issuers: []TrustedIssuer{
+			{
+				ID:        "issuer-1",
+				Issuer:    issuerURL,
+				JWKSURL:   jwksServer.URL,
+				Audience:  audience,
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+	}
+
+	validator := NewTokenValidator(cfg)
+
+	claims := jwt.MapClaims{
+		"iss": issuerURL,
+		"aud": audience,
+		"sub": "ec-user-456",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+
+	// Sign with ES256
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = kid
+	tokenStr, err := token.SignedString(ecKey)
+	if err != nil {
+		t.Fatalf("failed to sign ES256 token: %v", err)
+	}
+
+	result, err := validator.Validate(tokenStr)
+	if err != nil {
+		t.Fatalf("expected valid ES256 token, got error: %v", err)
+	}
+
+	if result.UserIdentifier != "ec-user-456" {
+		t.Errorf("expected UserIdentifier=ec-user-456, got %q", result.UserIdentifier)
+	}
+	if result.Issuer != issuerURL {
+		t.Errorf("expected Issuer=%q, got %q", issuerURL, result.Issuer)
+	}
+	if result.IssuerID != "issuer-1" {
+		t.Errorf("expected IssuerID=issuer-1, got %q", result.IssuerID)
+	}
+	t.Logf("ES256 token validated successfully: user=%s", result.UserIdentifier)
 }
 
 

--- a/pkg/api/a2a_auth.go
+++ b/pkg/api/a2a_auth.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -58,12 +59,11 @@ func A2AAuthMiddleware(next http.Handler) http.Handler {
 
 		claims, err := validator.Validate(tokenStr)
 		if err != nil {
-			// Determine appropriate error code from the error message
+			// Determine appropriate error code
 			code := a2a.ErrCodeForbidden
-			if strings.Contains(err.Error(), "expired") {
+			if errors.Is(err, a2a.ErrTokenExpired) {
 				code = a2a.ErrCodeAuthRequired
-			} else if strings.Contains(err.Error(), "untrusted issuer") ||
-				strings.Contains(err.Error(), "no trusted issuer") {
+			} else if errors.Is(err, a2a.ErrUntrustedIssuer) || errors.Is(err, a2a.ErrInvalidAudience) || errors.Is(err, a2a.ErrActorNotAllowed) {
 				code = a2a.ErrCodeForbidden
 			}
 			writeJSONRPCError(w, nil, code, err.Error())

--- a/pkg/api/a2a_auth.go
+++ b/pkg/api/a2a_auth.go
@@ -4,15 +4,38 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/SAP/astonish/pkg/a2a"
 )
 
-// a2aAgentContextKey is the context key for the authenticated A2A agent.
-type a2aAgentContextKey struct{}
+// --- Package-level state for A2A token validator (set by daemon during startup) ---
 
-// A2AAuthMiddleware authenticates incoming A2A requests by looking up the
-// agent in the registry. Supports Bearer token and X-API-Key header auth.
+var (
+	a2aValidatorMu sync.RWMutex
+	a2aValidator   *a2a.TokenValidator
+)
+
+// SetA2ATokenValidator sets the A2A token validator for the HTTP handlers.
+func SetA2ATokenValidator(v *a2a.TokenValidator) {
+	a2aValidatorMu.Lock()
+	defer a2aValidatorMu.Unlock()
+	a2aValidator = v
+}
+
+func getA2ATokenValidator() *a2a.TokenValidator {
+	a2aValidatorMu.RLock()
+	defer a2aValidatorMu.RUnlock()
+	return a2aValidator
+}
+
+// a2aClaimsContextKey is the context key for the validated A2A token claims.
+type a2aClaimsContextKey struct{}
+
+// A2AAuthMiddleware authenticates incoming A2A requests by validating a JWT
+// Bearer token against configured trusted issuers. The token's signature is
+// verified via JWKS, and the extracted identity (user + optional actor) is
+// injected into the request context.
 func A2AAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ch := getA2AChannel()
@@ -21,45 +44,49 @@ func A2AAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		apiKey := extractA2AKey(r)
-		if apiKey == "" {
-			writeJSONRPCError(w, nil, a2a.ErrCodeAuthRequired, "Authentication required: provide Authorization: Bearer <key> or X-API-Key header")
+		validator := getA2ATokenValidator()
+		if validator == nil {
+			writeJSONRPCError(w, nil, a2a.ErrCodeInternal, "A2A authentication not configured")
 			return
 		}
 
-		agent, err := ch.AgentRegistry().GetByAPIKey(apiKey)
+		tokenStr := extractBearerToken(r)
+		if tokenStr == "" {
+			writeJSONRPCError(w, nil, a2a.ErrCodeAuthRequired, "Authentication required: provide Authorization: Bearer <jwt>")
+			return
+		}
+
+		claims, err := validator.Validate(tokenStr)
 		if err != nil {
-			writeJSONRPCError(w, nil, a2a.ErrCodeForbidden, "Invalid credentials")
+			// Determine appropriate error code from the error message
+			code := a2a.ErrCodeForbidden
+			if strings.Contains(err.Error(), "expired") {
+				code = a2a.ErrCodeAuthRequired
+			} else if strings.Contains(err.Error(), "untrusted issuer") ||
+				strings.Contains(err.Error(), "no trusted issuer") {
+				code = a2a.ErrCodeForbidden
+			}
+			writeJSONRPCError(w, nil, code, err.Error())
 			return
 		}
 
-		// Inject agent into context
-		ctx := context.WithValue(r.Context(), a2aAgentContextKey{}, agent)
+		// Inject validated claims into context
+		ctx := context.WithValue(r.Context(), a2aClaimsContextKey{}, claims)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
-// AgentFromContext extracts the authenticated RegisteredAgent from the request context.
-func AgentFromContext(ctx context.Context) *a2a.RegisteredAgent {
-	agent, _ := ctx.Value(a2aAgentContextKey{}).(*a2a.RegisteredAgent)
-	return agent
+// A2AClaimsFromContext extracts the validated A2A token claims from the request context.
+func A2AClaimsFromContext(ctx context.Context) *a2a.A2ATokenClaims {
+	claims, _ := ctx.Value(a2aClaimsContextKey{}).(*a2a.A2ATokenClaims)
+	return claims
 }
 
-// extractA2AKey extracts the API key from the request.
-// Supports: Authorization: Bearer <key> and X-API-Key: <key>
-func extractA2AKey(r *http.Request) string {
-	// Check Authorization header first
+// extractBearerToken extracts the JWT from the Authorization: Bearer header.
+func extractBearerToken(r *http.Request) string {
 	auth := r.Header.Get("Authorization")
-	if auth != "" {
-		if strings.HasPrefix(auth, "Bearer ") {
-			return strings.TrimPrefix(auth, "Bearer ")
-		}
+	if auth != "" && strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
 	}
-
-	// Check X-API-Key header
-	if key := r.Header.Get("X-API-Key"); key != "" {
-		return key
-	}
-
 	return ""
 }

--- a/pkg/api/a2a_routes.go
+++ b/pkg/api/a2a_routes.go
@@ -39,13 +39,14 @@ func RegisterA2ARoutes(router *mux.Router) {
 	// Agent Card discovery — public, no auth required
 	router.HandleFunc("/.well-known/agent-card.json", AgentCardHandler).Methods("GET")
 
-	// A2A JSON-RPC endpoint — requires A2A auth (agent must be registered)
+	// A2A JSON-RPC endpoint — requires A2A auth (JWT Bearer validation)
 	a2aRouter := router.PathPrefix("/api/a2a").Subrouter()
 	a2aRouter.Use(A2AAuthMiddleware)
 	a2aRouter.HandleFunc("", A2AHandler).Methods("POST")
 	a2aRouter.HandleFunc("/stream", A2AStreamHandler).Methods("POST")
 
-	// Admin endpoints for managing registered agents
+	// Admin endpoints for managing registered agents (legacy — will be replaced with
+	// trusted issuer/allowed agent admin in a later phase)
 	router.HandleFunc("/api/admin/a2a/agents", A2AAdminListAgentsHandler).Methods("GET")
 	router.HandleFunc("/api/admin/a2a/agents", A2AAdminRegisterAgentHandler).Methods("POST")
 	router.HandleFunc("/api/admin/a2a/agents/{id}", A2AAdminDeleteAgentHandler).Methods("DELETE")
@@ -82,8 +83,8 @@ func A2AHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agent := AgentFromContext(r.Context())
-	if agent == nil {
+	claims := A2AClaimsFromContext(r.Context())
+	if claims == nil {
 		writeJSONRPCError(w, nil, a2a.ErrCodeAuthRequired, "Authentication required")
 		return
 	}
@@ -105,6 +106,10 @@ func A2AHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONRPCError(w, req.ID, a2a.ErrCodeInvalidRequest, "Invalid JSON-RPC version")
 		return
 	}
+
+	// Bridge: construct a RegisteredAgent from claims for backward compatibility
+	// with the channel adapter (until phase 5 updates the adapter signature).
+	agent := agentFromClaims(claims)
 
 	// Dispatch by method
 	switch req.Method {
@@ -243,8 +248,8 @@ func A2AStreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agent := AgentFromContext(r.Context())
-	if agent == nil {
+	claims := A2AClaimsFromContext(r.Context())
+	if claims == nil {
 		writeJSONRPCError(w, nil, a2a.ErrCodeAuthRequired, "Authentication required")
 		return
 	}
@@ -284,6 +289,9 @@ func A2AStreamHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	// Bridge: construct a RegisteredAgent from claims
+	agent := agentFromClaims(claims)
+
 	// Process the message (same as sync but we stream events)
 	task, err := ch.HandleSendMessage(r.Context(), agent, params)
 	if err != nil {
@@ -308,6 +316,25 @@ func A2AStreamHandler(w http.ResponseWriter, r *http.Request) {
 	data, _ := json.Marshal(resp)
 	fmt.Fprintf(w, "data: %s\n\n", data)
 	flusher.Flush()
+}
+
+// agentFromClaims constructs a RegisteredAgent from validated JWT claims.
+// This is a bridge function for backward compatibility with the channel adapter
+// until the adapter is updated to accept claims directly (phase 5).
+func agentFromClaims(claims *a2a.A2ATokenClaims) *a2a.RegisteredAgent {
+	// Use actor identifier as agent ID (for task ownership scoping).
+	// If no actor (direct user token), use the user identifier.
+	agentID := claims.ActorIdentifier
+	if agentID == "" {
+		agentID = claims.UserIdentifier
+	}
+	return &a2a.RegisteredAgent{
+		ID:             agentID,
+		Name:           claims.ActorIdentifier,
+		LinkedUserID:   claims.UserIdentifier,
+		LinkedOrgSlug:  claims.OrgID,
+		LinkedTeamSlug: "",
+	}
 }
 
 // --- JSON-RPC response helpers ---

--- a/pkg/api/a2a_routes.go
+++ b/pkg/api/a2a_routes.go
@@ -322,18 +322,23 @@ func A2AStreamHandler(w http.ResponseWriter, r *http.Request) {
 // This is a bridge function for backward compatibility with the channel adapter
 // until the adapter is updated to accept claims directly (phase 5).
 func agentFromClaims(claims *a2a.A2ATokenClaims) *a2a.RegisteredAgent {
-	// Use actor identifier as agent ID (for task ownership scoping).
-	// If no actor (direct user token), use the user identifier.
-	agentID := claims.ActorIdentifier
-	if agentID == "" {
+	// Derive agent ID for task ownership scoping.
+	// For delegated tokens (actor present): use composite key so one service
+	// acting for multiple users cannot see other users' tasks via tasks/get.
+	// For direct user tokens: use the user identifier alone.
+	var agentID string
+	if claims.ActorIdentifier != "" {
+		agentID = claims.ActorIdentifier + ":" + claims.UserIdentifier
+	} else {
 		agentID = claims.UserIdentifier
 	}
 	return &a2a.RegisteredAgent{
-		ID:             agentID,
-		Name:           claims.ActorIdentifier,
-		LinkedUserID:   claims.UserIdentifier,
-		LinkedOrgSlug:  claims.OrgID,
-		LinkedTeamSlug: "",
+		ID:                       agentID,
+		Name:                     claims.ActorIdentifier,
+		LinkedUserID:             claims.UserIdentifier,
+		LinkedOrgSlug:            claims.OrgID,
+		LinkedTeamSlug:           "",
+		AllowIdentityPropagation: false, // explicit: identity comes from JWT, never from message metadata
 	}
 }
 

--- a/pkg/api/a2a_routes_test.go
+++ b/pkg/api/a2a_routes_test.go
@@ -3,7 +3,11 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,10 +16,77 @@ import (
 	"github.com/SAP/astonish/pkg/a2a"
 	"github.com/SAP/astonish/pkg/channels"
 	a2achan "github.com/SAP/astonish/pkg/channels/a2a"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 )
 
-func setupA2ATestChannel(t *testing.T) (*a2achan.A2AChannel, string) {
+// testRSAKey is a shared RSA key for test JWT signing.
+var testRSAKey *rsa.PrivateKey
+
+func init() {
+	var err error
+	testRSAKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic("failed to generate test RSA key: " + err.Error())
+	}
+}
+
+// newTestJWKSServer creates an httptest.Server serving a JWKS with the test RSA public key.
+func newTestJWKSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	nBytes := testRSAKey.PublicKey.N.Bytes()
+	eBytes := big.NewInt(int64(testRSAKey.PublicKey.E)).Bytes()
+
+	jwks := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "RSA",
+				"kid": "test-key-1",
+				"n":   base64.RawURLEncoding.EncodeToString(nBytes),
+				"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+			},
+		},
+	}
+
+	data, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("failed to marshal JWKS: %v", err)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	}))
+}
+
+// signTestJWT creates a signed JWT for testing with the given claims.
+func signTestJWT(t *testing.T, issuer, subject, audience string, expiresAt time.Time, actorSub string) string {
+	t.Helper()
+
+	claims := jwt.MapClaims{
+		"iss": issuer,
+		"sub": subject,
+		"aud": audience,
+		"exp": jwt.NewNumericDate(expiresAt),
+		"iat": jwt.NewNumericDate(time.Now()),
+	}
+	if actorSub != "" {
+		claims["act"] = map[string]any{"sub": actorSub}
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key-1"
+
+	signed, err := token.SignedString(testRSAKey)
+	if err != nil {
+		t.Fatalf("failed to sign test JWT: %v", err)
+	}
+	return signed
+}
+
+// setupA2ATestWithJWT sets up the A2A channel and token validator for tests.
+func setupA2ATestWithJWT(t *testing.T) *a2achan.A2AChannel {
 	t.Helper()
 	store := a2a.NewInMemoryTaskStore(1 * time.Hour)
 	t.Cleanup(store.Close)
@@ -27,25 +98,47 @@ func setupA2ATestChannel(t *testing.T) (*a2achan.A2AChannel, string) {
 		BaseURL:       "http://localhost:9393",
 	}, nil)
 
-	// Register a test agent
-	apiKey, err := reg.Register(a2a.RegisteredAgent{
-		Name:                     "TestAgent",
-		LinkedUserID:             "test-user",
-		AllowIdentityPropagation: true,
-	})
-	if err != nil {
-		t.Fatalf("Failed to register test agent: %v", err)
-	}
-
 	// Set the global channel
 	SetA2AChannel(ch)
 	t.Cleanup(func() { SetA2AChannel(nil) })
 
-	return ch, apiKey
+	// Set up a token validator with a test JWKS server
+	jwksServer := newTestJWKSServer(t)
+	t.Cleanup(jwksServer.Close)
+
+	validator := a2a.NewTokenValidator(a2a.TokenValidatorConfig{
+		Issuers: []a2a.TrustedIssuer{
+			{
+				ID:        "test-issuer-id",
+				Name:      "Test Issuer",
+				Issuer:    "https://idp.example.com",
+				JWKSURL:   jwksServer.URL,
+				Audience:  "astonish-a2a",
+				UserClaim: "sub",
+				OrgID:     "org-1",
+			},
+		},
+		Agents: []a2a.AllowedAgent{
+			{
+				ID:       "agent-1",
+				Name:     "Test Service Agent",
+				ActorSub: "service-account-1",
+				IssuerID: "test-issuer-id",
+				OrgID:    "org-1",
+				Enabled:  true,
+			},
+		},
+		RequireActorClaim: false,
+	})
+
+	SetA2ATokenValidator(validator)
+	t.Cleanup(func() { SetA2ATokenValidator(nil) })
+
+	return ch
 }
 
 func TestA2AAgentCardHandler(t *testing.T) {
-	_, _ = setupA2ATestChannel(t)
+	_ = setupA2ATestWithJWT(t)
 
 	req := httptest.NewRequest("GET", "/.well-known/agent-card.json", nil)
 	w := httptest.NewRecorder()
@@ -82,8 +175,8 @@ func TestA2AAgentCardHandler_NotConfigured(t *testing.T) {
 	}
 }
 
-func TestA2AHandler_MessageSend(t *testing.T) {
-	ch, apiKey := setupA2ATestChannel(t)
+func TestA2AHandler_MessageSend_ValidJWT(t *testing.T) {
+	ch := setupA2ATestWithJWT(t)
 
 	// Start the channel with a handler that responds
 	_ = ch.Start(context.Background(), func(ctx context.Context, msg channels.InboundMessage) error {
@@ -97,7 +190,7 @@ func TestA2AHandler_MessageSend(t *testing.T) {
 			Parts: []a2a.Part{a2a.TextPart{Text: "Hello"}},
 		},
 		Configuration: &a2a.TaskConfig{
-			ReturnImmediately: true, // Use async mode for simpler test
+			ReturnImmediately: true,
 		},
 	}
 	paramsJSON, _ := json.Marshal(params)
@@ -115,8 +208,11 @@ func TestA2AHandler_MessageSend(t *testing.T) {
 	sub.Use(A2AAuthMiddleware)
 	sub.HandleFunc("", A2AHandler).Methods("POST")
 
+	// Sign a valid JWT
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(time.Hour), "")
+
 	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
-	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -135,8 +231,61 @@ func TestA2AHandler_MessageSend(t *testing.T) {
 	}
 }
 
-func TestA2AHandler_InvalidAuth(t *testing.T) {
-	_, _ = setupA2ATestChannel(t)
+func TestA2AHandler_MessageSend_WithActorClaim(t *testing.T) {
+	ch := setupA2ATestWithJWT(t)
+
+	_ = ch.Start(context.Background(), func(ctx context.Context, msg channels.InboundMessage) error {
+		return nil
+	})
+
+	params := a2a.SendMessageParams{
+		Message: a2a.Message{
+			Role:  "user",
+			Parts: []a2a.Part{a2a.TextPart{Text: "Hello from service"}},
+		},
+		Configuration: &a2a.TaskConfig{
+			ReturnImmediately: true,
+		},
+	}
+	paramsJSON, _ := json.Marshal(params)
+	rpcReq := a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "message/send",
+		Params:  paramsJSON,
+	}
+	body, _ := json.Marshal(rpcReq)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	// Sign a JWT with actor claim (delegation)
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(time.Hour), "service-account-1")
+
+	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp a2a.JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+}
+
+func TestA2AHandler_ExpiredToken(t *testing.T) {
+	_ = setupA2ATestWithJWT(t)
 
 	rpcReq := a2a.JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -150,8 +299,11 @@ func TestA2AHandler_InvalidAuth(t *testing.T) {
 	sub.Use(A2AAuthMiddleware)
 	sub.HandleFunc("", A2AHandler).Methods("POST")
 
+	// Sign an expired JWT
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(-time.Hour), "")
+
 	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
-	req.Header.Set("X-API-Key", "invalid-key")
+	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -161,15 +313,123 @@ func TestA2AHandler_InvalidAuth(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 	if resp.Error == nil {
-		t.Fatal("expected error for invalid auth")
+		t.Fatal("expected error for expired token")
+	}
+	if resp.Error.Code != a2a.ErrCodeAuthRequired {
+		t.Fatalf("expected error code %d (auth required), got %d", a2a.ErrCodeAuthRequired, resp.Error.Code)
+	}
+}
+
+func TestA2AHandler_WrongAudience(t *testing.T) {
+	_ = setupA2ATestWithJWT(t)
+
+	rpcReq := a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "message/send",
+	}
+	body, _ := json.Marshal(rpcReq)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	// Sign a JWT with wrong audience
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "wrong-audience", time.Now().Add(time.Hour), "")
+
+	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var resp a2a.JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for wrong audience")
 	}
 	if resp.Error.Code != a2a.ErrCodeForbidden {
-		t.Fatalf("expected error code %d, got %d", a2a.ErrCodeForbidden, resp.Error.Code)
+		t.Fatalf("expected error code %d (forbidden), got %d", a2a.ErrCodeForbidden, resp.Error.Code)
+	}
+}
+
+func TestA2AHandler_UnknownIssuer(t *testing.T) {
+	_ = setupA2ATestWithJWT(t)
+
+	rpcReq := a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "message/send",
+	}
+	body, _ := json.Marshal(rpcReq)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	// Sign a JWT with unknown issuer
+	token := signTestJWT(t, "https://unknown-idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(time.Hour), "")
+
+	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var resp a2a.JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown issuer")
+	}
+	if resp.Error.Code != a2a.ErrCodeForbidden {
+		t.Fatalf("expected error code %d (forbidden), got %d", a2a.ErrCodeForbidden, resp.Error.Code)
+	}
+}
+
+func TestA2AHandler_UnauthorizedActor(t *testing.T) {
+	_ = setupA2ATestWithJWT(t)
+
+	rpcReq := a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "message/send",
+	}
+	body, _ := json.Marshal(rpcReq)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	// Sign a JWT with an actor that's not in the allowed agents list
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(time.Hour), "unauthorized-service")
+
+	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var resp a2a.JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unauthorized actor")
+	}
+	if resp.Error.Code != a2a.ErrCodeForbidden {
+		t.Fatalf("expected error code %d (forbidden), got %d", a2a.ErrCodeForbidden, resp.Error.Code)
 	}
 }
 
 func TestA2AHandler_NoAuth(t *testing.T) {
-	_, _ = setupA2ATestChannel(t)
+	_ = setupA2ATestWithJWT(t)
 
 	rpcReq := a2a.JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -202,7 +462,7 @@ func TestA2AHandler_NoAuth(t *testing.T) {
 }
 
 func TestA2AHandler_UnknownMethod(t *testing.T) {
-	_, apiKey := setupA2ATestChannel(t)
+	_ = setupA2ATestWithJWT(t)
 
 	rpcReq := a2a.JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -216,8 +476,11 @@ func TestA2AHandler_UnknownMethod(t *testing.T) {
 	sub.Use(A2AAuthMiddleware)
 	sub.HandleFunc("", A2AHandler).Methods("POST")
 
+	// Valid JWT
+	token := signTestJWT(t, "https://idp.example.com", "user@example.com", "astonish-a2a", time.Now().Add(time.Hour), "")
+
 	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
-	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -234,45 +497,49 @@ func TestA2AHandler_UnknownMethod(t *testing.T) {
 	}
 }
 
-func TestA2AAdminRegisterAndList(t *testing.T) {
-	_, _ = setupA2ATestChannel(t)
+func TestA2AHandler_ValidatorNotConfigured(t *testing.T) {
+	// Set up channel but no validator
+	store := a2a.NewInMemoryTaskStore(1 * time.Hour)
+	t.Cleanup(store.Close)
+	reg := a2a.NewInMemoryAgentRegistry()
 
-	// Register a new agent
-	regReq := A2AAdminRegisterRequest{
-		Name:         "NewAgent",
-		LinkedUserID: "user-456",
+	ch := a2achan.New(&a2achan.Config{
+		TaskStore:     store,
+		AgentRegistry: reg,
+		BaseURL:       "http://localhost:9393",
+	}, nil)
+
+	SetA2AChannel(ch)
+	t.Cleanup(func() { SetA2AChannel(nil) })
+	SetA2ATokenValidator(nil)
+
+	rpcReq := a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "message/send",
 	}
-	body, _ := json.Marshal(regReq)
+	body, _ := json.Marshal(rpcReq)
 
-	req := httptest.NewRequest("POST", "/api/admin/a2a/agents", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer some-token")
 	w := httptest.NewRecorder()
 
-	A2AAdminRegisterAgentHandler(w, req)
+	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	var resp a2a.JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
 	}
-
-	var regResp A2AAdminRegisterResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &regResp); err != nil {
-		t.Fatalf("failed to parse register response: %v", err)
+	if resp.Error == nil {
+		t.Fatal("expected error when validator not configured")
 	}
-	if regResp.APIKey == "" {
-		t.Fatal("expected non-empty API key")
-	}
-	if regResp.Agent == nil || regResp.Agent.Name != "NewAgent" {
-		t.Fatal("expected agent with name 'NewAgent'")
-	}
-
-	// List agents
-	req = httptest.NewRequest("GET", "/api/admin/a2a/agents", nil)
-	w = httptest.NewRecorder()
-
-	A2AAdminListAgentsHandler(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
+	if resp.Error.Code != a2a.ErrCodeInternal {
+		t.Fatalf("expected error code %d (internal), got %d", a2a.ErrCodeInternal, resp.Error.Code)
 	}
 }
 

--- a/pkg/api/a2a_routes_test.go
+++ b/pkg/api/a2a_routes_test.go
@@ -560,3 +560,128 @@ func TestA2AAuthExemptPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestA2AHandler_TaskOwnershipIsolation(t *testing.T) {
+	// This test proves that a delegated service (actor) acting for multiple users
+	// cannot see other users' tasks — the exact attack vector identified in the
+	// design assessment.
+	ch := setupA2ATestWithJWT(t)
+
+	_ = ch.Start(context.Background(), func(ctx context.Context, msg channels.InboundMessage) error {
+		return nil
+	})
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api/a2a").Subrouter()
+	sub.Use(A2AAuthMiddleware)
+	sub.HandleFunc("", A2AHandler).Methods("POST")
+
+	// Helper to send a message and extract the task ID from the response.
+	sendMessage := func(t *testing.T, userSub string) string {
+		t.Helper()
+		params := a2a.SendMessageParams{
+			Message: a2a.Message{
+				Role:  "user",
+				Parts: []a2a.Part{a2a.TextPart{Text: "Hello from " + userSub}},
+			},
+			Configuration: &a2a.TaskConfig{
+				ReturnImmediately: true,
+			},
+		}
+		paramsJSON, _ := json.Marshal(params)
+		rpcReq := a2a.JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "message/send",
+			Params:  paramsJSON,
+		}
+		body, _ := json.Marshal(rpcReq)
+
+		// Same actor (service-account-1) but different user
+		token := signTestJWT(t, "https://idp.example.com", userSub, "astonish-a2a", time.Now().Add(time.Hour), "service-account-1")
+
+		req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp a2a.JSONRPCResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %+v", resp.Error)
+		}
+
+		// Extract task ID from result
+		resultBytes, _ := json.Marshal(resp.Result)
+		var task a2a.Task
+		if err := json.Unmarshal(resultBytes, &task); err != nil {
+			t.Fatalf("failed to parse task from result: %v", err)
+		}
+		if task.ID == "" {
+			t.Fatal("expected non-empty task ID")
+		}
+		return task.ID
+	}
+
+	// Helper to call tasks/get and return whether it succeeded.
+	getTask := func(t *testing.T, userSub, taskID string) (bool, *a2a.JSONRPCResponse) {
+		t.Helper()
+		params := a2a.GetTaskParams{TaskID: taskID}
+		paramsJSON, _ := json.Marshal(params)
+		rpcReq := a2a.JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      2,
+			Method:  "tasks/get",
+			Params:  paramsJSON,
+		}
+		body, _ := json.Marshal(rpcReq)
+
+		token := signTestJWT(t, "https://idp.example.com", userSub, "astonish-a2a", time.Now().Add(time.Hour), "service-account-1")
+
+		req := httptest.NewRequest("POST", "/api/a2a", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		var resp a2a.JSONRPCResponse
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		return resp.Error == nil, &resp
+	}
+
+	// Step 1: user-A creates a task via the shared service
+	taskA := sendMessage(t, "user-a@example.com")
+
+	// Step 2: user-B creates a task via the same service
+	taskB := sendMessage(t, "user-b@example.com")
+
+	// Step 3: user-B tries to access user-A's task — must fail
+	ok, resp := getTask(t, "user-b@example.com", taskA)
+	if ok {
+		t.Fatal("SECURITY: user-B was able to access user-A's task — cross-user visibility breach")
+	}
+	if resp.Error.Code != a2a.ErrCodeTaskNotFound {
+		t.Fatalf("expected task not found error, got code %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+
+	// Step 4: user-A can still access their own task — must succeed
+	ok, _ = getTask(t, "user-a@example.com", taskA)
+	if !ok {
+		t.Fatal("user-A should be able to access their own task")
+	}
+
+	// Step 5: user-B can access their own task — must succeed
+	ok, _ = getTask(t, "user-b@example.com", taskB)
+	if !ok {
+		t.Fatal("user-B should be able to access their own task")
+	}
+}

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -235,7 +235,9 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			info.Config["rate_limit"] = channels.A2A.RateLimit
 			info.Config["max_concurrent_tasks"] = channels.A2A.MaxConcurrentTasks
 			info.Config["task_ttl"] = channels.A2A.TaskTTL
-			info.Config["allow_identity_propagation"] = channels.A2A.AllowIdentityPropagation
+			info.Config["default_audience"] = channels.A2A.DefaultAudience
+			info.Config["auto_link_by_email"] = channels.A2A.AutoLinkByEmail
+			info.Config["require_actor_claim"] = channels.A2A.RequireActorClaim
 		}
 		result = append(result, info)
 	}
@@ -354,8 +356,14 @@ func PlatformAdminSaveChannelHandler(w http.ResponseWriter, r *http.Request) {
 		if v, ok := body.Config["task_ttl"].(string); ok {
 			cfg.TaskTTL = v
 		}
-		if v, ok := body.Config["allow_identity_propagation"].(bool); ok {
-			cfg.AllowIdentityPropagation = v
+		if v, ok := body.Config["default_audience"].(string); ok {
+			cfg.DefaultAudience = v
+		}
+		if v, ok := body.Config["auto_link_by_email"].(bool); ok {
+			cfg.AutoLinkByEmail = v
+		}
+		if v, ok := body.Config["require_actor_claim"].(bool); ok {
+			cfg.RequireActorClaim = v
 		}
 		settings.Channels.A2A = cfg
 	}

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -605,6 +605,54 @@ func Run(cfg RunConfig) error {
 			mgr.Register(a2aCh)
 			api.SetA2AChannel(a2aCh)
 			logger.Printf("A2A channel registered (multi-client, HTTP-driven)")
+
+			// Wire A2A token validator from channel config.
+			var issuers []a2apkg.TrustedIssuer
+			for _, ti := range chCfg.A2A.TrustedIssuers {
+				userClaim := ti.UserClaim
+				if userClaim == "" {
+					userClaim = "sub"
+				}
+				audience := ti.Audience
+				if audience == "" {
+					audience = chCfg.A2A.DefaultAudience
+				}
+				issuers = append(issuers, a2apkg.TrustedIssuer{
+					ID:        fmt.Sprintf("issuer-%s", ti.Name),
+					Name:      ti.Name,
+					Issuer:    ti.Issuer,
+					JWKSURL:   ti.JWKSURL,
+					Audience:  audience,
+					UserClaim: userClaim,
+				})
+			}
+			var agents []a2apkg.AllowedAgent
+			for _, aa := range chCfg.A2A.AllowedAgents {
+				// Find matching issuer ID by name.
+				var issuerID string
+				for _, iss := range issuers {
+					if iss.Name == aa.Issuer {
+						issuerID = iss.ID
+						break
+					}
+				}
+				agents = append(agents, a2apkg.AllowedAgent{
+					ID:        fmt.Sprintf("agent-%s", aa.Name),
+					Name:      aa.Name,
+					ActorSub:  aa.ActorSub,
+					IssuerID:  issuerID,
+					RateLimit: aa.RateLimit,
+					MaxTasks:  aa.MaxTasks,
+					Enabled:   true,
+				})
+			}
+			validator := a2apkg.NewTokenValidator(a2apkg.TokenValidatorConfig{
+				Issuers:           issuers,
+				Agents:            agents,
+				RequireActorClaim: chCfg.A2A.RequireActorClaim,
+			})
+			api.SetA2ATokenValidator(validator)
+			logger.Printf("A2A authentication: %d trusted issuers, %d allowed agents", len(issuers), len(agents))
 		}
 
 		if err := mgr.StartAll(ctx); err != nil {

--- a/pkg/launcher/studio.go
+++ b/pkg/launcher/studio.go
@@ -196,8 +196,9 @@ func NewStudioServer(port int, opts ...StudioOption) (*StudioServer, error) {
 		// Wrap router + SPA into a single handler
 		spaHandler := spaFileServer(http.FS(webFS))
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Let mux handle /api/* routes
-			if len(r.URL.Path) >= 4 && r.URL.Path[:4] == "/api" {
+			// Let mux handle /api/* and /.well-known/* routes
+			if (len(r.URL.Path) >= 4 && r.URL.Path[:4] == "/api") ||
+				strings.HasPrefix(r.URL.Path, "/.well-known/") {
 				router.ServeHTTP(w, r)
 				return
 			}
@@ -208,7 +209,8 @@ func NewStudioServer(port int, opts ...StudioOption) (*StudioServer, error) {
 		slog.Warn("no web assets found, run 'npm run build' in the web directory first")
 		fallback := noAssetsHandler()
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if len(r.URL.Path) >= 4 && r.URL.Path[:4] == "/api" {
+			if (len(r.URL.Path) >= 4 && r.URL.Path[:4] == "/api") ||
+				strings.HasPrefix(r.URL.Path, "/.well-known/") {
 				router.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/store/settings.go
+++ b/pkg/store/settings.go
@@ -110,13 +110,15 @@ type PlatformSlackConfig struct {
 
 // PlatformA2AConfig holds non-secret A2A (Agent-to-Agent) channel settings.
 type PlatformA2AConfig struct {
-	Enabled                  bool   `json:"enabled"`
-	BaseURL                  string `json:"base_url,omitempty"`               // External base URL for Agent Card
-	Description              string `json:"description,omitempty"`            // Agent description in Agent Card
-	RateLimit                int    `json:"rate_limit,omitempty"`             // Per-agent requests/min (0 = unlimited)
-	MaxConcurrentTasks       int    `json:"max_concurrent_tasks,omitempty"`   // Per-agent concurrent tasks (0 = unlimited)
-	TaskTTL                  string `json:"task_ttl,omitempty"`               // Duration for task retention, e.g. "72h"
-	AllowIdentityPropagation bool   `json:"allow_identity_propagation"`      // Global toggle for identity propagation
+	Enabled            bool   `json:"enabled"`
+	BaseURL            string `json:"base_url,omitempty"`             // External base URL for Agent Card
+	Description        string `json:"description,omitempty"`          // Agent description in Agent Card
+	RateLimit          int    `json:"rate_limit,omitempty"`           // Per-agent requests/min (0 = unlimited)
+	MaxConcurrentTasks int    `json:"max_concurrent_tasks,omitempty"` // Per-agent concurrent tasks (0 = unlimited)
+	TaskTTL            string `json:"task_ttl,omitempty"`             // Duration for task retention, e.g. "72h"
+	DefaultAudience    string `json:"default_audience,omitempty"`     // Expected "aud" claim in incoming A2A JWTs
+	AutoLinkByEmail    bool   `json:"auto_link_by_email"`            // Auto-link users by email claim
+	RequireActorClaim  bool   `json:"require_actor_claim"`           // Require "act" claim for delegation
 }
 
 // OrgSettings represents organization-wide configuration visible to all


### PR DESCRIPTION
## Summary

Redesigns the A2A authentication layer to use cryptographically signed JWTs validated against JWKS endpoints, replacing the insecure API-key + metadata identity model that allowed any external agent to impersonate any user.

## Security Problem (fixed)

The old design trusted requesters to self-assert identity via plaintext metadata in messages. A single API key with `AllowIdentityPropagation=true` allowed any external agent to claim to be ANY platform user. This violates Astonish's core security model.

## New Design

Identity now comes from cryptographically signed JWTs (OIDC tokens):
- **Direct User Token**: User's own OIDC token (sub = user email/ID)
- **Service Account Token**: From trusted issuer with RFC 8693 `act` claim for delegation (e.g., SAP Joule acting on behalf of a user)

## Changes (Phases 1–4 of 9)

### Phase 1: JWKS Client (`pkg/a2a/jwks.go`)
- Fetches public keys from IdP JWKS endpoints
- In-memory cache with configurable TTL (default 1h)
- Forced refresh on unknown `kid` (rate-limited to 1/min)

### Phase 2: Token Validator (`pkg/a2a/token_validator.go`)
- Validates JWT signature (RS256/ES256) via JWKS
- Matches `iss` to configured trusted issuers
- Verifies `aud`, expiry, not-before
- Extracts user identity from configurable claim (`sub`/`email`/`preferred_username`)
- Validates `act.sub` against allowed agents list (for delegation)

### Phase 3: Config & Store (`pkg/a2a/stores.go`, `pkg/store/settings.go`)
- `TrustedIssuer` and `AllowedAgent` types with in-memory stores
- `PlatformA2AConfig` updated: `AllowIdentityPropagation` → `DefaultAudience`, `AutoLinkByEmail`, `RequireActorClaim`

### Phase 4: Auth Middleware Rewrite (`pkg/api/a2a_auth.go`, `a2a_routes.go`)
- New middleware extracts Bearer JWT, validates via TokenValidator, injects `A2ATokenClaims` into context
- All handlers updated to use `A2AClaimsFromContext` 
- Bridge function maintains backward compat with channel adapter (next phase)
- Tests rewritten to use real JWT signing/validation

### Bug Fix: Agent Card routing
- `/.well-known/agent-card.json` was being swallowed by the SPA catch-all
- Added `/.well-known/*` to the router dispatch in `studio.go`

## Remaining Phases (follow-up PRs)
- Phase 5: Channel adapter update (resolve identity via PlatformResolver)
- Phase 6: Remove old agent registry, add trusted issuer admin API
- Phase 7: Agent Card update (advertise JWT Bearer auth)
- Phase 8: Auto-link by email, docs update

## Testing

```bash
go test ./pkg/a2a/... -v        # JWKS + validator + stores (all pass)
go test ./pkg/api/ -run TestA2A  # 11 route/auth tests (all pass)
go build ./...                   # Full build clean
```

## Architecture Doc
See `docs/architecture/a2a-auth-redesign.md` for the full design.

Refs: #424