### PR TITLE
Fix Slack message delivery and channel unlink

### DIFF
--- a/docs/website/docs/channels/slack.md
+++ b/docs/website/docs/channels/slack.md
@@ -26,8 +26,8 @@ The Slack channel integrates Astonish into your Slack workspace, enabling AI age
      - `app_mention` — required for `@Astonish` mentions in channels.
      - Optional, for Slack App Agent features: `assistant_thread_started`, `assistant_thread_context_changed`.
 7. Under **Slash Commands**, either create a `/link` command manually or configure App Manifest command sync in Astonish. For Socket Mode, Slack delivers slash commands over the WebSocket. For Events API mode, set the command request URL to `https://<your-astonish-host>/api/slack/commands`.
-8. Optional, for automatic command registration: create a Slack **App Configuration Token** from the Slack app configuration/token tooling and note the Slack **App ID**. This is **not** the Socket Mode App-Level Token (`xapp-...`) from **Basic Information → App-Level Tokens**, and it is not the bot token (`xoxb-...`). Astonish uses the configuration token to call App Manifest APIs and register `/link` plus the Slack-safe commands that make sense outside a specific thread.
-9. Install or **reinstall** the app to your workspace after changing scopes, slash commands, or event subscriptions, then copy the **Bot User OAuth Token** (`xoxb-...`).
+8. Optional, for automatic command and message-delivery registration: create a Slack **App Configuration Token** from the Slack app configuration/token tooling and note the Slack **App ID**. This is **not** the Socket Mode App-Level Token (`xapp-...`) from **Basic Information → App-Level Tokens**, and it is not the bot token (`xoxb-...`). Astonish uses the configuration token to reconcile the required bot events and OAuth scopes, then register `/link` plus the Slack-safe commands that make sense outside a specific thread.
+9. Install or **reinstall** the app to your workspace after changing scopes, slash commands, or event subscriptions, then copy the **Bot User OAuth Token** (`xoxb-...`). If Astonish reports that manifest requirements changed, reinstall even when the manifest update itself succeeded.
 
 ### 2. Configure via CLI
 
@@ -78,9 +78,11 @@ astonish daemon start
 
 Astonish sends Slack-native replies. Regular responses are converted to Slack `mrkdwn`, and structured summaries may use Block Kit sections, fields, tables, and a compact context footer for readability. Markdown tables and grouped inventory-style lists can be rendered as Slack table blocks without relying on a specific domain or topic. Long answers, code blocks, and content that would exceed Slack block limits automatically fall back to chunked text replies.
 
-## Programmatic Command Registration
+## Programmatic Manifest Synchronization
 
-Astonish can register Slack slash commands through Slack's App Manifest APIs. Configure the Slack App ID and an App Configuration Token (`channels.slack.config_token`). In Socket Mode, Astonish sets `settings.socket_mode_enabled=true` in the synced manifest and omits slash-command URLs, so no public command endpoint is needed. In Events API mode, also configure a public HTTPS command URL (`channels.slack.command_url`). Astonish will export the current app manifest, merge the commands it owns, validate the manifest, and update Slack best-effort on startup and when command registrations change. On startup, the daemon logs either `Slack slash command manifest sync enabled` or a `Slash command manifest sync skipped` reason so missing App Manifest configuration is visible. If Slack returns `invalid_auth`, the token is usually the wrong kind; App Manifest APIs require an App Configuration Token, not the `xapp-...` Socket Mode token created under App-Level Tokens. If Slack returns `invalid_manifest` in Events API mode, verify the command URL is a public `https://` URL ending in `/api/slack/commands`.
+Astonish can reconcile Slack message delivery and register slash commands through Slack's App Manifest APIs. Configure the Slack App ID and an App Configuration Token (`channels.slack.config_token`). The synchronization adds the required `message.im` and `app_mention` bot events and required bot OAuth scopes while preserving existing optional events, scopes, request URLs, non-Astonish commands, and other exported manifest fields. In Socket Mode, Astonish sets `settings.socket_mode_enabled=true`, clears the Events API request URL, and omits slash-command URLs, so no public endpoint is needed. In Events API mode, existing event configuration is preserved and a public HTTPS command URL (`channels.slack.command_url`) is required.
+
+Astonish exports the current app manifest, merges only the requirements it owns, validates it, and updates Slack best-effort on startup and when command registrations change. On startup, the daemon logs either `Slack slash command manifest sync enabled` or a `Slash command manifest sync skipped` reason so missing App Manifest configuration is visible. If synchronization says required message events or bot permissions changed, **reinstall the Slack app** before testing messages; a successful manifest update does not activate newly granted workspace permissions by itself. If Slack returns `invalid_auth`, the token is usually the wrong kind; App Manifest APIs require an App Configuration Token, not the `xapp-...` Socket Mode token. If Slack returns `invalid_manifest` in Events API mode, verify the command URL is a public `https://` URL ending in `/api/slack/commands`.
 
 The sync includes `/link` plus Slack-safe, app-prefixed command aliases such as `/astonish-help`, `/astonish-status`, and `/astonish-context` for commands that do not require a specific conversation thread. Slack reserves many generic command names, so Astonish does not try to register bare names such as `/status` or `/help`. Existing Slack app manifest fields are preserved, and non-Astonish slash commands are left in place. Because Slack manifest updates are exhaustive, Astonish always starts from Slack's exported manifest instead of constructing a minimal replacement manifest.
 
