### PR TITLE
fix(a2a): use advertised interface endpoint

### DIFF
--- a/docs/architecture/a2a-client.md
+++ b/docs/architecture/a2a-client.md
@@ -92,7 +92,7 @@ Location: `~/.config/astonish/a2a_agents.json`
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `url` | string | Base URL of the remote A2A agent |
+| `url` | string | Configured discovery anchor, supplied as either the agent base URL or the terminal `/.well-known/agent-card.json` URL; it is canonicalized to a base URL and is not necessarily the endpoint selected for invocation |
 | `credential_name` | string | Name of credential in the credential store |
 | `auth_type` | string | `bearer`, `api_key`, or `oauth` |
 | `enabled` | *bool | Defaults to `true` if nil |
@@ -162,10 +162,12 @@ func (c *Client) resolveAuthHeaders(req *http.Request) error {
 }
 ```
 
-**Key invariant:** Credentials are resolved at call time, never cached in the client struct. This ensures:
+**Key invariant:** Credentials are resolved at call time, never cached in the client struct. The same configured credential and custom headers are applied to both discovery requests and requests to the card-selected invocation endpoint. This ensures:
 - Token rotation is picked up immediately
 - OAuth token refresh happens transparently
 - No stale credentials after credential store updates
+
+Because the selected invocation URL can have a different origin from the configured discovery anchor, accepting an agent card also authorizes its compatible JSON-RPC endpoint to receive those headers. Operators must trust the discovery service to nominate that credential destination; see [Security Considerations](#11-security-considerations).
 
 ### Credential Sources
 
@@ -175,12 +177,25 @@ In platform mode, the credential resolver is backed by `credentials.StoreAdapter
 
 ### Agent Card Discovery
 
-On initialization (or refresh), the Manager fetches each agent's card from:
-```
-<agent_url>/.well-known/agent-card.json
-```
+On initialization (or refresh), the Manager normalizes the configured `url` and fetches the agent card. Configuration accepts either a base URL or a URL whose terminal path is `/.well-known/agent-card.json` (with an optional trailing slash). Normalization removes trailing slashes and, when present, that terminal card path, producing one canonical **discovery anchor**. This configured anchor determines where the card is fetched; it does not override an invocation endpoint advertised by that card.
 
-The card contains a `skills` array describing the agent's capabilities.
+Exact root and subpath discovery examples:
+
+| Configured `url` | Normalized discovery anchor | Discovery GET target |
+|------------------|-----------------------------|----------------------|
+| `https://example.com` | `https://example.com` | `https://example.com/.well-known/agent-card.json` |
+| `https://example.com/` | `https://example.com` | `https://example.com/.well-known/agent-card.json` |
+| `https://autonomous-operations-api.qa-de-1.cloud.sap/.well-known/agent-card.json` | `https://autonomous-operations-api.qa-de-1.cloud.sap` | `https://autonomous-operations-api.qa-de-1.cloud.sap/.well-known/agent-card.json` |
+| `https://autonomous-operations-api.qa-de-1.cloud.sap/graph-agent/.well-known/agent-card.json` | `https://autonomous-operations-api.qa-de-1.cloud.sap/graph-agent` | `https://autonomous-operations-api.qa-de-1.cloud.sap/graph-agent/.well-known/agent-card.json` |
+
+Discovery therefore always performs `GET <normalized_discovery_anchor>/.well-known/agent-card.json`. The returned card contains the `skills` used for tool generation and determines a separate **selected invocation endpoint** and protocol version:
+
+1. If `supportedInterfaces` is present, entries are inspected in advertised order. The first tuple whose `protocolBinding` is `JSONRPC` (case-insensitive; an omitted binding is accepted for early v1 cards) is selected.
+2. The tuple stays paired: both its `url` and its `protocolVersion` govern invocation. The client must not combine the URL from one interface with the version from another or with the top-level version.
+3. Legacy top-level `url` and `protocolVersion` are used only when `supportedInterfaces` is absent. They are not a fallback when the field is present but contains no compatible tuple.
+4. If a non-empty `supportedInterfaces` list contains no compatible JSON-RPC tuple, discovery fails explicitly with a no-compatible-interface error. The client does not silently post to the configured discovery anchor.
+
+JSON-RPC calls and SSE `message/stream` are sent to the selected invocation URL, not to the agent-card URL. A refresh repeats discovery from the unchanged configured anchor, re-runs ordered interface selection, and atomically replaces the cached card and the paired invocation URL/protocol version only after a compatible card is obtained. Thus a card may move invocation to a new endpoint on refresh; a fetch or compatibility failure leaves the previously usable selection intact rather than partially applying the new card.
 
 ### Tool Naming Convention
 
@@ -376,11 +391,14 @@ Errors from remote agents are **surfaced as tool output**, not propagated as pan
 
 ## 11. Security Considerations
 
-### URL Validation
+### URL and Endpoint Validation
 
-- URLs are validated with `url.ParseRequestURI()` on create/update via the API
-- Only HTTP(S) URLs are accepted
-- The agent card endpoint is deterministic: `<url>/.well-known/agent-card.json`
+- Create/update API inputs are checked with `url.ParseRequestURI()` for URL syntax; this check does not itself restrict the scheme to HTTP(S), require a host, or provide SSRF protection
+- The configured URL is a discovery anchor. The client accepts a base URL or a URL ending in `/.well-known/agent-card.json`, optionally followed by `/`, and canonicalizes either form before discovery
+- Discovery is deterministic relative to that anchor (`GET <normalized_discovery_anchor>/.well-known/agent-card.json`), but JSON-RPC and SSE use the first compatible invocation URL advertised by the card
+- Both the configured anchor and every potentially selected interface URL are remote-controlled network destinations and require equivalent scheme, host, SSRF, redirect, and allowlist validation
+- A cross-origin selected endpoint is especially sensitive because configured credentials and headers are sent to it; production policy should reject untrusted origins or explicitly allow the discovery-to-invocation origin transition
+- Refresh must apply the same checks before replacing the active endpoint, since a previously trusted card can later advertise a different URL
 
 ### Credential Isolation
 

