### PR TITLE
fix(chat): preserve substantive agent messages when followed by housekeeping tools

### DIFF
--- a/web/src/components/chat/__tests__/toolActivity.test.ts
+++ b/web/src/components/chat/__tests__/toolActivity.test.ts
@@ -11,11 +11,14 @@ import {
   hasAppFence,
   isAppProgressAgent,
   isHardBreakType,
+  isHousekeepingNote,
   isSoftNoteType,
   isStickyAgentBubble,
+  isSubstantiveMessage,
   isToolResultError,
   latestProcessText,
   liveActivityHint,
+  onlyHousekeepingToolsBetween,
   previewValue,
   stickyAgentBubbleKey,
   supersededAgentIndices,
@@ -471,5 +474,109 @@ describe('deriveLiveStreamStatus', () => {
       { type: 'agent', content: 'Hello', _streaming: true },
     ]
     expect(deriveLiveStreamStatus(messages)).toBe('Thinking…')
+  })
+})
+
+describe('supersededAgentIndices - housekeeping preservation', () => {
+  it('preserves substantive answer when followed by memory_save + trivial note', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'list VMs' },
+      {
+        type: 'agent',
+        content:
+          'Here are the available VMs:\n\n| Name | Status | IP |\n|---|---|---|\n| vm-1 | ACTIVE | 10.0.0.1 |\n| vm-2 | ACTIVE | 10.0.0.2 |\n| vm-3 | SHUTOFF | 10.0.0.3 |',
+      },
+      { type: 'tool_call', toolName: 'memory_save', toolArgs: {} },
+      { type: 'tool_result', toolName: 'memory_save', toolResult: { status: 'saved' } },
+      { type: 'agent', content: "I've saved the endpoint details to memory." },
+    ]
+    const superseded = supersededAgentIndices(messages)
+    expect(superseded.has(1)).toBe(false) // VM list is visible
+    expect(superseded.has(4)).toBe(false) // trivial note is also visible
+  })
+
+  it('normal superseding still works for intermediate thinking', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'find the VMs' },
+      { type: 'agent', content: 'Let me check...' },
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: { command: 'openstack server list' } },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: 'vm-1 ACTIVE\nvm-2 ACTIVE' },
+      {
+        type: 'agent',
+        content:
+          'Here are the results:\n\n| Name | Status |\n|---|---|\n| vm-1 | ACTIVE |\n| vm-2 | ACTIVE |',
+      },
+    ]
+    const superseded = supersededAgentIndices(messages)
+    expect(superseded.has(1)).toBe(true) // 'Let me check...' is superseded
+    expect(superseded.has(4)).toBe(false) // real answer is visible
+  })
+
+  it('multiple substantive messages - only last substantive before housekeeping survives', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'do stuff' },
+      { type: 'agent', content: 'First result with lots of content...'.repeat(20) },
+      { type: 'tool_call', toolName: 'edit_file', toolArgs: {} },
+      { type: 'tool_result', toolName: 'edit_file', toolResult: {} },
+      { type: 'agent', content: 'Updated result with even more content and details...'.repeat(20) },
+      { type: 'tool_call', toolName: 'memory_save', toolArgs: {} },
+      { type: 'tool_result', toolName: 'memory_save', toolResult: {} },
+      { type: 'agent', content: 'Done.' },
+    ]
+    const superseded = supersededAgentIndices(messages)
+    expect(superseded.has(1)).toBe(true) // first agent superseded (edit_file is not housekeeping)
+    expect(superseded.has(4)).toBe(false) // last substantive before housekeeping survives
+    expect(superseded.has(7)).toBe(false) // 'Done.' is visible
+  })
+
+  it('short final message after non-housekeeping tool still supersedes normally', () => {
+    const messages: ChatMsg[] = [
+      { type: 'user', content: 'run it' },
+      {
+        type: 'agent',
+        content: 'Here is a very long detailed response with tables and code blocks...'.repeat(10),
+      },
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: {} },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: {} },
+      { type: 'agent', content: 'Done.' },
+    ]
+    const superseded = supersededAgentIndices(messages)
+    expect(superseded.has(1)).toBe(true) // superseded (shell_command is not housekeeping)
+    expect(superseded.has(4)).toBe(false) // final message is visible
+  })
+
+  it('isHousekeepingNote helper', () => {
+    expect(isHousekeepingNote('Saved to memory.')).toBe(true)
+    expect(isHousekeepingNote('Done.')).toBe(true)
+    expect(isHousekeepingNote("I've noted that for next time.")).toBe(true)
+    expect(
+      isHousekeepingNote('Here are the VMs:\n| Name | Status |\n|---|---|\n| vm-1 | ACTIVE |'),
+    ).toBe(false) // has markdown table
+    expect(isHousekeepingNote('a'.repeat(200))).toBe(false) // too long
+  })
+
+  it('isSubstantiveMessage helper', () => {
+    expect(isSubstantiveMessage('Let me check...')).toBe(false) // short, no formatting
+    expect(isSubstantiveMessage('a'.repeat(250))).toBe(true) // long enough
+    expect(isSubstantiveMessage('Results:\n```\ncode here\n```')).toBe(true) // has code block
+    expect(isSubstantiveMessage('Items:\n- one\n- two\n- three')).toBe(true) // has list
+  })
+
+  it('onlyHousekeepingToolsBetween helper', () => {
+    const messages: ChatMsg[] = [
+      { type: 'agent', content: 'answer' },
+      { type: 'tool_call', toolName: 'memory_save', toolArgs: {} },
+      { type: 'tool_result', toolName: 'memory_save', toolResult: {} },
+      { type: 'agent', content: 'Done.' },
+    ]
+    expect(onlyHousekeepingToolsBetween(messages, 0, 3)).toBe(true)
+
+    const mixed: ChatMsg[] = [
+      { type: 'agent', content: 'answer' },
+      { type: 'tool_call', toolName: 'shell_command', toolArgs: {} },
+      { type: 'tool_result', toolName: 'shell_command', toolResult: {} },
+      { type: 'agent', content: 'Done.' },
+    ]
+    expect(onlyHousekeepingToolsBetween(mixed, 0, 3)).toBe(false)
   })
 })

