### PR TITLE
feat(plan-mode): improve plan readability, completeness, and rendering

### DIFF
--- a/pkg/agent/plan_document.go
+++ b/pkg/agent/plan_document.go
@@ -73,6 +73,7 @@ func RenderPlanFromInfoWithDoc(goal string, doc PlanDocumentInfo, steps []PlanSt
 			name:          s.Name,
 			description:   s.Description,
 			details:       s.Details,
+			summary:       s.Summary,
 			files:         s.Files,
 			verify:        s.Verify,
 			parallelGroup: s.ParallelGroup,
@@ -131,6 +132,10 @@ func renderPlanMarkdownWithDoc(goal string, doc PlanDocumentInfo, steps []planSt
 				line += " — " + s.description
 			}
 			sb.WriteString(line + "\n")
+			// Emit optional summary for the human reviewing the plan.
+			if strings.TrimSpace(s.summary) != "" {
+				sb.WriteString("  Summary: " + strings.TrimSpace(s.summary) + "\n")
+			}
 			// Emit affected files as an indented, machine-parseable sub-block so the
 			// concrete blast radius (dependency-first, no orphaned code) is recorded
 			// and can be re-hydrated after compaction.
@@ -207,6 +212,7 @@ func planStepsToInfo(steps []planStep) []PlanStepInfo {
 			Name:          s.name,
 			Description:   s.description,
 			Details:       s.details,
+			Summary:       s.summary,
 			Files:         s.files,
 			Verify:        s.verify,
 			ParallelGroup: s.parallelGroup,
@@ -334,7 +340,19 @@ func parsePlanMarkdownFull(md string) (doc PlanDocumentInfo, goal string, steps 
 				steps[len(steps)-1].verify = strings.TrimSpace(strings.TrimPrefix(trimmed, "Verify:"))
 				continue
 			}
-			detailLines = append(detailLines, trimmed)
+			// Summary line: "Summary: <text>".
+			if strings.HasPrefix(trimmed, "Summary:") {
+				steps[len(steps)-1].summary = strings.TrimSpace(strings.TrimPrefix(trimmed, "Summary:"))
+				continue
+			}
+			detailLines = append(detailLines, strings.TrimPrefix(raw, "  "))
+			continue
+		}
+
+		// Blank line inside a detail block (e.g. between paragraphs or inside
+		// a fenced code block): preserve it so markdown rendering works correctly.
+		if trimmed == "" && len(detailLines) > 0 && currentSection == secPhases {
+			detailLines = append(detailLines, "")
 			continue
 		}
 

--- a/pkg/agent/plan_document_test.go
+++ b/pkg/agent/plan_document_test.go
@@ -348,6 +348,244 @@ func TestParsePlanMarkdown_ParallelGroupsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParsePlanMarkdown_Summary(t *testing.T) {
+	md := `# Execution Plan
+
+**Goal:** Test Summary Field
+
+_Last updated: 2025-01-01T00:00:00Z_
+
+## Phases
+
+- [ ] **step-one** — Implement the core logic
+  Summary: Adds the new data model so the frontend can display results
+  - File (modify): pkg/api/handler.go
+  Verify: go test ./pkg/api/...
+  Concrete implementation details here
+- [ ] **step-two** — Write unit tests
+  Summary: Ensures the new handler doesn't break existing behavior
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	doc, goal, steps, err := ParsePlanDocument(md)
+	if err != nil {
+		t.Fatalf("ParsePlanDocument error: %v", err)
+	}
+	_ = doc
+	if goal != "Test Summary Field" {
+		t.Errorf("goal = %q, want %q", goal, "Test Summary Field")
+	}
+	if len(steps) != 2 {
+		t.Fatalf("parsed %d steps, want 2", len(steps))
+	}
+	if steps[0].Summary != "Adds the new data model so the frontend can display results" {
+		t.Errorf("step 0 Summary = %q, want %q", steps[0].Summary, "Adds the new data model so the frontend can display results")
+	}
+	if steps[1].Summary != "Ensures the new handler doesn't break existing behavior" {
+		t.Errorf("step 1 Summary = %q, want %q", steps[1].Summary, "Ensures the new handler doesn't break existing behavior")
+	}
+	// Also verify that other fields parsed correctly alongside summary.
+	if len(steps[0].Files) != 1 || steps[0].Files[0].Path != "pkg/api/handler.go" {
+		t.Errorf("step 0 files = %+v, want 1 file", steps[0].Files)
+	}
+	if steps[0].Verify != "go test ./pkg/api/..." {
+		t.Errorf("step 0 Verify = %q", steps[0].Verify)
+	}
+	if steps[0].Details != "Concrete implementation details here" {
+		t.Errorf("step 0 Details = %q", steps[0].Details)
+	}
+}
+
+func TestRenderPlanFromInfoWithDoc_Summary(t *testing.T) {
+	orig := planClock
+	planClock = func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) }
+	defer func() { planClock = orig }()
+
+	steps := []PlanStepInfo{
+		{
+			Name:        "step-one",
+			Description: "Implement the core logic",
+			Summary:     "Adds the new data model so the frontend can display results",
+			Files:       []PlanFileChange{{Path: "pkg/api/handler.go", Kind: "modify"}},
+			Verify:      "go test ./pkg/api/...",
+		},
+		{
+			Name:        "step-two",
+			Description: "Write unit tests",
+			Summary:     "Ensures the new handler doesn't break existing behavior",
+		},
+		{
+			Name:        "step-three",
+			Description: "No summary here",
+		},
+	}
+	doc := PlanDocumentInfo{}
+	md := RenderPlanFromInfoWithDoc("Test Summary Render", doc, steps)
+
+	wants := []string{
+		"  Summary: Adds the new data model so the frontend can display results",
+		"  Summary: Ensures the new handler doesn't break existing behavior",
+	}
+	for _, w := range wants {
+		if !strings.Contains(md, w) {
+			t.Errorf("rendered plan missing %q\n---\n%s", w, md)
+		}
+	}
+	// Step three has no summary, so "step-three" should NOT be followed by a Summary line.
+	stepThreeIdx := strings.Index(md, "**step-three**")
+	if stepThreeIdx < 0 {
+		t.Fatal("step-three not found in rendered markdown")
+	}
+	afterStepThree := md[stepThreeIdx:]
+	// Find the next newline after the step-three header line.
+	nlIdx := strings.Index(afterStepThree, "\n")
+	if nlIdx >= 0 {
+		nextLine := ""
+		rest := afterStepThree[nlIdx+1:]
+		if nlIdx2 := strings.Index(rest, "\n"); nlIdx2 >= 0 {
+			nextLine = rest[:nlIdx2]
+		} else {
+			nextLine = rest
+		}
+		if strings.Contains(nextLine, "Summary:") {
+			t.Errorf("step-three should not have a Summary line, but got: %q", nextLine)
+		}
+	}
+}
+
+func TestPlanDocument_RoundTrip_Summary(t *testing.T) {
+	orig := planClock
+	planClock = func() time.Time { return time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC) }
+	defer func() { planClock = orig }()
+
+	steps := []PlanStepInfo{
+		{
+			Name:        "alpha",
+			Description: "First phase",
+			Summary:     "Lays the groundwork for the feature",
+			Files:       []PlanFileChange{{Path: "pkg/core/model.go", Kind: "new"}},
+			Verify:      "go build ./pkg/core/...",
+			Details:     "Create the model struct",
+		},
+		{
+			Name:        "beta",
+			Description: "Second phase",
+			Summary:     "Wires up the API endpoints",
+		},
+		{
+			Name:        "gamma",
+			Description: "Third phase with no summary",
+		},
+	}
+	doc := PlanDocumentInfo{
+		Context:      "Adding a new feature.",
+		WhatNotToDo:  "Don't change the database schema.",
+		Verification: "go test ./...",
+	}
+
+	// Render
+	md := RenderPlanFromInfoWithDoc("Round Trip Goal", doc, steps)
+
+	// Parse back
+	parsedDoc, goal, parsedSteps, err := ParsePlanDocument(md)
+	if err != nil {
+		t.Fatalf("ParsePlanDocument error: %v", err)
+	}
+	if goal != "Round Trip Goal" {
+		t.Errorf("goal = %q, want %q", goal, "Round Trip Goal")
+	}
+	if parsedDoc.Context != doc.Context {
+		t.Errorf("Context = %q, want %q", parsedDoc.Context, doc.Context)
+	}
+	if len(parsedSteps) != 3 {
+		t.Fatalf("parsed %d steps, want 3", len(parsedSteps))
+	}
+
+	// Verify summaries round-trip.
+	if parsedSteps[0].Summary != "Lays the groundwork for the feature" {
+		t.Errorf("step 0 Summary = %q, want %q", parsedSteps[0].Summary, "Lays the groundwork for the feature")
+	}
+	if parsedSteps[1].Summary != "Wires up the API endpoints" {
+		t.Errorf("step 1 Summary = %q, want %q", parsedSteps[1].Summary, "Wires up the API endpoints")
+	}
+	if parsedSteps[2].Summary != "" {
+		t.Errorf("step 2 Summary = %q, want empty", parsedSteps[2].Summary)
+	}
+
+	// Also verify other fields still round-trip alongside summary.
+	if parsedSteps[0].Verify != "go build ./pkg/core/..." {
+		t.Errorf("step 0 Verify = %q", parsedSteps[0].Verify)
+	}
+	if len(parsedSteps[0].Files) != 1 || parsedSteps[0].Files[0].Path != "pkg/core/model.go" {
+		t.Errorf("step 0 Files = %+v", parsedSteps[0].Files)
+	}
+	if parsedSteps[0].Details != "Create the model struct" {
+		t.Errorf("step 0 Details = %q", parsedSteps[0].Details)
+	}
+}
+
+func TestParsePlanMarkdown_BackwardCompat(t *testing.T) {
+	// A PLAN.md without any Summary lines — should parse fine with empty Summary fields.
+	md := `# Execution Plan
+
+**Goal:** Legacy Plan
+
+_Last updated: 2024-06-01T10:00:00Z_
+
+## Phases
+
+- [x] **setup** — Initialize the project
+  - File (new): go.mod
+  Verify: go build ./...
+  Create go module
+- [~] **implement** — Write the code
+  - File (modify): main.go
+- [ ] **test** — Add tests
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	_, goal, steps, err := ParsePlanDocument(md)
+	if err != nil {
+		t.Fatalf("ParsePlanDocument error: %v", err)
+	}
+	if goal != "Legacy Plan" {
+		t.Errorf("goal = %q, want %q", goal, "Legacy Plan")
+	}
+	if len(steps) != 3 {
+		t.Fatalf("parsed %d steps, want 3", len(steps))
+	}
+
+	// All Summary fields should be empty.
+	for i, s := range steps {
+		if s.Summary != "" {
+			t.Errorf("step %d (%q) Summary = %q, want empty", i, s.Name, s.Summary)
+		}
+	}
+
+	// Verify other fields still parse correctly (backward compat).
+	if steps[0].Status != "complete" {
+		t.Errorf("step 0 status = %q, want complete", steps[0].Status)
+	}
+	if steps[1].Status != "running" {
+		t.Errorf("step 1 status = %q, want running", steps[1].Status)
+	}
+	if steps[2].Status != "pending" {
+		t.Errorf("step 2 status = %q, want pending", steps[2].Status)
+	}
+	if len(steps[0].Files) != 1 || steps[0].Files[0].Kind != "new" {
+		t.Errorf("step 0 files = %+v", steps[0].Files)
+	}
+	if steps[0].Verify != "go build ./..." {
+		t.Errorf("step 0 Verify = %q", steps[0].Verify)
+	}
+	if steps[0].Details != "Create go module" {
+		t.Errorf("step 0 Details = %q", steps[0].Details)
+	}
+	if steps[0].Name != "setup" || steps[1].Name != "implement" || steps[2].Name != "test" {
+		t.Errorf("names = %q, %q, %q", steps[0].Name, steps[1].Name, steps[2].Name)
+	}
+}
+
 func TestParsePlanDocument_ExportsStatusAndFiles(t *testing.T) {
 	md := `# Execution Plan
 

--- a/pkg/agent/plan_state.go
+++ b/pkg/agent/plan_state.go
@@ -43,6 +43,7 @@ type planStep struct {
 	name          string
 	description   string
 	details       string           // optional richer per-phase content persisted to PLAN.md
+	summary       string           // optional plain-English explanation for the human approving the plan
 	files         []PlanFileChange // optional affected files (path + new/modify/delete) persisted to PLAN.md
 	verify        string           // optional command that proves the phase is done, persisted to PLAN.md
 	parallelGroup string           // optional concurrency group label
@@ -63,6 +64,7 @@ func NewPlanState(goal string, doc PlanDocumentInfo, steps []PlanStepInfo) *Plan
 			name:          s.Name,
 			description:   s.Description,
 			details:       s.Details,
+			summary:       s.Summary,
 			files:         s.Files,
 			verify:        s.Verify,
 			parallelGroup: s.ParallelGroup,
@@ -107,6 +109,7 @@ func (ps *PlanState) SnapshotInfo() (string, []PlanStepInfo) {
 			Name:          s.name,
 			Description:   s.description,
 			Details:       s.details,
+			Summary:       s.summary,
 			Files:         s.files,
 			Verify:        s.verify,
 			ParallelGroup: s.parallelGroup,

--- a/pkg/agent/sub_agent.go
+++ b/pkg/agent/sub_agent.go
@@ -98,6 +98,8 @@ type PlanStepInfo struct {
 	// approach). It is persisted to PLAN.md so the detailed plan survives
 	// context compaction, not just the one-line description.
 	Details string `json:"details,omitempty"`
+	// Summary is an optional plain-English explanation of what this phase accomplishes from the user's perspective. Unlike 'details' (which contains implementation instructions for the executor), 'summary' is written for the human approving the plan.
+	Summary string `json:"summary,omitempty"`
 	// Files is the optional list of files this phase will create, modify, or
 	// delete. Making the blast radius explicit (dependency-first, no orphaned
 	// code) is what turns a sketch into a complete, approvable plan. Persisted

--- a/pkg/agent/system_prompt_contracts_code_test.go
+++ b/pkg/agent/system_prompt_contracts_code_test.go
@@ -297,3 +297,45 @@ func TestCodeSystemPromptContracts_NoCodeSectionsInChatMode(t *testing.T) {
 		assertNotContains(t, prompt, forbidden, fmt.Sprintf("code-only section %q must not appear in chat-mode prompt", forbidden))
 	}
 }
+
+// ─── Plan Mode Completeness Self-Check Contract Tests ────────────────────────
+
+func TestGraphPlanModeSystemContext_CompletenessCheck(t *testing.T) {
+	ctx := GraphPlanModeSystemContext
+
+	if !strings.Contains(ctx, "COMPLETENESS SELF-CHECK") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'COMPLETENESS SELF-CHECK'")
+	}
+	if !strings.Contains(ctx, "frontend") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'frontend' (frontend/backend coverage check)")
+	}
+	if !strings.Contains(ctx, "terminal TUI") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'terminal TUI' (TUI parity check)")
+	}
+	if !strings.Contains(ctx, "docs/architecture") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'docs/architecture' (documentation check)")
+	}
+	if !strings.Contains(ctx, "tests") && !strings.Contains(ctx, "*_test.go") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'tests' or '*_test.go' (test coverage check)")
+	}
+	if !strings.Contains(ctx, "breaking changes") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'breaking changes' (user-facing changes check)")
+	}
+	if !strings.Contains(ctx, "summary") {
+		t.Errorf("GraphPlanModeSystemContext must contain 'summary' (PHASE 4 summary field)")
+	}
+}
+
+func TestPlanModeSystemContext_CompletenessCheck(t *testing.T) {
+	ctx := PlanModeSystemContext
+
+	if !strings.Contains(ctx, "COMPLETENESS SELF-CHECK") {
+		t.Errorf("PlanModeSystemContext must contain 'COMPLETENESS SELF-CHECK'")
+	}
+	if !strings.Contains(ctx, "frontend") {
+		t.Errorf("PlanModeSystemContext must contain 'frontend' (frontend/backend coverage check)")
+	}
+	if !strings.Contains(ctx, "terminal TUI") {
+		t.Errorf("PlanModeSystemContext must contain 'terminal TUI' (TUI parity check)")
+	}
+}

--- a/pkg/agent/tool_categories.go
+++ b/pkg/agent/tool_categories.go
@@ -34,6 +34,17 @@ When your plan is finalized, record it with announce_plan (goal + ordered, depen
 - 'details': write a concrete, self-contained description of exactly what to do in this phase — specific structs/functions to add or remove, the exact logic change, new fields, interface updates. Write enough detail that execution can proceed directly from this text without re-reading the code. This is the most important field; a vague 'details' makes the plan useless.
 - 'verify': the command that proves the phase is done (build/test/lint).
 
+Before calling announce_plan, run this COMPLETENESS SELF-CHECK:
+- [ ] If you are changing backend code: did you check whether the frontend (web/src/) consumes the affected API/event/type? If yes, add a phase for the frontend change.
+- [ ] If you are changing the Studio Chat (web/src/components/StudioChat.tsx or SSE events): did you check whether the terminal TUI (pkg/tui/) has equivalent rendering that needs updating?
+- [ ] If you are changing a type/interface: did codegraph show ALL callers? Add phases for every caller that needs updating.
+- [ ] Did you check docs/architecture/ for documentation that describes the subsystem you're changing? If it exists, add a phase to update it.
+- [ ] Did you check for existing tests (*_test.go, *.test.ts) covering the code you're changing? Add a phase for test updates or new tests.
+- [ ] If you are adding a new tool or SSE event: does it need documentation in AGENTS.md or docs/architecture/?
+- [ ] Are there any breaking changes or user-visible behavior differences? Surface them in the plan's context or as explicit decisions.
+
+If any check reveals a gap, add the missing phase BEFORE calling announce_plan. Do NOT announce an incomplete plan.
+
 Call announce_plan WITHOUT any preceding prose or summary — the plan document is shown directly to the user and speaks for itself. Do NOT write a "Here's my plan..." narration before the tool call. This persists the full plan to a session PLAN.md that survives context compaction and is shown to the user. Do NOT hand-write PLAN.md yourself. (You will drive phase status with update_plan once execution begins. When executing, treat PLAN.md as the authoritative source — do NOT re-investigate files or symbols already confirmed in the plan unless the code has changed since planning.)`
 
 // PlanModeBlockedMessage is returned to the model when it calls a mutating tool
@@ -62,7 +73,18 @@ PHASE 2 — READ. ` + "`read_file`" + ` (and read_pdf/filter_json) unlock, plus 
 
 PHASE 3 — GAP (complementary). The remaining read-only tools unlock: grep_search, find_files, file_tree, repo_map, code_definition, code_references, web_fetch, memory_search, memory_get, skill_lookup — and delegate_tasks. Use these ONLY for the genuine gaps codegraph could not fill. Prefer ` + "`delegate_tasks`" + ` with read-only ` + "`tools`" + ` filters (e.g. ["grep_search","read_file","code_references"]) to fan out independent gap questions in parallel. Do not re-answer anything already established. When gaps are closed, call ` + "`gplan_finalize`" + ` to advance to the PLAN phase.
 
-PHASE 4 — PLAN. ` + "`announce_plan`" + ` unlocks. Call it WITHOUT any preceding prose — the plan document is shown directly to the user. Record the finalized plan: goal + ordered, dependency-first phases. For each phase list its affected files (each marked new/modify/delete — the symbol AND its callers, tests, generated code, migrations, docs, so nothing is left unwired); write a concrete, self-contained 'details' field describing exactly what to do (specific functions/structs to add or change, the exact logic, new fields, interface updates — enough detail that execution can proceed directly from it without re-reading the code); and give a verify step (the build/test/lint command that proves the phase is done). File paths must be confirmed: only record a file path in 'details' or 'files' if codegraph_explore, code_definition, find_files, or read_file explicitly returned that exact path this session — do NOT infer paths from symbol names or directory conventions; if a path was not confirmed, call find_files before adding it to the plan. This persists the full plan to a session PLAN.md shown to the user; do NOT hand-write PLAN.md. End by asking the user to exit to Normal mode (shift+tab) before any execution. When executing later, treat PLAN.md as authoritative — do NOT re-investigate files or symbols already confirmed in the plan.
+PHASE 4 — PLAN. ` + "`announce_plan`" + ` unlocks. Call it WITHOUT any preceding prose — the plan document is shown directly to the user. Record the finalized plan: goal + ordered, dependency-first phases. For each phase list its affected files (each marked new/modify/delete — the symbol AND its callers, tests, generated code, migrations, docs, so nothing is left unwired); write a concrete, self-contained 'details' field describing exactly what to do (specific functions/structs to add or change, the exact logic, new fields, interface updates — enough detail that execution can proceed directly from it without re-reading the code); and give a verify step (the build/test/lint command that proves the phase is done); and write a 'summary' for each phase — a 1-2 sentence plain-English explanation of what the phase accomplishes from the user's perspective (e.g. 'Updates the TUI to show both the main answer and the memory-save note instead of hiding the answer'). File paths must be confirmed: only record a file path in 'details' or 'files' if codegraph_explore, code_definition, find_files, or read_file explicitly returned that exact path this session — do NOT infer paths from symbol names or directory conventions; if a path was not confirmed, call find_files before adding it to the plan. This persists the full plan to a session PLAN.md shown to the user; do NOT hand-write PLAN.md. End by asking the user to exit to Normal mode (shift+tab) before any execution. When executing later, treat PLAN.md as authoritative — do NOT re-investigate files or symbols already confirmed in the plan.
+
+Before calling announce_plan, run this COMPLETENESS SELF-CHECK:
+- [ ] If you are changing backend code: did you check whether the frontend (web/src/) consumes the affected API/event/type? If yes, add a phase for the frontend change.
+- [ ] If you are changing the Studio Chat (web/src/components/StudioChat.tsx or SSE events): did you check whether the terminal TUI (pkg/tui/) has equivalent rendering that needs updating?
+- [ ] If you are changing a type/interface: did codegraph show ALL callers? Add phases for every caller that needs updating.
+- [ ] Did you check docs/architecture/ for documentation that describes the subsystem you're changing? If it exists, add a phase to update it.
+- [ ] Did you check for existing tests (*_test.go, *.test.ts) covering the code you're changing? Add a phase for test updates or new tests.
+- [ ] If you are adding a new tool or SSE event: does it need documentation in AGENTS.md or docs/architecture/?
+- [ ] Are there any breaking changes or user-visible behavior differences? Surface them in the plan's context or as explicit decisions.
+
+If any check reveals a gap, add the missing phase BEFORE calling announce_plan. Do NOT announce an incomplete plan.
 
 Produce a COMPLETE plan — cover every dependency the change reaches, order phases dependency-first, and surface any human decisions (breaking changes, alternatives with trade-offs, ambiguous requirements) explicitly. Spend effort proportional to blast radius.`
 

--- a/pkg/tools/plan_tool.go
+++ b/pkg/tools/plan_tool.go
@@ -53,6 +53,7 @@ type PlanStepInput struct {
 	Name          string                `json:"name" jsonschema:"Short identifier for this step (e.g., 'explore-repos', 'analyze-implementations', 'write-report'). Use this exact value as the 'step' argument to update_plan."`
 	Description   string                `json:"description" jsonschema:"Human-readable label for this phase (e.g., 'Explore both repository structures and dependencies')."`
 	Details       string                `json:"details,omitempty" jsonschema:"Optional richer, concrete plan for this phase: the specific approach and reasoning. Persisted to the session PLAN.md so the detailed plan survives context compaction. Use this to record the actual step-by-step work, not just the label."`
+	Summary       string                `json:"summary,omitempty" jsonschema:"Optional 1-2 sentence plain-English explanation of what this phase accomplishes from the user's perspective. Write this for the human approving the plan, not for the executor. Example: 'Adds a meta flag to SSE text events so housekeeping messages don't hide the main answer.'"`
 	Files         []PlanFileChangeInput `json:"files,omitempty" jsonschema:"The files this phase will create, modify, or delete — the concrete blast radius. List every affected file (the symbol AND its callers, tests, generated code, migrations, docs) so the plan is complete and has no orphaned code. Order phases dependency-first. Persisted to PLAN.md and shown in the plan UI."`
 	Verify        string                `json:"verify,omitempty" jsonschema:"The command that proves this phase is done (build, test, or lint), e.g. 'go test ./pkg/agent/...'. Encodes the 'every phase ends verified' discipline. Persisted to PLAN.md."`
 	ParallelGroup string                `json:"parallel_group,omitempty" jsonschema:"Optional concurrency group label. Steps sharing the same non-empty label may execute concurrently. Steps touching different file subtrees with no shared interfaces can share a group. Steps that produce types or files consumed by other steps must remain serial (leave this empty or use distinct labels)."`
@@ -86,6 +87,7 @@ func announcePlan(_ tool.Context, args AnnouncePlanArgs) (AnnouncePlanResult, er
 			Name:          s.Name,
 			Description:   s.Description,
 			Details:       s.Details,
+			Summary:       s.Summary,
 			Files:         files,
 			Verify:        s.Verify,
 			ParallelGroup: s.ParallelGroup,
@@ -132,8 +134,12 @@ Document-level sections (set once for the whole plan):
 Make each phase complete, not a sketch:
 - 'files': list every file the phase touches, each marked 'new'/'modify'/'delete'. Include the symbol AND its callers, tests, generated code, migrations, and docs so nothing is left orphaned or unwired.
 - 'details': the concrete approach and reasoning for the phase.
+- 'summary': a 1-2 sentence plain-English explanation of what this phase accomplishes from the user's perspective. Written for the human approving the plan, not the executor. Example: 'Adds a meta flag to SSE text events so the frontend knows not to hide the main answer behind a housekeeping note.'
 - 'verify': the command that proves the phase is done (build/test/lint).
 - 'parallel_group': Structure the plan in waves. Before submitting, group phases by which ones can start simultaneously — a phase can start when it has no dependency on an unfinished phase's output (types, files, compiled symbols). Assign all phases in the same wave the same label (e.g. 'wave-1', 'wave-2'). Serial phases — where one phase produces something another phase needs — get no label or a distinct label. Most plans have at least two waves; a plan where every phase is unlabeled should only happen when every phase strictly depends on the previous one. Independence is about type/file dependencies, not package boundaries: two phases in the same package can be in the same wave if they touch disjoint files and neither produces a symbol the other consumes.
+
+Completeness discipline:
+Before calling announce_plan, verify you have covered: (1) both frontend and backend if the change crosses the boundary, (2) terminal TUI if you changed Studio Chat rendering, (3) docs/architecture/ if the subsystem has documentation, (4) tests for every file you modify, (5) any breaking changes surfaced explicitly.
 
 Tracking progress:
 - For work you do yourself on the main thread (edit_file, shell_command, etc.), call update_plan to mark each phase 'running' when you start it and 'complete' (or 'failed') when you finish. This keeps the checklist and PLAN.md accurate as you go, and lets you recover exactly where you were after a context summary.

--- a/pkg/tui/plan.go
+++ b/pkg/tui/plan.go
@@ -32,9 +32,20 @@ func (m model) renderPlanCard(goal string, doc agent.PlanDocumentInfo, steps []a
 	}
 
 	nFiles := 0
+	nNew, nModify, nDelete := 0, 0, 0
 	complete, running, pending := 0, 0, 0
 	for _, s := range steps {
 		nFiles += len(s.Files)
+		for _, f := range s.Files {
+			switch strings.ToLower(strings.TrimSpace(f.Kind)) {
+			case "new", "add", "create":
+				nNew++
+			case "delete", "remove", "rm":
+				nDelete++
+			default:
+				nModify++
+			}
+		}
 		switch s.Status {
 		case "complete":
 			complete++
@@ -67,6 +78,11 @@ func (m model) renderPlanCard(goal string, doc agent.PlanDocumentInfo, steps []a
 		body = append(body, m.planPhaseLines(i+1, s, inner)...)
 		if i < len(steps)-1 {
 			body = append(body, "")
+			if len(steps) > 2 {
+				sep := strings.Repeat("·", min(inner/2, 20))
+				body = append(body, th.PlanMuted.Render(sep))
+				body = append(body, "")
+			}
 		}
 	}
 
@@ -86,7 +102,32 @@ func (m model) renderPlanCard(goal string, doc agent.PlanDocumentInfo, steps []a
 	}
 	meta := fmt.Sprintf("%d phases", len(steps))
 	if nFiles > 0 {
-		meta += fmt.Sprintf(" · %d files", nFiles)
+		// Show file kind breakdown when there's a mix of kinds.
+		kinds := 0
+		if nNew > 0 {
+			kinds++
+		}
+		if nModify > 0 {
+			kinds++
+		}
+		if nDelete > 0 {
+			kinds++
+		}
+		if kinds > 1 {
+			var parts []string
+			if nNew > 0 {
+				parts = append(parts, fmt.Sprintf("%d new", nNew))
+			}
+			if nModify > 0 {
+				parts = append(parts, fmt.Sprintf("%d modify", nModify))
+			}
+			if nDelete > 0 {
+				parts = append(parts, fmt.Sprintf("%d delete", nDelete))
+			}
+			meta += fmt.Sprintf(" · %d files (%s)", nFiles, strings.Join(parts, ", "))
+		} else {
+			meta += fmt.Sprintf(" · %d files", nFiles)
+		}
 	}
 	return m.paintPlanFrame(title, meta, body, footer, width, inner)
 }
@@ -100,6 +141,11 @@ func (m model) planPhaseLines(n int, s agent.PlanStepInfo, inner int) []string {
 	prefix := th.Number.Render(fmt.Sprintf("%d", n)) + "  " + planStatusGlyph(s.Status, th) + " "
 	lines := wrapPrefixed(prefix, desc, inner, th.Text)
 
+	// Summary: plain-English explanation for the approver (prominent, normal text style).
+	if summary := strings.TrimSpace(s.Summary); summary != "" {
+		lines = append(lines, wrapPrefixed("   ", summary, inner, th.Text)...)
+	}
+
 	for _, f := range s.Files {
 		if strings.TrimSpace(f.Path) == "" {
 			continue
@@ -112,13 +158,22 @@ func (m model) planPhaseLines(n int, s agent.PlanStepInfo, inner int) []string {
 		lines = append(lines, wrapPrefixed("   ", "$ "+v, inner, th.PlanMuted)...)
 	}
 	if d := strings.TrimSpace(s.Details); d != "" {
-		for _, dl := range strings.Split(d, "\n") {
-			dl = strings.TrimSpace(dl)
-			if dl == "" {
-				lines = append(lines, "")
-				continue
-			}
-			lines = append(lines, wrapPrefixed("   ", dl, inner, th.PlanMuted)...)
+		lines = append(lines, "") // breathing room before implementation details
+		// Render details as markdown (with syntax highlighting, code blocks,
+		// inline formatting) rather than plain muted text. The details field
+		// typically contains numbered steps, backtick-quoted identifiers, and
+		// fenced code blocks that benefit from proper rendering.
+		detailWidth := inner - 3 // account for "   " indent
+		if detailWidth < 20 {
+			detailWidth = 20
+		}
+		md := render.Markdown(d, detailWidth, th.RenderStyles())
+		if md == "" {
+			// Fallback: plain text if markdown rendering produces nothing.
+			md = th.PlanMuted.Width(detailWidth).Render(d)
+		}
+		for _, dl := range strings.Split(md, "\n") {
+			lines = append(lines, "   "+dl)
 		}
 	}
 	return lines
@@ -127,12 +182,22 @@ func (m model) planPhaseLines(n int, s agent.PlanStepInfo, inner int) []string {
 func (m model) planBand(label, body string, inner int) []string {
 	th := m.theme
 	lines := []string{th.PlanHeader.Render(label)}
-	for _, para := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
-		if strings.TrimSpace(para) == "" {
-			lines = append(lines, "")
-			continue
+	// Render band body as markdown for proper formatting (inline code,
+	// bold, lists) instead of plain muted text.
+	md := render.Markdown(body, inner, th.RenderStyles())
+	if md == "" {
+		// Fallback: plain wrapped text.
+		for _, para := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+			if strings.TrimSpace(para) == "" {
+				lines = append(lines, "")
+				continue
+			}
+			lines = append(lines, wrapPrefixed("", para, inner, th.PlanMuted)...)
 		}
-		lines = append(lines, wrapPrefixed("", para, inner, th.PlanMuted)...)
+	} else {
+		for _, ml := range strings.Split(md, "\n") {
+			lines = append(lines, ml)
+		}
 	}
 	return lines
 }

--- a/pkg/tui/plan_render_test.go
+++ b/pkg/tui/plan_render_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SAP/astonish/pkg/agent"
 	"github.com/SAP/astonish/pkg/tui/events"
 )
 
@@ -294,5 +295,169 @@ func TestPlanDocumentContentSpan(t *testing.T) {
 	}
 	if !strings.Contains(extracted, "Step one") {
 		t.Fatalf("extracted content should contain the body text, got %q", extracted)
+	}
+}
+
+func TestRenderPlanDocumentWithSummary(t *testing.T) {
+	m := newModel(context.Background(), Config{Backend: staticBackend{}, Width: 80, Height: 24})
+	m.ready = true
+	m.layout()
+
+	content := `# Execution Plan
+
+**Goal:** Add caching layer
+
+_Last updated: 2025-01-01T00:00:00Z_
+
+## Phases
+
+- [ ] **add-cache** — Implement Redis caching
+  Summary: This phase adds a Redis-backed cache to reduce database load by 80%.
+- [ ] **update-config** — Add cache configuration
+  Summary: Exposes cache TTL and connection pool settings to operators.
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	plain := stripANSI(m.renderPlanDocument(content, 80))
+
+	if !strings.Contains(plain, "reduce database load by 80%") {
+		t.Fatalf("expected summary text for first phase in output:\n%s", plain)
+	}
+	if !strings.Contains(plain, "cache TTL and connection pool") {
+		t.Fatalf("expected summary text for second phase in output:\n%s", plain)
+	}
+}
+
+func TestRenderPlanDocumentPhaseSeparators(t *testing.T) {
+	m := newModel(context.Background(), Config{Backend: staticBackend{}, Width: 80, Height: 24})
+	m.ready = true
+	m.layout()
+
+	content := `# Execution Plan
+
+**Goal:** Multi-phase refactor
+
+_Last updated: 2025-01-01T00:00:00Z_
+
+## Phases
+
+- [ ] **phase-one** — First step
+- [ ] **phase-two** — Second step
+- [ ] **phase-three** — Third step
+- [ ] **phase-four** — Fourth step
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	plain := stripANSI(m.renderPlanDocument(content, 80))
+
+	if !strings.Contains(plain, "···") {
+		t.Fatalf("expected dot separators (·) between phases when 4 phases present:\n%s", plain)
+	}
+}
+
+func TestRenderPlanDocumentDetailsRenderedAsMarkdown(t *testing.T) {
+	m := newModel(context.Background(), Config{Backend: staticBackend{}, Width: 80, Height: 24})
+	m.ready = true
+	m.layout()
+
+	content := `# Execution Plan
+
+**Goal:** Implement feature Y
+
+_Last updated: 2025-01-01T00:00:00Z_
+
+## Phases
+
+- [ ] **impl-feature** — Build the feature
+  Use the adapter pattern to decouple the interface from the implementation.
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	plain := stripANSI(m.renderPlanDocument(content, 80))
+
+	if !strings.Contains(plain, "adapter pattern") {
+		t.Fatalf("expected details text rendered in output:\n%s", plain)
+	}
+}
+
+func TestRenderPlanDocumentFileKindBreakdown(t *testing.T) {
+	m := newModel(context.Background(), Config{Backend: staticBackend{}, Width: 80, Height: 24})
+	m.ready = true
+	m.layout()
+
+	content := `# Execution Plan
+
+**Goal:** Refactor storage layer
+
+_Last updated: 2025-01-01T00:00:00Z_
+
+## Phases
+
+- [ ] **refactor-storage** — Restructure storage package
+  - File (new): pkg/storage/cache.go
+  - File (modify): pkg/storage/db.go
+  - File (modify): pkg/storage/config.go
+  - File (delete): pkg/storage/legacy.go
+
+Legend: ` + "`[ ]`" + ` pending · ` + "`[~]`" + ` running · ` + "`[x]`" + ` complete · ` + "`[!]`" + ` failed
+`
+	plain := stripANSI(m.renderPlanDocument(content, 80))
+
+	if !strings.Contains(plain, "1 new") {
+		t.Fatalf("expected '1 new' in file kind breakdown:\n%s", plain)
+	}
+	if !strings.Contains(plain, "2 modify") {
+		t.Fatalf("expected '2 modify' in file kind breakdown:\n%s", plain)
+	}
+	if !strings.Contains(plain, "1 delete") {
+		t.Fatalf("expected '1 delete' in file kind breakdown:\n%s", plain)
+	}
+}
+
+func TestPlanDocumentRoundTrip_Summary(t *testing.T) {
+	steps := []agent.PlanStepInfo{
+		{
+			Name:        "setup-infra",
+			Description: "Provision cloud resources",
+			Summary:     "Creates the VPC, subnets, and security groups needed for the service.",
+		},
+		{
+			Name:        "deploy-service",
+			Description: "Deploy the microservice",
+			Summary:     "Builds and deploys the container image to the new infrastructure.",
+			Files: []agent.PlanFileChange{
+				{Path: "deploy/main.tf", Kind: "modify"},
+			},
+			Verify: "terraform plan",
+		},
+	}
+	doc := agent.PlanDocumentInfo{
+		Context:      "We need dedicated infrastructure for the new service.",
+		Verification: "curl https://service.example.com/health",
+	}
+
+	rendered := agent.RenderPlanFromInfoWithDoc("Deploy new service", doc, steps)
+
+	parsedDoc, parsedGoal, parsedSteps, err := agent.ParsePlanDocument(rendered)
+	if err != nil {
+		t.Fatalf("ParsePlanDocument failed: %v", err)
+	}
+	if parsedGoal != "Deploy new service" {
+		t.Fatalf("goal mismatch: got %q", parsedGoal)
+	}
+	if parsedDoc.Context != doc.Context {
+		t.Fatalf("context mismatch: got %q", parsedDoc.Context)
+	}
+	if parsedDoc.Verification != doc.Verification {
+		t.Fatalf("verification mismatch: got %q", parsedDoc.Verification)
+	}
+	if len(parsedSteps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(parsedSteps))
+	}
+	if parsedSteps[0].Summary != steps[0].Summary {
+		t.Fatalf("step 0 summary mismatch: got %q, want %q", parsedSteps[0].Summary, steps[0].Summary)
+	}
+	if parsedSteps[1].Summary != steps[1].Summary {
+		t.Fatalf("step 1 summary mismatch: got %q, want %q", parsedSteps[1].Summary, steps[1].Summary)
 	}
 }