@@ -130,7 +132,17 @@ Bot:  ✓ Account linked. You're now connected as alice@acme.corp
 
 If Slack shows no response when you run `/link`, verify that the Slack app has a `/link` slash command. If using programmatic command registration, check that the App ID and App Configuration Token are configured and that the daemon logs show command sync success. Also verify that Socket Mode or the `/api/slack/commands` request URL is configured. Slack slash commands are not delivered as normal DM text.
 
-If `/link` works but normal chat messages do not, verify that **Event Subscriptions** is enabled, that the bot is subscribed to `message.im` and `app_mention`, and that the app was reinstalled after those changes. OAuth scopes grant permission, but bot event subscriptions control which message events Slack delivers to Astonish.
+If `/link` works but normal chat messages do not, verify that **Event Subscriptions** is enabled, that the bot is subscribed to `message.im` and `app_mention`, and that the app was reinstalled after those changes. OAuth scopes grant permission, but bot event subscriptions control which message events Slack delivers to Astonish. With App Manifest synchronization configured, reload the channel and follow any reinstall warning; without it, make these changes manually in Slack.
+
+### Message-delivery log diagnosis
+
+Use the daemon logs to identify where delivery stops:
+
+1. `Socket Mode connected` followed by `type=hello` proves only that Astonish opened Slack's WebSocket. It does **not** prove message subscriptions are active.
+2. `Socket Mode envelope received: type=events_api` proves Slack delivered an Events API envelope to Astonish.
+3. `[channels] Inbound from slack` proves the Slack adapter accepted the event and dispatched it to the channel manager.
+
+If a sent DM produces no `events_api` log, check `message.im`, reinstall the app, and confirm you are messaging the app rather than its profile. If a channel mention produces no event, check `app_mention` and invite the app to that channel. If an event arrives but is logged as blocked, link that Slack user to Astonish with `/link <code>`.
 
 ## Managing the Channel
 

--- a/pkg/channels/slack/manifest.go
+++ b/pkg/channels/slack/manifest.go
@@ -16,13 +16,17 @@ const (
 	slackCommandPrefix               = "astonish"
 )
 