--- a/web/src/components/chat/toolActivity.ts
+++ b/web/src/components/chat/toolActivity.ts
@@ -326,9 +326,67 @@ export function softRunBounds(messages: ChatMsg[], index: number): [number, numb
   return [runStart, runEnd]
 }
 
+/** Tools that are purely bookkeeping and don't change the answer. */
+export const HOUSEKEEPING_TOOLS = new Set([
+  'memory_save',
+  'memory_delete',
+  'memory_search',
+  'memory_get',
+  'announce_plan',
+  'update_plan',
+])
+
+/**
+ * Returns true when content is short (< 120 chars trimmed) and doesn't contain
+ * markdown formatting (no code blocks, no tables, no lists with 3+ items).
+ */
+export function isHousekeepingNote(content: string): boolean {
+  const trimmed = content.trim()
+  if (trimmed.length >= 120) return false
+  if (trimmed.includes('```')) return false
+  if (trimmed.includes('|---')) return false
+  // Count list items (lines starting with - or *)
+  const listItems = trimmed.split('\n').filter(line => /^\s*[-*]\s/.test(line))
+  if (listItems.length >= 3) return false
+  return true
+}
+
+/**
+ * Returns true when content length > 200 chars OR contains markdown indicators
+ * (```, |---|, or 3+ lines starting with - or *).
+ */
+export function isSubstantiveMessage(content: string): boolean {
+  const trimmed = content.trim()
+  if (trimmed.length > 200) return true
+  if (trimmed.includes('```')) return true
+  if (trimmed.includes('|---')) return true
+  const listItems = trimmed.split('\n').filter(line => /^\s*[-*]\s/.test(line))
+  if (listItems.length >= 3) return true
+  return false
+}
+
+/**
+ * Returns true if all tool_call messages between fromIndex and toIndex (exclusive)
+ * have toolName in HOUSEKEEPING_TOOLS.
+ */
+export function onlyHousekeepingToolsBetween(messages: ChatMsg[], fromIndex: number, toIndex: number): boolean {
+  for (let i = fromIndex + 1; i < toIndex; i++) {
+    const msg = messages[i]
+    if (msg.type === 'tool_call') {
+      const name = String((msg as ToolCallMessage).toolName || '')
+      if (!HOUSEKEEPING_TOOLS.has(name)) return false
+    }
+  }
+  return true
+}
+
 /**
  * Within each soft+tool run, only the latest agent message is shown as a bubble.
  * Earlier agents are "replaced" (not rendered) so mid-turn tools never remove the bubble.
+ *
+ * Exception: if the latest agent is just a housekeeping note (e.g. "Saved to memory")
+ * and an earlier agent in the same run is substantive, and only housekeeping tools
+ * appear between them, the earlier substantive agent is also kept visible.
  */
 export function supersededAgentIndices(messages: ChatMsg[]): Set<number> {
   const skip = new Set<number>()
@@ -348,8 +406,30 @@ export function supersededAgentIndices(messages: ChatMsg[]): Set<number> {
       if (messages[j].type === 'agent') lastAgent = j
     }
     if (lastAgent < 0) continue
+
+    // Determine if we should also keep a substantive earlier agent visible
+    let preservedAgent = -1
+    const lastContent = typeof (messages[lastAgent] as any).content === 'string'
+      ? (messages[lastAgent] as any).content
+      : String((messages[lastAgent] as any).content ?? '')
+
+    if (isHousekeepingNote(lastContent)) {
+      // Find the LAST substantive agent before lastAgent that has only housekeeping tools between it and lastAgent
+      for (let j = lastAgent - 1; j >= runStart; j--) {
+        if (messages[j].type === 'agent') {
+          const content = typeof (messages[j] as any).content === 'string'
+            ? (messages[j] as any).content
+            : String((messages[j] as any).content ?? '')
+          if (isSubstantiveMessage(content) && onlyHousekeepingToolsBetween(messages, j, lastAgent)) {
+            preservedAgent = j
+            break
+          }
+        }
+      }
+    }
+
     for (let j = runStart; j <= runEnd; j++) {
-      if (messages[j].type === 'agent' && j !== lastAgent) {
+      if (messages[j].type === 'agent' && j !== lastAgent && j !== preservedAgent) {
         skip.add(j)
       }
     }


### PR DESCRIPTION
## Problem

When the agent answers a user's question (e.g. listing VMs from OpenStack) and then calls a housekeeping tool like `memory_save` followed by a short confirmation message ("Saved to memory"), the **substantive answer disappears** from the chat UI.

### Root Cause

`supersededAgentIndices()` in `toolActivity.ts` unconditionally marks every agent message except the **last** one in a "soft+tool run" as hidden (superseded). This is correct for intermediate thinking messages, but wrong when the last agent message is a trivial housekeeping note and an earlier one contains the actual answer.

### Example Flow
1. User asks: "List the VMs available in OpenStack"
2. Agent responds with a table of VMs ← **this is the answer**
3. Agent calls `memory_save` to remember the endpoint
4. Agent says "I've saved the endpoint details to memory" ← trivial note
5. **Bug**: The VM table (step 2) disappears because step 4 supersedes it

## Fix

Modified `supersededAgentIndices` to detect when the last agent message is a trivial housekeeping note and preserve the earlier substantive answer. Both messages are now shown.

### New helpers:
- `HOUSEKEEPING_TOOLS` — set of tool names that are purely bookkeeping (`memory_save`, `memory_delete`, `memory_search`, `memory_get`, `announce_plan`, `update_plan`)
- `isHousekeepingNote(content)` — true for short messages (< 120 chars) without markdown formatting
- `isSubstantiveMessage(content)` — true for messages > 200 chars or containing code blocks/tables/lists
- `onlyHousekeepingToolsBetween(messages, from, to)` — checks only housekeeping tools appear between two indices

### Logic:
- If the last agent in a run is substantive → current behavior (supersede all earlier agents)
- If the last agent is a housekeeping note AND there's an earlier substantive agent with only housekeeping tools between them → **keep both visible**

## Tests

7 new test cases covering:
- Substantive answer preserved when followed by memory_save + trivial note
- Normal superseding still works for intermediate thinking
- Multiple substantive messages — only last substantive before housekeeping survives
- Short final message after non-housekeeping tool still supersedes normally
- Direct tests for helper functions

## Verification
- ✅ `npm run build` — TypeScript + Vite production build passes
- ✅ `npm test` — 510 tests pass
- ✅ `npm run lint` — 0 errors