### PR DESCRIPTION
## Summary

Three-pronged improvement to the Code TUI plan mode to make plans more readable, complete, and visually appealing for users approving them.

### Problem

1. Plans were too dense — everything rendered in flat gray monochrome text with markdown annotations showing literally (backticks, code fences, numbered lists as raw text)
2. Plans were frequently incomplete — missing frontend/backend counterparts, documentation, tests, or terminal-vs-studio parity
3. No visual hierarchy between approval-level info and implementation details

### Changes

#### 1. Completeness Self-Check (`pkg/agent/tool_categories.go`)

Added a mandatory 7-item COMPLETENESS SELF-CHECK to both `GraphPlanModeSystemContext` and `PlanModeSystemContext` that forces the model to verify coverage before calling `announce_plan`:
- Frontend/backend parity
- Terminal TUI vs Studio Chat parity
- All callers of changed types/interfaces
- `docs/architecture/` documentation
- Existing tests
- AGENTS.md for new tools/events
- Breaking changes surfaced explicitly

#### 2. New `summary` Field

Added an optional `Summary` field to plan phases — a plain-English 1-2 sentence explanation of what the phase does for the user (distinct from `details` which is implementation instructions). Rendered prominently in normal text style in the TUI card.

#### 3. Enhanced TUI Rendering (`pkg/tui/plan.go`)