-var slackBuiltinCommands = []slackapi.ManifestSlashCommand{
-	{
-		Command:     "/link",
-		Description: "Link your Slack account to Astonish",
-		UsageHint:   "CODE",
-	},
-}
+var (
+	slackBuiltinCommands = []slackapi.ManifestSlashCommand{
+		{
+			Command:     "/link",
+			Description: "Link your Slack account to Astonish",
+			UsageHint:   "CODE",
+		},
+	}
+	requiredSlackBotEvents = []string{"message.im", "app_mention"}
+	requiredSlackBotScopes = []string{"chat:write", "commands", "app_mentions:read", "im:history", "im:read", "im:write", "users:read"}
+)
 
 func (s *SlackChannel) refreshCommandsBestEffort(ctx context.Context, commands *channels.CommandRegistry) {
 	if ok, reason := s.manifestSyncConfigured(); !ok {
@@ -30,9 +34,9 @@ func (s *SlackChannel) refreshCommandsBestEffort(ctx context.Context, commands *
 		return
 	}
 	commandCount := len(buildAstonishSlackCommands(commands, s.manifestCommandURL()))
-	s.logger.Printf("[slack] Syncing %d slash command(s) via app manifest for app %s", commandCount, s.config.AppID)
+	s.logger.Printf("[slack] Synchronizing app manifest requirements and %d slash command(s) for app %s", commandCount, s.config.AppID)
 	if err := s.syncCommandManifest(ctx, commands); err != nil {
-		s.logger.Printf("[slack] Failed to sync slash commands via app manifest: %v", err)
+		s.logger.Printf("[slack] Failed to synchronize app manifest: %v", err)
 	}
 }
 
@@ -105,6 +109,7 @@ func (s *SlackChannel) syncCommandManifest(ctx context.Context, commands *channe
 	}
 
 	configureManifestTransport(manifest, s.usesSocketMode())
+	requirementsAdded := reconcileSlackManifestRequirements(manifest, s.usesSocketMode())
 	mergeAstonishSlashCommands(manifest, buildAstonishSlackCommands(commands, s.manifestCommandURL()), commands)
 	if err := validateSlackManifest(ctx, api, manifest, s.config.ConfigToken, s.config.AppID); err != nil {
 		return err
@@ -114,10 +119,10 @@ func (s *SlackChannel) syncCommandManifest(ctx context.Context, commands *channe
 	if err != nil {
 		return fmt.Errorf("update manifest: %w", err)
 	}
-	if resp != nil && resp.PermissionsUpdated {
-		s.logger.Printf("[slack] Slash commands synced; Slack reports permission changes, so the app may need reinstalling")
+	if (resp != nil && resp.PermissionsUpdated) || requirementsAdded {
+		s.logger.Printf("[slack] App manifest synchronized; required message events or bot permissions changed, so reinstall the Slack app for the changes to take effect")
 	} else {
-		s.logger.Printf("[slack] Slash commands synced via app manifest")
+		s.logger.Printf("[slack] App manifest requirements and slash commands synchronized")
 	}
 	return nil
 }
@@ -127,6 +132,41 @@ func configureManifestTransport(manifest *slackapi.Manifest, socketMode bool) {
 		return
 	}
 	manifest.Settings.SocketModeEnabled = socketMode
+}
+
+func reconcileSlackManifestRequirements(manifest *slackapi.Manifest, socketMode bool) bool {
+	if manifest == nil {
+		return false
+	}
+	changed := false
+	if manifest.Settings.EventSubscriptions == nil {
+		manifest.Settings.EventSubscriptions = &slackapi.EventSubscriptions{}
+		changed = true
+	}
+	subscriptions := manifest.Settings.EventSubscriptions
+	subscriptions.BotEvents, changed = appendMissingStrings(subscriptions.BotEvents, requiredSlackBotEvents, changed)
+	if socketMode && subscriptions.RequestUrl != "" {
+		subscriptions.RequestUrl = ""
+		changed = true
+	}
+	manifest.OAuthConfig.Scopes.Bot, changed = appendMissingStrings(manifest.OAuthConfig.Scopes.Bot, requiredSlackBotScopes, changed)
+	return changed
+}
+
+func appendMissingStrings(existing, required []string, changed bool) ([]string, bool) {
+	seen := make(map[string]bool, len(existing)+len(required))
+	for _, value := range existing {
+		seen[value] = true
+	}
+	for _, value := range required {
+		if seen[value] {
+			continue
+		}
+		existing = append(existing, value)
+		seen[value] = true
+		changed = true
+	}
+	return existing, changed
 }
 
 func buildAstonishSlackCommands(registry *channels.CommandRegistry, commandURL string) []slackapi.ManifestSlashCommand {

--- a/pkg/channels/slack/manifest_test.go
+++ b/pkg/channels/slack/manifest_test.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -100,6 +101,89 @@ func TestSlackCommandAliasUsesAppPrefix(t *testing.T) {
 	}
 	if got := slackCommandNameFromInvocation("/astonish-fleet-plan", registry); got != "fleet_plan" {
 		t.Fatalf("slackCommandNameFromInvocation(/astonish-fleet-plan) = %q", got)
+	}
+}
+
+func TestReconcileSlackManifestRequirements(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		socketMode     bool
+		requestURL     string
+		wantRequestURL string
+	}{
+		{name: "socket mode clears Events API URL", socketMode: true, requestURL: "https://external.example.com/events"},
+		{name: "events mode preserves Events API URL", requestURL: "https://external.example.com/events", wantRequestURL: "https://external.example.com/events"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			manifest := &slackapi.Manifest{}
+			manifest.Display.Name = "External app"
+			manifest.Settings.AllowedIPAddressRanges = []string{"192.0.2.0/24"}
+			manifest.Settings.EventSubscriptions = &slackapi.EventSubscriptions{
+				RequestUrl: tt.requestURL,
+				BotEvents:  []string{"reaction_added", "message.im"},
+				UserEvents: []string{"message.channels"},
+			}
+			manifest.OAuthConfig.RedirectUrls = []string{"https://external.example.com/oauth"}
+			manifest.OAuthConfig.Scopes.Bot = []string{"files:read", "chat:write"}
+			manifest.OAuthConfig.Scopes.User = []string{"search:read"}
+			manifest.OAuthConfig.Scopes.BotOptional = []string{"reactions:read"}
+			manifest.Features.SlashCommands = []slackapi.ManifestSlashCommand{{Command: "/external"}}
+
+			reconcileSlackManifestRequirements(manifest, tt.socketMode)
+			first := *manifest
+			first.Settings.EventSubscriptions = &slackapi.EventSubscriptions{
+				RequestUrl: manifest.Settings.EventSubscriptions.RequestUrl,
+				BotEvents:  append([]string(nil), manifest.Settings.EventSubscriptions.BotEvents...),
+				UserEvents: append([]string(nil), manifest.Settings.EventSubscriptions.UserEvents...),
+			}
+			first.OAuthConfig.Scopes.Bot = append([]string(nil), manifest.OAuthConfig.Scopes.Bot...)
+			reconcileSlackManifestRequirements(manifest, tt.socketMode)
+
+			if !reflect.DeepEqual(first, *manifest) {
+				t.Fatalf("reconciliation is not idempotent:\nfirst:  %#v\nsecond: %#v", first, *manifest)
+			}
+			if got := manifest.Settings.EventSubscriptions.RequestUrl; got != tt.wantRequestURL {
+				t.Fatalf("request URL = %q, want %q", got, tt.wantRequestURL)
+			}
+			assertContainsEachOnce(t, manifest.Settings.EventSubscriptions.BotEvents, requiredSlackBotEvents)
+			assertContainsEachOnce(t, manifest.OAuthConfig.Scopes.Bot, requiredSlackBotScopes)
+			if manifest.Display.Name != "External app" ||
+				!reflect.DeepEqual(manifest.Settings.AllowedIPAddressRanges, []string{"192.0.2.0/24"}) ||
+				!reflect.DeepEqual(manifest.Settings.EventSubscriptions.UserEvents, []string{"message.channels"}) ||
+				!reflect.DeepEqual(manifest.OAuthConfig.RedirectUrls, []string{"https://external.example.com/oauth"}) ||
+				!reflect.DeepEqual(manifest.OAuthConfig.Scopes.User, []string{"search:read"}) ||
+				!reflect.DeepEqual(manifest.OAuthConfig.Scopes.BotOptional, []string{"reactions:read"}) ||
+				!reflect.DeepEqual(manifest.Features.SlashCommands, []slackapi.ManifestSlashCommand{{Command: "/external"}}) {
+				t.Fatalf("unmanaged manifest fields changed: %#v", manifest)
+			}
+		})
+	}
+}
+
+func TestReconcileSlackManifestRequirementsInitializesSubscriptions(t *testing.T) {
+	t.Parallel()
+	manifest := &slackapi.Manifest{}
+	reconcileSlackManifestRequirements(manifest, false)
+	if manifest.Settings.EventSubscriptions == nil {
+		t.Fatal("event subscriptions were not initialized")
+	}
+	assertContainsEachOnce(t, manifest.Settings.EventSubscriptions.BotEvents, requiredSlackBotEvents)
+	assertContainsEachOnce(t, manifest.OAuthConfig.Scopes.Bot, requiredSlackBotScopes)
+}
+
+func assertContainsEachOnce(t *testing.T, got, required []string) {
+	t.Helper()
+	counts := make(map[string]int, len(got))
+	for _, value := range got {
+		counts[value]++
+	}
+	for _, value := range required {
+		if counts[value] != 1 {
+			t.Errorf("%q occurs %d times in %#v, want once", value, counts[value], got)
+		}
 	}
 }
 