--- a/pkg/a2a/types.go
+++ b/pkg/a2a/types.go
@@ -4,6 +4,9 @@ package a2a
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -301,17 +304,46 @@ type AgentInterface struct {
 	ProtocolVersion string `json:"protocolVersion,omitempty"`
 }
 
-// DetectProtocolVersion returns the protocol version from the agent card,
-// checking (in order): top-level protocolVersion, supportedInterfaces[0].protocolVersion.
-// Returns empty string if no protocol version is found.
+// ErrNoCompatibleAgentInterface indicates that a card advertises interfaces,
+// but none use a protocol binding supported by this client.
+var ErrNoCompatibleAgentInterface = errors.New("no compatible agent interface")
+
+// SelectCompatibleInterface returns the first compatible interface in card order.
+// JSON-RPC binding matching is case-insensitive. A missing binding is treated as
+// JSON-RPC for compatibility with early v1 agent cards.
+//
+// Cards without supportedInterfaces use the legacy top-level URL and protocol
+// version. A non-empty supportedInterfaces list must contain a compatible entry.
+func (c *AgentCard) SelectCompatibleInterface() (AgentInterface, error) {
+	if len(c.SupportedInterfaces) == 0 {
+		return AgentInterface{
+			URL:             c.URL,
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: c.ProtocolVersion,
+		}, nil
+	}
+
+	for _, agentInterface := range c.SupportedInterfaces {
+		binding := strings.TrimSpace(agentInterface.ProtocolBinding)
+		if binding == "" || strings.EqualFold(binding, "JSONRPC") {
+			return agentInterface, nil
+		}
+	}
+
+	return AgentInterface{}, fmt.Errorf("%w: supportedInterfaces contains no JSONRPC binding", ErrNoCompatibleAgentInterface)
+}
+
+// DetectProtocolVersion returns the protocol version selected from the agent card.
+// It prefers the first compatible supported interface in card order. Legacy cards
+// without supportedInterfaces fall back to the top-level protocolVersion.
+// Returns empty string if no protocol version is found or advertised interfaces
+// are incompatible.
 func (c *AgentCard) DetectProtocolVersion() string {
-	if c.ProtocolVersion != "" {
-		return c.ProtocolVersion
+	agentInterface, err := c.SelectCompatibleInterface()
+	if err != nil {
+		return ""
 	}
-	if len(c.SupportedInterfaces) > 0 && c.SupportedInterfaces[0].ProtocolVersion != "" {
-		return c.SupportedInterfaces[0].ProtocolVersion
-	}
-	return ""
+	return agentInterface.ProtocolVersion
 }
 
 // AgentProvider identifies the organization providing the agent.

--- a/pkg/a2aclient/client.go
+++ b/pkg/a2aclient/client.go
@@ -19,34 +19,93 @@ import (
 
 // StreamEvent represents an event received from an SSE stream.
 type StreamEvent struct {
-	Type           string                        // "status_update" or "artifact_update"
-	StatusUpdate   *a2a.TaskStatusUpdateEvent    `json:"statusUpdate,omitempty"`
-	ArtifactUpdate *a2a.TaskArtifactUpdateEvent  `json:"artifactUpdate,omitempty"`
-	Error          error                         `json:"-"`
+	Type           string                       // "status_update" or "artifact_update"
+	StatusUpdate   *a2a.TaskStatusUpdateEvent   `json:"statusUpdate,omitempty"`
+	ArtifactUpdate *a2a.TaskArtifactUpdateEvent `json:"artifactUpdate,omitempty"`
+	Error          error                        `json:"-"`
 }
 
 // Client is an HTTP client for communicating with a remote A2A agent.
 type Client struct {
-	httpClient      *http.Client
-	config          A2AAgentConfig
-	resolver        credentials.CredentialResolver
-	requestID       atomic.Int64
+	httpClient *http.Client
+	config     A2AAgentConfig
+	resolver   credentials.CredentialResolver
+	requestID  atomic.Int64
+	invocation atomic.Pointer[invocationConfig]
+}
+
+type invocationConfig struct {
+	endpointURL     string
 	protocolVersion string
 }
 
 // SetProtocolVersion sets the A2A protocol version detected from the agent card.
 func (c *Client) SetProtocolVersion(v string) {
-	c.protocolVersion = v
+	for {
+		current := c.invocation.Load()
+		next := &invocationConfig{endpointURL: c.config.URL, protocolVersion: v}
+		if current != nil {
+			next.endpointURL = current.endpointURL
+		}
+		if c.invocation.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+// ApplyAgentCard atomically applies the invocation endpoint and protocol version
+// selected from an agent card. Discovery continues to use the configured URL.
+func (c *Client) ApplyAgentCard(card *a2a.AgentCard) error {
+	selected, err := card.SelectCompatibleInterface()
+	if err != nil {
+		return fmt.Errorf("a2aclient: failed to select agent interface: %w", err)
+	}
+
+	endpointURL := selected.URL
+	if endpointURL == "" {
+		endpointURL = c.config.URL
+	}
+	c.invocation.Store(&invocationConfig{
+		endpointURL:     endpointURL,
+		protocolVersion: selected.ProtocolVersion,
+	})
+	return nil
+}
+
+func (c *Client) invocationConfig() invocationConfig {
+	if selected := c.invocation.Load(); selected != nil {
+		return *selected
+	}
+	return invocationConfig{endpointURL: c.config.URL}
 }
 
 // isV1 returns true if the remote agent uses A2A v1.0 protocol.
 func (c *Client) isV1() bool {
-	v := c.protocolVersion
+	return isV1Protocol(c.invocationConfig().protocolVersion)
+}
+
+func isV1Protocol(v string) bool {
 	return v == "1.0" || v == "1" || strings.HasPrefix(v, "1.")
+}
+
+const agentCardPath = "/.well-known/agent-card.json"
+
+// NormalizeBaseURL returns the canonical A2A agent base URL.
+// It removes trailing slashes and a terminal agent-card well-known path.
+func NormalizeBaseURL(rawURL string) string {
+	baseURL := strings.TrimRight(rawURL, "/")
+	baseURL = strings.TrimSuffix(baseURL, agentCardPath)
+	return strings.TrimRight(baseURL, "/")
+}
+
+// AgentCardURL returns the agent-card well-known URL for an A2A agent URL.
+func AgentCardURL(rawURL string) string {
+	return NormalizeBaseURL(rawURL) + agentCardPath
 }
 
 // NewClient creates a new A2A client for the given agent configuration.
 func NewClient(cfg A2AAgentConfig, resolver credentials.CredentialResolver) *Client {
+	cfg.URL = NormalizeBaseURL(cfg.URL)
 	timeout := cfg.Timeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
@@ -60,7 +119,7 @@ func NewClient(cfg A2AAgentConfig, resolver credentials.CredentialResolver) *Cli
 
 // FetchAgentCard retrieves the agent card from the well-known endpoint.
 func (c *Client) FetchAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
-	url := strings.TrimRight(c.config.URL, "/") + "/.well-known/agent-card.json"
+	url := AgentCardURL(c.config.URL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -92,15 +151,17 @@ func (c *Client) FetchAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 
 // SendMessage sends a message to the remote agent and returns the resulting task.
 func (c *Client) SendMessage(ctx context.Context, params a2a.SendMessageParams) (*a2a.Task, error) {
+	invocation := c.invocationConfig()
+	v1 := isV1Protocol(invocation.protocolVersion)
 	method := "message/send"
 	var rpcParams any = params
 
-	if c.isV1() {
+	if v1 {
 		method = "SendMessage"
 		rpcParams = c.buildV1Params(params)
 	}
 
-	resp, err := c.doJSONRPC(ctx, method, rpcParams)
+	resp, err := c.doJSONRPCAt(ctx, invocation, method, rpcParams)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +177,7 @@ func (c *Client) SendMessage(ctx context.Context, params a2a.SendMessageParams) 
 	}
 
 	var task a2a.Task
-	if c.isV1() {
+	if v1 {
 		task, err = parseV1TaskResponse(resultBytes)
 		if err != nil {
 			return nil, err
@@ -361,7 +422,7 @@ func (c *Client) SendMessageStream(ctx context.Context, params a2a.SendMessagePa
 		return nil, err
 	}
 
-	url := strings.TrimRight(c.config.URL, "/")
+	url := c.invocationConfig().endpointURL
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("a2aclient: failed to create stream request: %w", err)
@@ -445,19 +506,23 @@ func (c *Client) CancelTask(ctx context.Context, taskID string) error {
 
 // doJSONRPC performs a JSON-RPC 2.0 call to the remote agent.
 func (c *Client) doJSONRPC(ctx context.Context, method string, params any) (*a2a.JSONRPCResponse, error) {
+	return c.doJSONRPCAt(ctx, c.invocationConfig(), method, params)
+}
+
+func (c *Client) doJSONRPCAt(ctx context.Context, invocation invocationConfig, method string, params any) (*a2a.JSONRPCResponse, error) {
 	reqBody, err := c.buildJSONRPCBody(method, params)
 	if err != nil {
 		return nil, err
 	}
 
-	url := strings.TrimRight(c.config.URL, "/")
+	url := invocation.endpointURL
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("a2aclient: failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if c.isV1() {
+	if isV1Protocol(invocation.protocolVersion) {
 		req.Header.Set("A2A-Version", "1.0")
 	}
 
@@ -574,7 +639,7 @@ func (c *Client) readSSEStream(ctx context.Context, body io.ReadCloser, ch chan<
 func (c *Client) parseSSEEvent(eventType, data string) StreamEvent {
 	// Try to parse as JSON-RPC response first
 	var rpcResp struct {
-		Result json.RawMessage `json:"result"`
+		Result json.RawMessage   `json:"result"`
 		Error  *a2a.JSONRPCError `json:"error,omitempty"`
 	}
 

--- a/pkg/a2aclient/client_test.go
+++ b/pkg/a2aclient/client_test.go
@@ -3,6 +3,7 @@ package a2aclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,6 +32,245 @@ func (m *mockResolver) Resolve(name string) (string, string, error) {
 
 func (m *mockResolver) Reload() error {
 	return nil
+}
+
+func TestEndpointURLHelpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantBase string
+		wantCard string
+	}{
+		{
+			name:     "root base",
+			input:    "https://example.com",
+			wantBase: "https://example.com",
+			wantCard: "https://example.com/.well-known/agent-card.json",
+		},
+		{
+			name:     "root base trailing slash",
+			input:    "https://example.com/",
+			wantBase: "https://example.com",
+			wantCard: "https://example.com/.well-known/agent-card.json",
+		},
+		{
+			name:     "root full card trailing slash",
+			input:    "https://example.com/.well-known/agent-card.json/",
+			wantBase: "https://example.com",
+			wantCard: "https://example.com/.well-known/agent-card.json",
+		},
+		{
+			name:     "subpath base trailing slash",
+			input:    "https://example.com/agents/demo/",
+			wantBase: "https://example.com/agents/demo",
+			wantCard: "https://example.com/agents/demo/.well-known/agent-card.json",
+		},
+		{
+			name:     "subpath full card",
+			input:    "https://example.com/agents/demo/.well-known/agent-card.json",
+			wantBase: "https://example.com/agents/demo",
+			wantCard: "https://example.com/agents/demo/.well-known/agent-card.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeBaseURL(tt.input); got != tt.wantBase {
+				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.wantBase)
+			}
+			if got := AgentCardURL(tt.input); got != tt.wantCard {
+				t.Errorf("AgentCardURL(%q) = %q, want %q", tt.input, got, tt.wantCard)
+			}
+			client := NewClient(A2AAgentConfig{URL: tt.input}, nil)
+			if got := client.config.URL; got != tt.wantBase {
+				t.Errorf("NewClient config URL = %q, want %q", got, tt.wantBase)
+			}
+		})
+	}
+}
+
+func TestClientEndpointPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		configured   func(string) string
+		wantCardPath string
+		wantRPCPath  string
+	}{
+		{"root base", func(base string) string { return base }, "/.well-known/agent-card.json", "/"},
+		{"root base trailing slash", func(base string) string { return base + "/" }, "/.well-known/agent-card.json", "/"},
+		{"root full card", func(base string) string { return base + "/.well-known/agent-card.json" }, "/.well-known/agent-card.json", "/"},
+		{"root full card trailing slash", func(base string) string { return base + "/.well-known/agent-card.json/" }, "/.well-known/agent-card.json", "/"},
+		{"subpath base", func(base string) string { return base + "/agents/demo" }, "/agents/demo/.well-known/agent-card.json", "/agents/demo"},
+		{"subpath base trailing slash", func(base string) string { return base + "/agents/demo/" }, "/agents/demo/.well-known/agent-card.json", "/agents/demo"},
+		{"subpath full card", func(base string) string { return base + "/agents/demo/.well-known/agent-card.json" }, "/agents/demo/.well-known/agent-card.json", "/agents/demo"},
+		{"subpath full card trailing slash", func(base string) string { return base + "/agents/demo/.well-known/agent-card.json/" }, "/agents/demo/.well-known/agent-card.json", "/agents/demo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					if r.URL.Path != tt.wantCardPath {
+						t.Errorf("card GET path = %q, want %q", r.URL.Path, tt.wantCardPath)
+					}
+					_ = json.NewEncoder(w).Encode(a2a.AgentCard{Name: "test"})
+				case http.MethodPost:
+					if r.URL.Path != tt.wantRPCPath {
+						t.Errorf("JSON-RPC POST path = %q, want %q", r.URL.Path, tt.wantRPCPath)
+					}
+					var req a2a.JSONRPCRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+						t.Errorf("decode JSON-RPC request: %v", err)
+					}
+					_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+						JSONRPC: "2.0",
+						ID:      req.ID,
+						Result: a2a.Task{
+							ID:     "task-1",
+							Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+						},
+					})
+				default:
+					t.Errorf("unexpected method %s", r.Method)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClient(A2AAgentConfig{URL: tt.configured(server.URL)}, nil)
+			if _, err := client.FetchAgentCard(context.Background()); err != nil {
+				t.Fatalf("FetchAgentCard failed: %v", err)
+			}
+			if _, err := client.SendMessage(context.Background(), a2a.SendMessageParams{
+				Message: a2a.Message{Role: "user", Parts: []a2a.Part{a2a.TextPart{Text: "hello"}}},
+			}); err != nil {
+				t.Fatalf("SendMessage failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestFullAgentCardURLGeneratesAndInvokesTools(t *testing.T) {
+	var cardRequests, rpcRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			cardRequests++
+			if r.URL.Path != "/graph-agent/.well-known/agent-card.json" {
+				t.Errorf("card GET path = %q, want %q", r.URL.Path, "/graph-agent/.well-known/agent-card.json")
+			}
+			_ = json.NewEncoder(w).Encode(a2a.AgentCard{
+				Name: "graph-agent",
+				Skills: []a2a.Skill{
+					{ID: "query_graph", Name: "Query Graph", Description: "Queries the graph"},
+				},
+			})
+		case http.MethodPost:
+			rpcRequests++
+			if r.URL.Path != "/graph-agent" {
+				t.Errorf("tool JSON-RPC POST path = %q, want %q", r.URL.Path, "/graph-agent")
+			}
+			var req a2a.JSONRPCRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode JSON-RPC request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: a2a.Task{
+					ID: "task-1",
+					Status: a2a.TaskStatus{
+						State:   a2a.TaskStateCompleted,
+						Message: &a2a.Message{Role: "agent", Parts: []a2a.Part{a2a.TextPart{Text: "done"}}},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &A2AClientConfig{Agents: map[string]A2AAgentConfig{
+		"graph-agent": {
+			Name: "graph-agent",
+			URL:  server.URL + "/graph-agent/.well-known/agent-card.json",
+		},
+	}}
+	mgr := NewManager(cfg)
+	if err := mgr.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	card, err := mgr.GetAgentCard("graph-agent")
+	if err != nil {
+		t.Fatalf("GetAgentCard failed: %v", err)
+	}
+	client, err := mgr.GetClient("graph-agent")
+	if err != nil {
+		t.Fatalf("GetClient failed: %v", err)
+	}
+	tools := GenerateTools("graph-agent", card, client)
+	if len(tools) != 1 {
+		t.Fatalf("generated %d tools, want 1", len(tools))
+	}
+	if tools[0].Name() != "a2a_graph_agent_query_graph" {
+		t.Errorf("tool name = %q, want %q", tools[0].Name(), "a2a_graph_agent_query_graph")
+	}
+	result, err := tools[0].Run(context.Background(), map[string]any{"message": "query"})
+	if err != nil {
+		t.Fatalf("tool Run failed: %v", err)
+	}
+	if result["response"] != "done" {
+		t.Errorf("tool response = %v, want %q", result["response"], "done")
+	}
+	if cardRequests != 1 || rpcRequests != 1 {
+		t.Errorf("requests = card:%d rpc:%d, want card:1 rpc:1", cardRequests, rpcRequests)
+	}
+}
+
+func TestApplyAgentCardRoutesRPCAndStreamToAdvertisedPath(t *testing.T) {
+	var rpcPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rpcPaths = append(rpcPaths, r.URL.Path)
+		if r.Header.Get("Accept") == "text/event-stream" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: status_update\ndata: {\"jsonrpc\":\"2.0\",\"result\":{\"taskId\":\"task-1\",\"status\":{\"state\":\"completed\",\"timestamp\":\"0001-01-01T00:00:00Z\"}}}\n\n")
+			return
+		}
+		var req a2a.JSONRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+			JSONRPC: "2.0", ID: req.ID,
+			Result: a2a.Task{ID: "task-1", Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(A2AAgentConfig{URL: server.URL + "/discovery-root"}, nil)
+	card := &a2a.AgentCard{SupportedInterfaces: []a2a.AgentInterface{{
+		URL: server.URL + "/advertised/rpc/", ProtocolBinding: "JSONRPC", ProtocolVersion: "0.3",
+	}}}
+	if err := client.ApplyAgentCard(card); err != nil {
+		t.Fatalf("ApplyAgentCard failed: %v", err)
+	}
+	if _, err := client.SendMessage(context.Background(), a2a.SendMessageParams{
+		Message: a2a.Message{Role: "user", Parts: []a2a.Part{a2a.TextPart{Text: "hello"}}},
+	}); err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+	stream, err := client.SendMessageStream(context.Background(), a2a.SendMessageParams{
+		Message: a2a.Message{Role: "user", Parts: []a2a.Part{a2a.TextPart{Text: "hello"}}},
+	})
+	if err != nil {
+		t.Fatalf("SendMessageStream failed: %v", err)
+	}
+	if event := <-stream; event.Error != nil {
+		t.Fatalf("stream event failed: %v", event.Error)
+	}
+	if len(rpcPaths) != 2 || rpcPaths[0] != "/advertised/rpc/" || rpcPaths[1] != "/advertised/rpc/" {
+		t.Fatalf("request paths = %v, want advertised path preserved twice", rpcPaths)
+	}
 }
 
 func TestFetchAgentCard(t *testing.T) {
@@ -605,6 +845,74 @@ func TestV1NormalizeTaskState(t *testing.T) {
 	}
 }
 
+func TestSelectCompatibleInterface(t *testing.T) {
+	tests := []struct {
+		name      string
+		card      a2a.AgentCard
+		want      a2a.AgentInterface
+		wantError bool
+	}{
+		{
+			name: "selects first compatible interface in advertised order",
+			card: a2a.AgentCard{SupportedInterfaces: []a2a.AgentInterface{
+				{URL: "https://grpc.example", ProtocolBinding: "GRPC", ProtocolVersion: "1.0"},
+				{URL: "https://first.example", ProtocolBinding: "JSONRPC", ProtocolVersion: "1.1"},
+				{URL: "https://second.example", ProtocolBinding: "jsonrpc", ProtocolVersion: "1.2"},
+			}},
+			want: a2a.AgentInterface{URL: "https://first.example", ProtocolBinding: "JSONRPC", ProtocolVersion: "1.1"},
+		},
+		{
+			name: "binding comparison is case insensitive",
+			card: a2a.AgentCard{SupportedInterfaces: []a2a.AgentInterface{
+				{URL: "https://example.com", ProtocolBinding: "jsonrpc", ProtocolVersion: "1.0"},
+			}},
+			want: a2a.AgentInterface{URL: "https://example.com", ProtocolBinding: "jsonrpc", ProtocolVersion: "1.0"},
+		},
+		{
+			name: "empty binding is compatible",
+			card: a2a.AgentCard{SupportedInterfaces: []a2a.AgentInterface{
+				{URL: "https://example.com", ProtocolVersion: "1.0"},
+			}},
+			want: a2a.AgentInterface{URL: "https://example.com", ProtocolVersion: "1.0"},
+		},
+		{
+			name: "legacy card falls back to top level fields",
+			card: a2a.AgentCard{URL: "https://legacy.example", ProtocolVersion: "0.3"},
+			want: a2a.AgentInterface{URL: "https://legacy.example", ProtocolBinding: "JSONRPC", ProtocolVersion: "0.3"},
+		},
+		{
+			name: "non-empty incompatible interfaces return explicit error",
+			card: a2a.AgentCard{
+				URL:             "https://legacy.example",
+				ProtocolVersion: "0.3",
+				SupportedInterfaces: []a2a.AgentInterface{
+					{URL: "https://grpc.example", ProtocolBinding: "GRPC", ProtocolVersion: "1.0"},
+					{URL: "https://http.example", ProtocolBinding: "HTTP+JSON", ProtocolVersion: "1.0"},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.card.SelectCompatibleInterface()
+			if tt.wantError {
+				if !errors.Is(err, a2a.ErrNoCompatibleAgentInterface) {
+					t.Fatalf("SelectCompatibleInterface() error = %v, want ErrNoCompatibleAgentInterface", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SelectCompatibleInterface() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("SelectCompatibleInterface() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectProtocolVersionFromSupportedInterfaces(t *testing.T) {
 	// Simulates the SAP Autonomous Operations agent card structure
 	card := a2a.AgentCard{
@@ -625,18 +933,30 @@ func TestDetectProtocolVersionFromSupportedInterfaces(t *testing.T) {
 	}
 }
 
-func TestDetectProtocolVersionTopLevelTakesPrecedence(t *testing.T) {
+func TestDetectProtocolVersionUsesSelectedInterface(t *testing.T) {
 	card := a2a.AgentCard{
 		Name:            "Agent",
 		ProtocolVersion: "2.0",
 		SupportedInterfaces: []a2a.AgentInterface{
-			{ProtocolVersion: "1.0"},
+			{ProtocolBinding: "GRPC", ProtocolVersion: "9.0"},
+			{ProtocolBinding: "JSONRPC", ProtocolVersion: "1.0"},
 		},
 	}
 
 	pv := card.DetectProtocolVersion()
-	if pv != "2.0" {
-		t.Errorf("expected top-level protocolVersion '2.0' to take precedence, got %q", pv)
+	if pv != "1.0" {
+		t.Errorf("expected selected interface protocolVersion '1.0', got %q", pv)
+	}
+}
+
+func TestDetectProtocolVersionLegacyTopLevel(t *testing.T) {
+	card := a2a.AgentCard{
+		Name:            "Agent",
+		ProtocolVersion: "0.3",
+	}
+
+	if pv := card.DetectProtocolVersion(); pv != "0.3" {
+		t.Errorf("expected legacy top-level protocolVersion '0.3', got %q", pv)
 	}
 }
 
@@ -656,7 +976,8 @@ func TestV1SendMessageWithSupportedInterfaces(t *testing.T) {
 	// End-to-end test: agent card has supportedInterfaces with protocolVersion 1.0
 	// Verify the manager detects it and the client sends the correct method
 	var receivedMethod string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/agent-card.json" {
 			// Return a card with supportedInterfaces (like SAP AO agent)
 			card := map[string]any{
@@ -664,7 +985,7 @@ func TestV1SendMessageWithSupportedInterfaces(t *testing.T) {
 				"version": "0.1.0",
 				"supportedInterfaces": []map[string]any{
 					{
-						"url":             "https://example.com/",
+						"url":             server.URL + "/rpc/v1",
 						"protocolBinding": "JSONRPC",
 						"protocolVersion": "1.0",
 					},
@@ -679,6 +1000,9 @@ func TestV1SendMessageWithSupportedInterfaces(t *testing.T) {
 		}
 
 		// RPC endpoint
+		if r.URL.Path != "/rpc/v1" {
+			t.Errorf("RPC path = %q, want /rpc/v1", r.URL.Path)
+		}
 		body, _ := io.ReadAll(r.Body)
 		var rpcReq struct {
 			Method string `json:"method"`

--- a/pkg/a2aclient/manager.go
+++ b/pkg/a2aclient/manager.go
@@ -79,10 +79,10 @@ func (m *Manager) Initialize(ctx context.Context) error {
 		}
 		m.cards[name] = card
 
-		// Detect protocol version from the agent card.
-		// Uses the card's DetectProtocolVersion which checks top-level and supportedInterfaces.
-		if pv := card.DetectProtocolVersion(); pv != "" {
-			client.SetProtocolVersion(pv)
+		if err := client.ApplyAgentCard(card); err != nil {
+			log.Printf("a2aclient: warning: failed to apply agent card for %q: %v", name, err)
+			delete(m.cards, name)
+			continue
 		}
 	}
 
@@ -153,6 +153,10 @@ func (m *Manager) RefreshCard(ctx context.Context, agentName string) (*a2a.Agent
 
 	card, err := client.FetchAgentCard(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := client.ApplyAgentCard(card); err != nil {
 		return nil, err
 	}
 

--- a/pkg/a2aclient/manager_test.go
+++ b/pkg/a2aclient/manager_test.go
@@ -214,6 +214,57 @@ func TestManagerRefreshCard(t *testing.T) {
 	}
 }
 
+func TestManagerRefreshCardAppliesSelectedEndpointAndVersion(t *testing.T) {
+	cardCalls := 0
+	var rpcPaths []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			cardCalls++
+			path, version := "/rpc/initial", "0.3"
+			if cardCalls > 1 {
+				path, version = "/rpc/refreshed/", "1.0"
+			}
+			_ = json.NewEncoder(w).Encode(a2a.AgentCard{SupportedInterfaces: []a2a.AgentInterface{{URL: server.URL + path, ProtocolBinding: "JSONRPC", ProtocolVersion: version}}})
+			return
+		}
+		rpcPaths = append(rpcPaths, r.URL.Path)
+		var req a2a.JSONRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		result := any(a2a.Task{ID: "task-1", Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}})
+		if req.Method == "SendMessage" {
+			result = map[string]any{"task": map[string]any{"id": "task-1", "status": map[string]any{"state": "TASK_STATE_COMPLETED"}}}
+		}
+		_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result})
+	}))
+	defer server.Close()
+
+	mgr := NewManager(&A2AClientConfig{Agents: map[string]A2AAgentConfig{"agent": {URL: server.URL + "/discovery"}}})
+	if err := mgr.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	client, err := mgr.GetClient("agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	send := func() {
+		if _, err := client.SendMessage(context.Background(), a2a.SendMessageParams{Message: a2a.Message{Role: "user", Parts: []a2a.Part{a2a.TextPart{Text: "hello"}}}}); err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+	}
+	send()
+	if _, err := mgr.RefreshCard(context.Background(), "agent"); err != nil {
+		t.Fatalf("RefreshCard failed: %v", err)
+	}
+	send()
+	if len(rpcPaths) != 2 || rpcPaths[0] != "/rpc/initial" || rpcPaths[1] != "/rpc/refreshed/" {
+		t.Fatalf("RPC paths = %v", rpcPaths)
+	}
+	if !client.isV1() {
+		t.Fatal("refreshed client should use v1 protocol")
+	}
+}
+
 func TestManagerInitializeWithFailedCard(t *testing.T) {
 	// Server that returns errors for agent card
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/a2a_client_handlers.go
+++ b/pkg/api/a2a_client_handlers.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
-	"strings"
 
+	"github.com/SAP/astonish/pkg/a2aclient"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/gorilla/mux"
 )
@@ -133,6 +133,7 @@ func CreateA2AAgentHandler(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "Invalid URL format: "+err.Error())
 		return
 	}
+	req.URL = a2aclient.NormalizeBaseURL(req.URL)
 	if req.AuthType == "" {
 		req.AuthType = "bearer"
 	}
@@ -194,6 +195,7 @@ func UpdateA2AAgentHandler(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "Invalid URL format: "+err.Error())
 			return
 		}
+		req.URL = a2aclient.NormalizeBaseURL(req.URL)
 	}
 
 	if req.AuthType == "" {
@@ -315,7 +317,7 @@ func RefreshA2AAgentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch agent card from remote agent
-	cardURL := resolveAgentCardURL(existing.URL)
+	cardURL := a2aclient.AgentCardURL(existing.URL)
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, cardURL, nil) //nolint:gosec // URL is user-configured
 	if err != nil {
 		respondError(w, http.StatusBadGateway, "Invalid agent card URL: "+err.Error())
@@ -406,7 +408,7 @@ func TestA2AAgentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test connectivity by fetching the agent card
-	cardURL := resolveAgentCardURL(existing.URL)
+	cardURL := a2aclient.AgentCardURL(existing.URL)
 
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, cardURL, nil)
 	if err != nil {
@@ -479,17 +481,6 @@ func TestA2AAgentHandler(w http.ResponseWriter, r *http.Request) {
 		"version":     card.Version,
 		"skill_count": len(card.Skills),
 	})
-}
-
-// resolveAgentCardURL returns the agent card URL for the given base URL.
-// If the URL already ends with /.well-known/agent-card.json, it is used as-is.
-// Otherwise, the well-known path is appended.
-func resolveAgentCardURL(rawURL string) string {
-	trimmed := strings.TrimRight(rawURL, "/")
-	if strings.HasSuffix(trimmed, "/.well-known/agent-card.json") {
-		return trimmed
-	}
-	return trimmed + "/.well-known/agent-card.json"
 }
 
 // --- Internal helpers ---

--- a/pkg/api/a2a_client_handlers_test.go
+++ b/pkg/api/a2a_client_handlers_test.go
@@ -1,17 +1,19 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
+	"github.com/SAP/astonish/pkg/a2aclient"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/gorilla/mux"
 )
 
-func TestResolveAgentCardURL(t *testing.T) {
+func TestAgentCardURLSharedContract(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -61,9 +63,9 @@ func TestResolveAgentCardURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveAgentCardURL(tt.input)
+			got := a2aclient.AgentCardURL(tt.input)
 			if got != tt.expected {
-				t.Errorf("resolveAgentCardURL(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("a2aclient.AgentCardURL(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -90,8 +92,15 @@ func (m *mockA2AAgentStore) Get(_ context.Context, name string) (*store.A2AAgent
 	return nil, nil
 }
 
-func (m *mockA2AAgentStore) Save(_ context.Context, _ *store.A2AAgent) error { return nil }
-func (m *mockA2AAgentStore) Delete(_ context.Context, _ string) error        { return nil }
+func (m *mockA2AAgentStore) Save(_ context.Context, agent *store.A2AAgent) error {
+	if m.agents == nil {
+		m.agents = make(map[string]*store.A2AAgent)
+	}
+	saved := *agent
+	m.agents[agent.Name] = &saved
+	return nil
+}
+func (m *mockA2AAgentStore) Delete(_ context.Context, _ string) error { return nil }
 func (m *mockA2AAgentStore) UpdateCachedCard(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error {
 	return nil
 }
@@ -119,6 +128,64 @@ func (b *bearerCredentialStore) Resolve(_ context.Context, name string) (string,
 }
 
 // --- Handler tests ---
+
+func TestCreateA2AAgentHandler_NormalizesAgentCardURLBeforeSave(t *testing.T) {
+	agentStore := &mockA2AAgentStore{}
+	body := []byte(`{"name":"graph-agent","url":"https://autonomous-operations-api.qa-de-1.cloud.sap/graph-agent/.well-known/agent-card.json"}`)
+	r := newPlatformAdminA2ARequest(http.MethodPost, "/api/a2a-agents?scope=platform", body, agentStore)
+
+	w := httptest.NewRecorder()
+	CreateA2AAgentHandler(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", w.Code, w.Body.String())
+	}
+	saved := agentStore.agents["graph-agent"]
+	if saved == nil {
+		t.Fatal("expected created agent to be saved")
+	}
+	const want = "https://autonomous-operations-api.qa-de-1.cloud.sap/graph-agent"
+	if saved.URL != want {
+		t.Errorf("saved URL = %q, want %q", saved.URL, want)
+	}
+}
+
+func TestUpdateA2AAgentHandler_NormalizesAgentCardURLBeforeSave(t *testing.T) {
+	agentStore := &mockA2AAgentStore{}
+	body := []byte(`{"url":"https://autonomous-operations-api.qa-de-1.cloud.sap/.well-known/agent-card.json"}`)
+	r := newPlatformAdminA2ARequest(http.MethodPut, "/api/a2a-agents/root-agent?scope=platform", body, agentStore)
+	r = mux.SetURLVars(r, map[string]string{"name": "root-agent"})
+
+	w := httptest.NewRecorder()
+	UpdateA2AAgentHandler(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	saved := agentStore.agents["root-agent"]
+	if saved == nil {
+		t.Fatal("expected updated agent to be saved")
+	}
+	const want = "https://autonomous-operations-api.qa-de-1.cloud.sap"
+	if saved.URL != want {
+		t.Errorf("saved URL = %q, want %q", saved.URL, want)
+	}
+}
+
+func newPlatformAdminA2ARequest(method, target string, body []byte, agentStore store.A2AAgentStore) *http.Request {
+	r := httptest.NewRequest(method, target, bytes.NewReader(body))
+	svc := &store.Services{
+		Mode:              store.ModePlatform,
+		PlatformA2AAgents: agentStore,
+	}
+	ctx := store.WithServices(r.Context(), svc)
+	ctx = WithPlatformUser(ctx, &PlatformUser{
+		ID:           "admin-user",
+		Email:        "admin@example.com",
+		PlatformRole: "superadmin",
+	})
+	return r.WithContext(ctx)
+}
 
 func TestTestA2AAgentHandler_ResolvesCredential(t *testing.T) {
 	// Mock HTTP server that requires Authorization: Bearer test-token

--- a/pkg/api/app_data_handler.go
+++ b/pkg/api/app_data_handler.go
@@ -446,13 +446,14 @@ func resolveA2ASource(r *http.Request, agentName string, args map[string]any) (a
 
 	client := a2aclient.NewClient(agentCfg, resolver)
 
-	// Fetch agent card to detect protocol version
+	// Fetch and apply the shared card selection so app requests use the advertised
+	// JSON-RPC endpoint and its protocol version as one invocation configuration.
 	card, err := client.FetchAgentCard(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("A2A agent %q: failed to fetch agent card: %w", agentName, err)
 	}
-	if pv := card.DetectProtocolVersion(); pv != "" {
-		client.SetProtocolVersion(pv)
+	if err := client.ApplyAgentCard(card); err != nil {
+		return nil, fmt.Errorf("A2A agent %q: incompatible agent card: %w", agentName, err)
 	}
 
 	// Build and send the message

--- a/pkg/api/app_data_handler_a2a_test.go
+++ b/pkg/api/app_data_handler_a2a_test.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/SAP/astonish/pkg/a2a"
 	"github.com/SAP/astonish/pkg/a2aclient"
 	"github.com/SAP/astonish/pkg/store"
 )
@@ -131,6 +134,116 @@ func TestResolveA2ASource_PlatformStoresInjected(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to fetch agent card") {
 		t.Fatalf("unexpected error (expected agent card fetch failure): %v", err)
 	}
+}
+
+func TestResolveA2ASource_AdvertisedInterfaceRouting(t *testing.T) {
+	var discoveryRequests atomic.Int32
+	var rpcRequests atomic.Int32
+
+	rpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rpcRequests.Add(1)
+		if r.Method != http.MethodPost || r.URL.Path != "/invoke" {
+			t.Errorf("RPC request = %s %s, want POST /invoke", r.Method, r.URL.Path)
+		}
+		var req a2a.JSONRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode RPC request: %v", err)
+		}
+		if req.Method != "SendMessage" {
+			t.Errorf("RPC method = %q, want SendMessage", req.Method)
+		}
+		_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]any{"task": map[string]any{
+				"id": "task-1",
+				"status": map[string]any{
+					"state": "TASK_STATE_COMPLETED",
+					"message": map[string]any{
+						"role":  "ROLE_AGENT",
+						"parts": []map[string]any{{"text": "routed"}},
+					},
+				},
+			}},
+		})
+	}))
+	defer rpcServer.Close()
+
+	discoveryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		discoveryRequests.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/discovery/.well-known/agent-card.json" {
+			t.Errorf("discovery request = %s %s, want GET /discovery/.well-known/agent-card.json", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(a2a.AgentCard{
+			Name: "routed-agent",
+			SupportedInterfaces: []a2a.AgentInterface{
+				{URL: rpcServer.URL + "/ignored", ProtocolBinding: "GRPC", ProtocolVersion: "1.0"},
+				{URL: rpcServer.URL + "/invoke", ProtocolBinding: "JSONRPC", ProtocolVersion: "1.0"},
+			},
+		})
+	}))
+	defer discoveryServer.Close()
+
+	r := requestWithA2AAgent(t, "routed-agent", discoveryServer.URL+"/discovery")
+	result, err := resolveA2ASource(r, "routed-agent", map[string]any{"message": "hello"})
+	if err != nil {
+		t.Fatalf("resolveA2ASource failed: %v", err)
+	}
+	data, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", result)
+	}
+	if data["response"] != "routed" {
+		t.Errorf("response = %v, want routed", data["response"])
+	}
+	if discoveryRequests.Load() != 1 || rpcRequests.Load() != 1 {
+		t.Errorf("requests = discovery:%d rpc:%d, want 1 each", discoveryRequests.Load(), rpcRequests.Load())
+	}
+}
+
+func TestResolveA2ASource_IncompatibleAdvertisedInterfaces(t *testing.T) {
+	var rpcRequests atomic.Int32
+	rpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rpcRequests.Add(1)
+		http.Error(w, "unexpected RPC", http.StatusInternalServerError)
+	}))
+	defer rpcServer.Close()
+
+	discoveryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(a2a.AgentCard{
+			Name: "incompatible-agent",
+			URL:  rpcServer.URL,
+			SupportedInterfaces: []a2a.AgentInterface{
+				{URL: rpcServer.URL, ProtocolBinding: "GRPC", ProtocolVersion: "1.0"},
+				{URL: rpcServer.URL, ProtocolBinding: "HTTP+JSON", ProtocolVersion: "1.0"},
+			},
+		})
+	}))
+	defer discoveryServer.Close()
+
+	r := requestWithA2AAgent(t, "incompatible-agent", discoveryServer.URL)
+	_, err := resolveA2ASource(r, "incompatible-agent", map[string]any{"message": "hello"})
+	if err == nil {
+		t.Fatal("expected incompatible interface error")
+	}
+	if !strings.Contains(err.Error(), "incompatible agent card") || !strings.Contains(err.Error(), "no compatible agent interface") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rpcRequests.Load() != 0 {
+		t.Errorf("RPC requests = %d, want 0", rpcRequests.Load())
+	}
+}
+
+func requestWithA2AAgent(t *testing.T, name, url string) *http.Request {
+	t.Helper()
+	agentStore := &mockA2AAgentStore{agents: map[string]*store.A2AAgent{
+		name: {Name: name, URL: url},
+	}}
+	r := httptest.NewRequest(http.MethodPost, "/api/apps/data", nil)
+	return r.WithContext(store.WithServices(r.Context(), &store.Services{
+		Mode:          store.ModePlatform,
+		TeamA2AAgents: agentStore,
+	}))
 }
 
 func TestNormalizeAgentName(t *testing.T) {


### PR DESCRIPTION
## Summary
- select the first compatible ordered JSON-RPC interface from Agent Card `supportedInterfaces`
- keep the configured URL as the discovery anchor while routing JSON-RPC and SSE calls to the advertised endpoint
- apply endpoint/version selection consistently across generated tools, manager refreshes, and app A2A data sources
- preserve legacy fallback when `supportedInterfaces` is absent and fail explicitly for incompatible advertised lists
- document routing, refresh, and credential security behavior

## Tests
- `go test ./pkg/a2aclient ./pkg/api`
- `go test ./...`
- `make lint`
- `git diff --check`