- **Markdown rendering for details** — code blocks get syntax highlighting + line numbers, inline \`backtick\` text gets highlighted, numbered lists format properly
- **Markdown rendering for bands** (CONTEXT, WHAT NOT TO CHANGE, VERIFY)
- **Phase separators** (`···`) between phases when 3+ phases exist
- **File kind breakdown** in header meta: `5 files (1 new, 3 modify, 1 delete)`
- **Indentation preservation** — fixed parser to keep code indentation in detail blocks
- **Blank line preservation** — fixed parser to keep blank lines inside fenced code blocks

### Files Changed

| File | Change |
|------|--------|
| `pkg/agent/tool_categories.go` | Self-check blocks + summary mention in prompts |
| `pkg/agent/sub_agent.go` | Summary field on PlanStepInfo |
| `pkg/agent/plan_state.go` | Summary field on planStep |
| `pkg/agent/plan_document.go` | Summary serialization/parsing + indentation fix |
| `pkg/tools/plan_tool.go` | Summary field + completeness discipline in tool desc |
| `pkg/tui/plan.go` | Markdown rendering, separators, file breakdown |
| `pkg/agent/plan_document_test.go` | 4 new tests |
| `pkg/agent/system_prompt_contracts_code_test.go` | 2 new tests |
| `pkg/tui/plan_render_test.go` | 5 new tests |

### Backward Compatibility

- Existing PLAN.md files without Summary lines parse correctly (field stays empty)
- No changes to the PLAN.md format that would break existing sessions
- No changes to Studio/web PlanPanel rendering
- No changes to the graph plan state machine phases