--- a/web/src/components/__tests__/SettingsPage.test.tsx
+++ b/web/src/components/__tests__/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SettingsPage from '../SettingsPage'
 
@@ -37,10 +37,17 @@ vi.mock('../settings/settingsApi', () => ({
   fetchTeamProviders: vi.fn().mockResolvedValue({ providers: {}, default_provider: '', default_model: '' }),
   savePlatformProviders: vi.fn().mockResolvedValue({}),
   saveOrgProviders: vi.fn().mockResolvedValue({}),
+  inputClass: '',
+  inputStyle: {},
+  labelStyle: {},
+  hintStyle: {},
+  sectionBorderStyle: {},
+  saveButtonStyle: {},
 }))
 
 // Mock global fetch for /api/standard-servers and other API calls
 beforeEach(() => {
+  vi.clearAllMocks()
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: () => Promise.resolve({ servers: [] }),
@@ -121,6 +128,100 @@ describe('SettingsPage', () => {
     // platform-general maps through PLATFORM_SYSTEM_SECTIONS → 'general' → SettingsContent → GeneralSettings
     const el = await screen.findByTestId('general-settings')
     expect(el).toBeInTheDocument()
+  })
+
+  it('unlinks Slack with the CSRF header and refreshes the channel list', async () => {
+    const user = userEvent.setup()
+    const slackChannel = {
+      id: 'slack-1',
+      user_id: 'user-1',
+      channel_type: 'slack',
+      external_id: 'U123',
+      display_name: 'Test Slack',
+      enabled: true,
+      verified: true,
+      created_at: '2026-08-19T00:00:00Z',
+    }
+    let channelLoads = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/api/user/channels' && (!init?.method || init.method === 'GET')) {
+        channelLoads += 1
+        return new Response(JSON.stringify({ channels: channelLoads === 1 ? [slackChannel] : [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (url === '/api/channels/info') {
+        return new Response(JSON.stringify({
+          telegram: { bot_username: '', configured: false, connected: false, enabled: false, error: '' },
+          slack: { bot_user_id: 'B123', configured: true, connected: true, enabled: true, error: '' },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url === '/api/user/channels/slack-1' && init?.method === 'DELETE') {
+        expect(new Headers(init.headers).get('X-Requested-With')).toBe('XMLHttpRequest')
+        return new Response(null, { status: 204 })
+      }
+      return new Response(JSON.stringify({ servers: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    render(<SettingsPage {...defaultProps} activeSection="channels" isPlatformMode />)
+    await screen.findByText('Test Slack')
+    await user.click(screen.getByTitle('Unlink'))
+
+    expect(await screen.findByText('Channel unlinked')).toBeInTheDocument()
+    await waitFor(() => expect(channelLoads).toBe(2))
+    expect(screen.queryByText('Test Slack')).not.toBeInTheDocument()
+  })
+
+  it('displays the server error when Slack unlink fails', async () => {
+    const user = userEvent.setup()
+    const slackChannel = {
+      id: 'slack-1',
+      user_id: 'user-1',
+      channel_type: 'slack',
+      external_id: 'U123',
+      display_name: 'Test Slack',
+      enabled: true,
+      verified: true,
+      created_at: '2026-08-19T00:00:00Z',
+    }
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/api/user/channels/slack-1' && init?.method === 'DELETE') {
+        return new Response(JSON.stringify({ error: 'Slack unlink was rejected' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (url === '/api/user/channels') {
+        return new Response(JSON.stringify({ channels: [slackChannel] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (url === '/api/channels/info') {
+        return new Response(JSON.stringify({
+          telegram: { bot_username: '', configured: false, connected: false, enabled: false, error: '' },
+          slack: { bot_user_id: 'B123', configured: true, connected: true, enabled: true, error: '' },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ servers: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    render(<SettingsPage {...defaultProps} activeSection="channels" isPlatformMode />)
+    await screen.findByText('Test Slack')
+    await user.click(screen.getByTitle('Unlink'))
+
+    expect(await screen.findByText('Slack unlink was rejected')).toBeInTheDocument()
+    expect(screen.getByText('Test Slack')).toBeInTheDocument()
   })
 
   it('renders ProvidersSettings for platform-providers section', async () => {

--- a/web/src/components/settings/ConnectedChannelsSettings.tsx
+++ b/web/src/components/settings/ConnectedChannelsSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Plus, Trash2, Check, AlertCircle, Loader2, Radio, CheckCircle, XCircle, Edit2, X, Copy, ExternalLink } from 'lucide-react'
 import { inputClass, inputStyle, labelStyle, hintStyle, sectionBorderStyle, saveButtonStyle } from './settingsApi'
+import { teamFetch } from '../../api/teamContext'
 import { useChannelLinkFlow } from '../../hooks/useChannelLinkFlow'
 
 interface UserChannel {
@@ -49,6 +50,20 @@ const channelLabels: Record<string, string> = {
   telegram: 'Telegram',
   email: 'Email',
   slack: 'Slack',
+}
+
+async function apiError(response: Response, fallback: string): Promise<string> {
+  try {
+    const body: unknown = await response.json()
+    if (typeof body === 'object' && body !== null) {
+      const { error, message } = body as { error?: unknown; message?: unknown }
+      if (typeof error === 'string' && error) return error
+      if (typeof message === 'string' && message) return message
+    }
+  } catch {
+    // Fall back when the response is empty or not JSON.
+  }
+  return fallback
 }
 
 export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin?: boolean }) {
@@ -104,8 +119,8 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
 
   const fetchChannels = useCallback(async () => {
     try {
-      const res = await fetch('/api/user/channels', { credentials: 'include' })
-      if (!res.ok) throw new Error('Failed to load channels')
+      const res = await teamFetch('/api/user/channels', { credentials: 'include' })
+      if (!res.ok) throw new Error(await apiError(res, 'Failed to load channels'))
       const data = await res.json()
       setChannels(data.channels || [])
     } catch (err: unknown) {
@@ -117,8 +132,8 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
 
   const fetchChannelInfo = useCallback(async () => {
     try {
-      const res = await fetch('/api/channels/info', { credentials: 'include' })
-      if (!res.ok) throw new Error('Failed to load channel info')
+      const res = await teamFetch('/api/channels/info', { credentials: 'include' })
+      if (!res.ok) throw new Error(await apiError(res, 'Failed to load channel info'))
       const data: ChannelInfo = await res.json()
       setChannelInfo(data)
     } catch {
@@ -157,15 +172,14 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
     setEmailLinkLoading(true)
     setError(null)
     try {
-      const res = await fetch('/api/user/channels/link-code', {
+      const res = await teamFetch('/api/user/channels/link-code', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ channel_type: 'email', email: emailInput.trim() }),
       })
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Failed to send code' }))
-        throw new Error(data.error || 'Failed to send verification email')
+        throw new Error(await apiError(res, 'Failed to send verification email'))
       }
       const data = await res.json()
       setEmailLinkEmail(data.email)
@@ -183,15 +197,14 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
     setEmailLinkLoading(true)
     setError(null)
     try {
-      const res = await fetch('/api/user/channels/verify-email-code', {
+      const res = await teamFetch('/api/user/channels/verify-email-code', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ code: emailCodeInput.trim() }),
       })
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: 'Verification failed' }))
-        throw new Error(data.error || 'Failed to verify email code')
+        throw new Error(await apiError(res, 'Failed to verify email code'))
       }
       setEmailLinkStep('idle')
       setEmailExpiresAt(null)
@@ -220,11 +233,11 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
     setActionLoading(id)
     setError(null)
     try {
-      const res = await fetch(`/api/user/channels/${id}`, {
+      const res = await teamFetch(`/api/user/channels/${id}`, {
         method: 'DELETE',
         credentials: 'include',
       })
-      if (!res.ok) throw new Error('Failed to unlink channel')
+      if (!res.ok) throw new Error(await apiError(res, 'Failed to unlink channel'))
       setSuccess('Channel unlinked')
       await fetchChannels()
       setTimeout(() => setSuccess(null), 3000)
@@ -240,13 +253,13 @@ export default function ConnectedChannelsSettings({ isAdmin = false }: { isAdmin
     setActionLoading(`edit-${editingChannel.id}`)
     setError(null)
     try {
-      const res = await fetch(`/api/user/channels/${editingChannel.id}`, {
+      const res = await teamFetch(`/api/user/channels/${editingChannel.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify(editForm),
       })
-      if (!res.ok) throw new Error('Failed to update channel')
+      if (!res.ok) throw new Error(await apiError(res, 'Failed to update channel'))
       setSuccess('Channel updated')
       setEditingChannel(null)
       await fetchChannels()


### PR DESCRIPTION
## Summary
- reconcile required Slack message events and bot OAuth scopes during app manifest sync
- preserve existing optional manifest configuration and warn when the Slack app must be reinstalled
- route connected-channel requests through `teamFetch` so unlink DELETE requests include CSRF protection
- surface backend unlink errors in Studio and document Slack message-delivery diagnostics

## Testing
- `go test ./pkg/channels/slack ./pkg/channels/... ./pkg/api/...`
- `cd web && npm test -- --run src/components/__tests__/SettingsPage.test.tsx`
- `cd web && npm run typecheck`
- commit hook: `golangci-lint`