### PR TITLE
fix: skills picker overlay, live reload, create_skill content + frontmatter guard

### DIFF
--- a/docs/architecture/skills-multi-file-clawhub-support.md
+++ b/docs/architecture/skills-multi-file-clawhub-support.md
@@ -1,315 +1,181 @@
 # Multi-File ClawHub Skill Support
 
-**Status:** Draft  
-**Date:** 2026-05-29  
+**Status:** Implemented
+
+**Originally drafted:** 2026-05-29
+
 **Author:** Astonish Team
 
-## Problem Statement
+## Overview
 
-Astonish currently supports ClawHub skills only as single-file `SKILL.md` documents stored in the database. Many real-world ClawHub skills (and the OpenClaw reference implementation) use a multi-file directory structure:
+Astonish supports the standard multi-file skill layout used by ClawHub and OpenClaw:
 
-- `SKILL.md` (required)
-- `scripts/` — helper scripts the agent can execute
-- `references/` — documentation the agent can read on demand
-- `assets/` — templates and resources
-
-Current limitations:
-- Only the `SKILL.md` content is stored (in the `skills.content` column).
-- Auxiliary files from ClawHub ZIP downloads are discarded.
-- The agent has no way to discover or load additional files belonging to a skill.
-- This blocks adoption of the majority of useful community skills on ClawHub.
-
-## Goals
-
-1. **Full ClawHub compatibility** — Support the standard multi-file skill layout used by OpenClaw/ClawHub.
-2. **Preserve the `skill_lookup` model** — Keep explicit, controllable loading via tools instead of eager injection.
-3. **Strong isolation** — Skill files must never require host-to-container bind mounts when sandbox is enabled.
-4. **Centralized storage** — All skill content lives in the platform database (works for both SQLite and PostgreSQL in multi-instance K8s deployments).
-5. **Security by default** — Size limits, no arbitrary binary execution, clear provenance.
-
-## Non-Goals (for v1)
-
-- Executing pre-compiled binaries shipped inside skills (`bin/`).
-- Full dependency/install-spec resolution (`metadata.openclaw.install`).
-- Per-skill configuration/env injection.
-- Skill publishing or verification flows.
-
-## Design
-
-### 1. Database Schema
-
-We will use **Option A** (separate table) for minimal disruption:
-
-#### New Table: `skill_files`
-
-```sql
-CREATE TABLE skill_files (
-    id              TEXT PRIMARY KEY,
-    skill_id        TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
-    path            TEXT NOT NULL,           -- relative directory, e.g. "scripts" or ""
-    filename        TEXT NOT NULL,           -- e.g. "helper.sh" or "SKILL.md"
-    content         TEXT NOT NULL,           -- file contents (text only)
-    is_executable   BOOLEAN NOT NULL DEFAULT false,
-    size_bytes      INTEGER NOT NULL,
-    created_at      TEXT NOT NULL,
-    updated_at      TEXT NOT NULL,
-
-    UNIQUE(skill_id, path, filename)
-);
+```text
+my-skill/
+├── SKILL.md
+├── scripts/
+│   └── deploy.sh
+├── references/
+│   └── api.md
+└── assets/
+    └── template.yaml
 ```
 
-**Notes:**
-- `path` is the directory portion (empty string for root).
-- `filename` is just the basename.
-- Only text files are supported in v1 (`content` is `TEXT`).
-- Binary files are rejected during import.
-- The existing `skills` table remains unchanged (it continues to store the canonical `SKILL.md` in the `content` column for backwards compatibility and fast lookup).
+`SKILL.md` is required. Auxiliary files may be nested recursively under arbitrary directories. The agent first loads the main instructions and a file manifest, then reads individual supporting files on demand.
 
-Equivalent tables are created in both SQLite (per-team + org) and PostgreSQL schemas.
+## Goals and Constraints
 
-### 2. Tool Interface
+The implementation provides:
 
-#### `skill_lookup` (enhanced)
+1. **Multi-file compatibility** — Preserve and expose scripts, references, templates, and other auxiliary text files.
+2. **Progressive disclosure** — Keep the main prompt small and load supporting files through `skill_lookup` only when needed.
+3. **Mode isolation** — Code sessions use filesystem skills and built-ins only; they never query database-backed skill stores.
+4. **Deterministic precedence** — Resolve same-named skills case-insensitively according to the active mode.
+5. **Safe filesystem access** — Reject traversal and symlink escapes and enforce a 256 KiB per-file read limit.
+6. **Safe local creation** — Let the agent scaffold a local skill without overwriting existing content.
 
-Existing signature continues to work:
+Pre-compiled skill binaries and automatic dependency installation remain unsupported. A skill may provide a script as text, but executing it is a separate, explicit agent action subject to the normal tool and sandbox controls.
+
+## Discovery and Precedence
+
+### Filesystem Sources
+
+Filesystem loading begins with the configured user skills directory and then processes configured extra skills roots in order. Each root contains immediate child directories with a `SKILL.md` file.
+
+Names are normalized case-insensitively for both collision handling and allowlist filtering. A later root replaces an earlier same-named skill:
+
+```text
+configured user directory < first extra root < ... < last extra root
+```
+
+The optional allowlist is applied to the merged result and also matches case-insensitively. Built-in skills are the lowest static source; a same-named filesystem skill wins over a built-in.
+
+### Code Mode
+
+Code mode receives only:
+
+- built-in skills; and
+- the merged, allowlisted filesystem skills described above.
+
+It does **not** read platform, organization, or team database skills. This remains true even if database stores are present in the surrounding application context.
+
+### Platform Mode
+
+Platform mode overlays database-backed scopes on the static filesystem/built-in base. Same-name comparisons are case-insensitive, with this precedence:
+
+```text
+filesystem and built-ins < platform < organization < team
+```
+
+Lookup checks the most specific database scope first (team, then organization, then platform) and falls back to the filesystem/built-in definition. The rendered skill index uses the equivalent low-to-high overlay order, yielding one entry per case-insensitive name.
+
+## Tool Interface
+
+### `skill_lookup`
+
+Loading a skill root uses the existing signature:
+
 ```json
 { "name": "docker" }
 ```
 
-New parameters for multi-file access:
-```json
-{
-  "name": "docker",
-  "file": "scripts/deploy.sh"     // or
-  "path": "scripts",
-  "filename": "deploy.sh"
-}
-```
-
-**Revised behavior (inspired by Hermes progressive disclosure):**
-
-- If only `name` is provided → returns the main `SKILL.md` **plus** a `files` manifest showing all available auxiliary files for that skill (no separate discovery call needed).
-- If `file` (or `path`+`filename`) is provided → returns that specific file from `skill_files`.
-
-Example response when loading the skill root:
+For a filesystem skill, the response contains the parsed `SKILL.md` instructions and a recursive manifest of regular files:
 
 ```json
 {
   "name": "docker",
   "description": "Container management with Docker",
   "content": "# Docker\n\n## Building Images\n...",
-  "files": {
-    "scripts": ["scripts/deploy.sh", "scripts/cleanup.sh"],
-    "references": ["references/best-practices.md"],
-    "templates": ["templates/Dockerfile.tmpl"]
+  "files": [
+    "SKILL.md",
+    "references/best-practices.md",
+    "scripts/deploy.sh"
+  ],
+  "files_manifest": {
+    "": ["SKILL.md"],
+    "references": ["best-practices.md"],
+    "scripts": ["deploy.sh"]
   }
 }
 ```
 
-This approach reduces tool calls and ensures the model immediately knows what additional files exist for the skill.
+The agent can load one auxiliary file using either form:
 
-### 3. System Prompt Instructions
-
-The skill index section (already present via `BuildSkillIndex`) will be extended with guidance:
-
-> **Multi-file skills**: Many skills contain additional files (`scripts/`, `references/`, `templates/`, etc.).
->
-> When you call `skill_lookup(name)` on a skill, the response includes a `files` manifest listing all available auxiliary files. Use `skill_lookup(name, file: "scripts/foo.sh")` (or `path` + `filename`) to load any specific file.
->
-> Relative paths mentioned inside a skill's `SKILL.md` must be resolved by loading them via `skill_lookup`.
->
-> Never attempt to execute or reference files from a skill unless you first loaded them through `skill_lookup`.
-
-This design (inspired by Hermes) ensures the model discovers auxiliary files in the same call that loads the main skill content, reducing unnecessary tool calls.
-
-### 4. ClawHub Install Flow
-
-When a user runs `astonish skills install <slug>` (or the future Studio equivalent):
-
-1. Download the ZIP from the ClawHub registry endpoint.
-2. Extract the archive in memory.
-3. Locate `SKILL.md` (required).
-4. Parse frontmatter (name, description, metadata).
-5. Insert/update the main row in `skills` (name + full `SKILL.md` content).
-6. For every other file in the archive:
-   - If it is a text file and ≤ 256 KiB → insert into `skill_files`.
-   - If binary or too large → log a warning and skip (with clear message to the user).
-7. Store ClawHub provenance (slug, version, installed_at) — either in an extended `_meta` column or a small side table (future).
-
-The same logic will apply to manual uploads via the Studio UI.
-
-### 5. Runtime Execution Model (Sandbox vs Non-Sandbox)
-
-**When sandbox is enabled (the common case in platform deployments):**
-
-- `skill_lookup` runs on the host (it queries the DB).
-- When the agent calls `skill_lookup(name)`, it receives both the SKILL.md content **and** the `files` manifest in one response.
-- To load a specific auxiliary file, the agent calls `skill_lookup(name, file: "...")`.
-- The tool returns the content.
-- The agent uses `write_file` to place the content inside the session container at a well-known temporary location (e.g. `/tmp/skills/<skill-name>/scripts/deploy.sh`).
-- The agent then uses `shell_command` (which executes inside the container) to run it.
-
-**Benefits:**
-- No host paths are ever leaked into the container.
-- Full isolation is preserved.
-- The agent is in control of what gets materialized inside the sandbox.
-
-**When sandbox is disabled:**
-- The agent can still use `write_file` + `shell_command`, or the system can optionally write files to a temp directory on the host for convenience. The tool behavior remains the same.
-
-### 6. Limits and Security
-
-- **Per-file limit**: 256 KiB (matching OpenClaw's `SKILL.md` cap). Larger files are rejected at import time.
-- **Total per skill**: 2 MiB (soft limit, configurable later).
-- **Content type**: Only UTF-8 text files are accepted. Binary content is rejected.
-- **No execution of skill-shipped binaries**: Explicitly unsupported in v1 (and likely forever). Only scripts the agent writes into the container via `write_file` may be executed.
-- **Provenance**: All imported files carry metadata about their origin (ClawHub slug + version, or manual upload user + timestamp).
-
-## 7. UI Impact and Changes
-
-The current Studio Skills UI (`web/src/components/settings/SkillsSettings.tsx`) is designed exclusively around single-file skills. It presents each skill as a single CodeMirror editor showing the full `raw_file` (YAML frontmatter + markdown body). There is no concept of auxiliary files in the UI today, even though the backend already sends a `has_directory` flag (currently ignored by the frontend).
-
-Supporting multi-file ClawHub skills requires a significant but manageable evolution of the editor experience.
-
-### 7.1 Current UI State (Single-File Only)
-
-- Skill list shows name + description + eligibility badge.
-- Clicking View/Edit opens a full-screen CodeMirror editor for the entire `SKILL.md`.
-- Create flow: only asks for skill name → generates template → opens editor.
-- No file tree, no tabs, no "Add File" capability.
-- ClawHub installation is CLI-only (a hint message suggests using `astonish skills install`).
-
-### 7.2 Target Editor Experience (Multi-File)
-
-When a skill has auxiliary files, the editor should evolve to a two-pane layout:
-
-```
-┌────────────────────────────────────────────────────────────┐
-│  ← Back to Skills                              [Save All]  │
-├──────────────────────┬─────────────────────────────────────┤
-│ Files                │  SKILL.md  │  scripts/deploy.sh    │
-│                      ├─────────────────────────────────────┤
-│ ▼ my-skill           │                                     │
-│   SKILL.md        ●  │  ---                                │
-│   ▼ scripts          │  name: my-skill                     │
-│     deploy.sh        │  ...                                │
-│     cleanup.sh       │                                     │
-│   ▼ references       │  # My Skill                         │
-│     api.md           │  Instructions...                    │
-│                      │                                     │
-│ [+ Add File]         │                                     │
-│                      │                                     │
-└──────────────────────┴─────────────────────────────────────┘
+```json
+{ "name": "docker", "file": "scripts/deploy.sh" }
 ```
 
-**Key behaviors:**
+```json
+{
+  "name": "docker",
+  "path": "scripts",
+  "filename": "deploy.sh"
+}
+```
 
-- **Single-file skills** (only `SKILL.md`): Keep the current full-screen editor experience (no tree panel) for backwards compatibility.
-- **Multi-file skills**: Show a collapsible file tree on the left.
-- Clicking any file opens it in a tab on the right (CodeMirror with appropriate language mode: markdown, shell, etc.).
-- **[+ Add File]** button allows creating new files under `scripts/`, `references/`, `templates/`, or custom paths.
-- Right-click / hover menu on files supports Rename and Delete (with confirmation; `SKILL.md` cannot be deleted).
-- Files in `scripts/` are visually marked as executable.
-- Changes to any file are tracked; a global "Save All" button saves modified files.
+Database-backed platform skills expose the same main-content, manifest, and individual-file interface. The selected platform scope supplies both the main skill and its auxiliary files.
 
-### 7.3 API Changes Required
+### `create_skill`
 
-The existing skill content API must be extended:
+`create_skill` scaffolds a new skill only beneath the configured local user skills directory. The requested name is trimmed and must contain only ASCII letters, digits, hyphens, and underscores.
 
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| `GET`  | `/api/skills/{name}/content?scope=` | Extend response to include `files: [{path, filename, size, is_executable}]` |
-| `GET`  | `/api/skills/{name}/files` | List all auxiliary files for a skill |
-| `GET`  | `/api/skills/{name}/files/{path}/{filename}` | Retrieve content of one auxiliary file |
-| `PUT`  | `/api/skills/{name}/files/{path}/{filename}` | Create or overwrite an auxiliary file |
-| `DELETE` | `/api/skills/{name}/files/{path}/{filename}` | Delete an auxiliary file |
+Creation is intentionally non-destructive:
 
-New backend handlers will be needed in `pkg/api/skills_handlers.go` to support the file operations (especially for the platform DB stores).
+- It never targets an extra root or a platform database.
+- It uses exclusive filesystem creation and never overwrites an existing directory or `SKILL.md`.
 
-### 7.4 Frontend Component Changes
+The generated scaffold can then be expanded with auxiliary directories and files through ordinary filesystem tools.
 
-Major updates expected in:
+## Secure Auxiliary-File Access
 
-- `SkillsSettings.tsx` — Core editor view will need significant refactoring to support the two-pane + tabbed layout.
-- New component: `SkillFileTree.tsx` — Renders the left-side file explorer.
-- New or extended editor wrapper to manage multiple open tabs and dirty state across files.
-- API client functions in `web/src/api/` or `settingsApi.ts` for the new file endpoints.
+Filesystem manifests walk the complete skill directory recursively, allowing nested paths such as `references/api/v2/auth.md`. The walk includes regular files only and does not follow symlinks.
 
-### 7.5 Create Flow
+Individual reads enforce all of the following:
 
-The "New Skill" modal can remain simple (just name). After creation:
-- The editor opens showing only `SKILL.md`.
-- The user can immediately use `[+ Add File]` to start building the multi-file structure.
+- The requested path must be a clean relative path.
+- Absolute paths, backslashes, empty paths, and `..` traversal are rejected.
+- The candidate path must be contained within the skill root before resolution.
+- Symlinks are resolved before reading, and the resolved target must still be within the resolved skill root.
+- The target must be a regular file.
+- At most **256 KiB** is read; larger files return an error and no partial content.
 
-No need to overcomplicate the initial creation step.
+These checks prevent a skill from exposing arbitrary host files through crafted paths or symlinks. Database auxiliary-file reads enforce the same 256 KiB limit.
 
-### 7.6 ClawHub Install UI (Phase 3)
+**Threat-model boundary:** The traversal and resolved-root/symlink containment checks protect a filesystem skill tree that remains stable during each lookup. The tree is expected not to be concurrently and adversarially mutated while validation and reading are in progress. Because lookup uses pathname-based filesystem APIs rather than descriptor-relative `openat`-style operations, it does not provide race hardening against an attacker who can rename or replace path components between checks and use. This concurrency assumption does not relax any of the traversal, symlink-resolution, containment, regular-file, or size checks above.
 
-A future "Install from ClawHub" button in the skills list header can:
-- Accept a ClawHub slug or URL.
-- Call a new `POST /api/skills/install` endpoint.
-- Show the number of files imported and open the skill in the new multi-file editor.
+## Runtime Execution Model
 
-This is lower priority; the CLI path works well in the meantime.
+### Sandbox Enabled
 
-### 7.7 Backwards Compatibility
+`skill_lookup` returns file content to the agent rather than exposing or mounting a host skill path into the sandbox. If a script is needed, the agent can explicitly materialize the returned text inside the session using `write_file`, inspect it, and then invoke `shell_command` under the sandbox's normal policy.
 
-- Skills that only contain `SKILL.md` continue to render exactly as today.
-- The file tree panel only appears when the `files` array returned by the API is non-empty (or when `has_directory` is true).
-- Existing single-file skills require zero changes from users.
+Benefits:
 
-## Implementation Phases
+- No skill-directory bind mount is required.
+- Host paths need not be usable from the container.
+- The agent materializes only files needed for the current task.
+- Existing sandbox command and network controls continue to apply.
 
-### Phase 1: Foundation (DB + Tools)
+### Sandbox Disabled
 
-- Add `skill_files` table (and equivalent org/team versions) + migrations.
-- Extend `skill_lookup` so that calling it with only `name` returns the main content + a `files` manifest of auxiliary files.
-- Extend `skill_lookup` to accept `file` / `path`+`filename` parameters to fetch specific files from `skill_files`.
-- Update system prompt instructions to reflect the single-tool progressive disclosure model.
-- Add basic validation + size limits at import time.
+The lookup contract is unchanged. The agent may use returned content directly or write it to an appropriate temporary/work directory before execution.
 
-### Phase 2: ClawHub Import
+## Terminal Experience
 
-- Modify `DownloadFromClawHub` + CLI install path to populate `skill_files`.
-- Add support for importing multi-file ZIPs via the existing `skills install` command.
-- Update tests.
+The terminal UI provides `/skills` when the backend supports local skill summaries. The command lists available skills and eligibility/source information directly without starting an LLM turn. It reports an unsupported message when that capability is unavailable.
 
-### Phase 3: Agent Experience & Polish (including Studio UI)
+## Storage and UI Notes
 
-- Finalize the `files` manifest format returned by `skill_lookup(name)`.
-- Add clear error messages when a skill references a file that doesn't exist in the manifest.
-- Implement full multi-file support in the Studio Skills editor:
-  - File tree sidebar + tabbed CodeMirror editor
-  - Add / Rename / Delete file operations
-  - Support for executable flag on scripts
-- Extend backend skill content APIs to return file manifests and support file CRUD.
-- Update documentation and bundled skill examples if needed.
-- Ensure `skill_lookup` (with file support) is included in the default tool allowlist.
+Filesystem multi-file skills remain directories on disk. Platform, organization, and team skills may store main and auxiliary content in their scoped stores. Code mode does not consult those stores.
 
-### Phase 4: Future (out of scope for v1)
+Studio can continue to present `SKILL.md` as the primary editor while progressively adding file-tree editing for auxiliary files. Regardless of UI capabilities, the runtime `skill_lookup` interface already supports manifests and individual auxiliary-file reads.
 
-- ClawHub lockfile / version tracking
-- `skills update` command
-- ClawHub install UI in Studio (Phase 3 has the editor; full install flow is future)
-- Install-spec evaluation (`metadata.openclaw.install`)
-- Per-skill configuration
-- Binary file support (explicitly out of scope)
+## Implementation References
 
-## Open Questions
-
-- Should we allow the agent to request a "bulk load" of small files in one call, or keep it strictly one-file-at-a-time via repeated `skill_lookup` calls?
-- Do we want a size-based heuristic that automatically inlines very small auxiliary files (< 2 KiB) directly in the `skill_lookup` response?
-- How (if at all) do we want to surface the existence of auxiliary files in the lightweight skill index shown in the system prompt (vs. only revealing them when the model calls `skill_lookup` on the skill)?
-
-## References
-
-- Existing skills architecture: `docs/architecture/skills.md`
-- OpenClaw skill layout and loading: `/root/openclaw` (reference implementation)
-- Hermes agent skills system: `/root/hermes-agent` — particularly its progressive disclosure model using `skills_list` + `skill_view(name)` (which returns a `linked_files` manifest) + `skill_view(name, file_path)`. This directly influenced the decision to embed the file manifest in the primary `skill_lookup` response instead of using a separate `skill_tree` tool.
-- Current `skill_lookup` implementation: `pkg/tools/skill_lookup.go`
-- ClawHub download logic: `pkg/skills/clawhub.go`
-- Skill store interfaces: `pkg/store/skills.go`
-
----
-
-**Next step:** Once this document is approved, we will begin Phase 1 implementation.
+- Filesystem loading and precedence: `pkg/skills/loader.go`
+- Built-in skills: `pkg/skills/bundled.go`
+- Main and auxiliary-file lookup: `pkg/tools/skill_lookup.go`
+- Safe local scaffolding: `pkg/tools/create_skill.go`
+- Platform/org/team overlay: `pkg/channels/manager.go`
+- Terminal `/skills`: `pkg/tui/skills.go`
+- General skills architecture: [skills.md](./skills.md)

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Skills are markdown-based guides that teach the AI agent how to use specific CLI tools and platforms. Each skill document describes capabilities, commands, patterns, and best practices for a technology (git, Docker, Kubernetes, Terraform, etc.). Skills are indexed in the vector store and retrieved automatically when the user's request matches a skill's domain.
+Skills are markdown-based guides that teach the AI agent how to use specific CLI tools, APIs, platforms, and workflows. Each skill has a required `SKILL.md` and may include auxiliary files such as scripts, references, and templates. The system exposes a lightweight list of available skills and lets the agent load full instructions and supporting files on demand with `skill_lookup`.
 
 ## Key Design Decisions
 
@@ -28,110 +28,123 @@ requires:
 This format was chosen because:
 
 - **Human-readable and editable**: Anyone can write or modify a skill.
-- **LLM-friendly**: Markdown is the format LLMs are most comfortable consuming and producing.
+- **LLM-friendly**: Markdown is a natural format for model instructions.
 - **Structured metadata**: YAML frontmatter provides machine-parseable eligibility criteria without polluting the content.
 - **Version-controllable**: Plain text files work naturally with git.
+- **Compatible with multi-file skills**: A skill directory can keep focused details in auxiliary files and reveal them only when needed.
 
 ### Why Eligibility Checking
 
-Not all skills are relevant to every environment. A Kubernetes skill is useless if `kubectl` isn't installed. Eligibility checking validates:
+Not all skills are relevant to every environment. Eligibility checking validates:
 
 - **OS**: The skill applies to the current operating system.
 - **Binaries**: Required CLI tools are installed (checked via `exec.LookPath`).
-- **Environment variables**: Required env vars are set.
+- **Environment variables**: Required environment variables are set.
 
-Ineligible skills are excluded from indexing, preventing the agent from attempting operations that will fail due to missing prerequisites.
+Missing requirements are reported with the skill so the agent can avoid blindly attempting operations that cannot succeed.
 
-### Why Bundled Skills Plus Marketplace
+### Why Filesystem Skills Plus Platform Scopes
 
-Astonish ships with 10 bundled skills covering common tools. But organizations and communities may need custom skills for their specific toolchains. The **ClawHub marketplace** provides:
+Local and Code sessions load filesystem skills from the configured user skills directory first, followed by each configured extra skills root in order. Each root contains one immediate subdirectory per skill, with `SKILL.md` at the skill root.
 
-- A registry of community-contributed skills.
-- Install/uninstall via the CLI or Studio.
-- Skills are downloaded to the local skills directory and indexed alongside bundled ones.
+An optional allowlist filters the merged result. Allowlist matching and skill-name collision matching are case-insensitive. Later filesystem roots replace earlier definitions with the same name, so the precedence is:
 
-### Why Directory Watching
+```text
+configured user skills directory < first extra root < ... < last extra root
+```
 
-Skills can be added, modified, or removed at any time. An `fsnotify` file watcher detects changes and triggers re-indexing automatically. This means:
+Built-in skills are also available. Filesystem skills override built-ins on a case-insensitive name collision.
 
-- Installing a new skill from the marketplace is immediately available.
-- Editing a skill file updates the vector index without restart.
-- Removing a skill removes it from retrieval.
+Code mode deliberately uses only this filesystem-plus-built-ins view. It does not read platform, organization, or team skill databases.
+
+Platform sessions add database-backed scopes. Their case-insensitive collision precedence is:
+
+```text
+filesystem and built-ins < platform < organization < team
+```
+
+Thus the most specific available definition wins while unrelated skills from every scope remain visible.
+
+### Why Progressive Disclosure
+
+The system prompt includes only skill names and one-line descriptions. Calling `skill_lookup` with a skill name returns the main instructions plus a manifest of auxiliary files. The agent can then request one file by relative path. This keeps the prompt small while making complete multi-file skills available when needed.
 
 ## Architecture
 
 ### Skill Discovery and Retrieval
 
-```
+```text
 User message: "Deploy the app to our Kubernetes cluster"
     |
     v
-Auto-knowledge retrieval (vector + BM25 search)
+Available Skills index identifies the kubernetes skill
     |
     v
-Matches: kubernetes skill (high relevance)
+Agent calls skill_lookup(name: "kubernetes")
     |
     v
-Skill content injected into system prompt (Tier 3 dynamic knowledge)
+SKILL.md and an auxiliary-file manifest are returned
     |
     v
-Agent uses Kubernetes commands and patterns from the skill
+Agent loads only the referenced scripts or documentation it needs
 ```
 
-The `skill_lookup` tool also allows the agent to explicitly search for skills mid-turn.
+Filesystem discovery loads the configured user root and then configured extra roots. The merged, allowlisted result is used by Local and Code sessions. Platform sessions overlay database skills using platform, organization, and team precedence.
 
-### Skill Index in System Prompt
+### Skill Index in the System Prompt
 
-The system prompt (Tier 1 static) includes a lightweight skill listing -- just names and one-line descriptions:
+The system prompt includes a lightweight skill listing rather than every skill body:
 
-```
+```text
 Available Skills: git (version control), docker (containers), kubernetes (orchestration), ...
 ```
 
-This tells the agent what skills exist without consuming tokens for full content. When a skill is relevant, the full content is retrieved from the vector store.
+This tells the agent what exists without consuming tokens for full content. `skill_lookup` provides explicit, on-demand access to the selected skill.
 
-### Bundled Skills
+### Multi-File Lookup and Security
 
-| Skill | Description |
-|---|---|
-| git | Version control operations, branching, merging |
-| github | GitHub CLI, issues, PRs, releases |
-| docker | Container management, Compose, images |
-| kubernetes | kubectl, deployments, services, pods |
-| terraform | Infrastructure as code, state management |
-| aws | AWS CLI, common services |
-| gcloud | Google Cloud CLI, projects, services |
-| npm | Node.js package management, scripts |
-| python | Python development, pip, venv, uv |
-| web-registration | Web portal account creation patterns |
+For a filesystem skill, `skill_lookup(name)` recursively lists regular files beneath the skill directory and returns both a sorted file list and a directory-grouped manifest. A request can use either `file`, or `path` plus `filename`, to read a specific auxiliary file.
 
-### Memory Integration
+Filesystem access is constrained as follows:
 
-Skills are indexed in the same vector store as other memory documents, under the "skill" category. This means:
+- Paths must be clean, relative paths; absolute paths, backslashes, and `..` traversal are rejected.
+- Recursive manifests skip symlinks and non-regular files.
+- A requested file is resolved through symlinks and must still be contained within the resolved skill root.
+- Only regular files are returned.
+- Reads are capped at **256 KiB per file**; larger files are rejected.
 
-- Skills participate in the same hybrid search (vector + BM25) as general knowledge.
-- The `CategoryFromPath` function assigns the "skill" category based on file location.
-- Skills can be filtered by category for targeted retrieval.
+Database-backed platform auxiliary files use the same lookup interface and 256 KiB read limit.
+
+See [Multi-File ClawHub Skill Support](./skills-multi-file-clawhub-support.md) for the detailed multi-file design.
+
+### Built-in Skills
+
+Astonish includes built-in skills for common tools and workflows. They form the lowest static layer: a same-named filesystem skill replaces a built-in before any platform database overlays are applied.
+
+### Agent-Created Skills
+
+The `create_skill` tool creates a new scaffold only in the configured local user skills directory. It validates the requested name and creates a new skill directory containing `SKILL.md`. It never writes to extra roots or platform databases, and it refuses to overwrite an existing skill directory or `SKILL.md`.
+
+### Terminal Command
+
+The terminal UI exposes `/skills` when the active backend supports local skill listing. It renders the available skill summaries directly and does not send an agent turn. Platform-only or otherwise unsupported backends report that the command is unavailable.
 
 ## Key Files
 
 | File | Purpose |
 |---|---|
-| `pkg/skills/skills.go` | Skill loading, eligibility checking, directory management |
-| `pkg/skills/bundled.go` | Embedded bundled skill files |
-| `pkg/skills/marketplace.go` | ClawHub marketplace integration |
-| `pkg/skills/watcher.go` | fsnotify-based directory watching for live updates |
-| `pkg/tools/skill_lookup.go` | skill_lookup tool for explicit skill search |
+| `pkg/skills/loader.go` | Filesystem loading, allowlist filtering, precedence, and eligibility metadata |
+| `pkg/skills/bundled.go` | Embedded built-in skill files |
+| `pkg/tools/skill_lookup.go` | Mode-aware main and auxiliary-file lookup |
+| `pkg/tools/create_skill.go` | Safe local skill scaffold creation |
+| `pkg/channels/manager.go` | Platform/org/team skill-index overlay |
+| `pkg/tui/skills.go` | Terminal `/skills` rendering |
 
 ## Interactions
 
-- **Memory**: Skills are indexed in the vector store for automatic retrieval. Category-based filtering allows partitioned searches.
-- **Agent Engine**: Skill content is injected into the system prompt via Tier 3 dynamic knowledge. The skill index (Tier 1) lists available skills.
-- **Configuration**: Skill directory is configured in app config. Custom skill paths can be added.
-- **Daemon**: Skill indexer initializes at daemon startup with fsnotify watcher.
-
-## Multi-File ClawHub Skills (Planned)
-
-The current system stores only the main `SKILL.md` content per skill. A future enhancement will add full support for the standard ClawHub multi-file layout (`scripts/`, `references/`, etc.) using a dedicated `skill_files` table, an enhanced `skill_lookup` tool, and a new `skill_tree` tool.
-
-See: [skills-multi-file-clawhub-support.md](./skills-multi-file-clawhub-support.md) for the detailed design and implementation plan.
+- **Agent Engine**: The system prompt lists available skills; the agent calls `skill_lookup` for full content.
+- **Code mode**: Uses filesystem skills and built-ins only and never consults database skill stores.
+- **Platform**: Adds database-backed skills with filesystem `<` platform `<` organization `<` team precedence.
+- **Configuration**: Defines the user skills directory, ordered extra roots, and optional allowlist.
+- **ClawHub**: Installed multi-file skills retain their auxiliary files for progressive lookup.
+- **Terminal UI**: `/skills` lists available local skills without invoking the model.

--- a/docs/website/docs/agent/skills.md
+++ b/docs/website/docs/agent/skills.md
@@ -1,56 +1,98 @@
 # Skills
 
-Skills are markdown-based instruction files that teach the agent specific tools, APIs, workflows, or domain knowledge. They are loaded on demand when a task matches a skill's description.
+Skills are markdown-based instruction packages that teach the agent specific tools, APIs, workflows, or domain knowledge. Every skill has a `SKILL.md`; it may also include scripts, references, templates, and other auxiliary text files that the agent loads on demand.
 
 ## How Skills Work
 
-When you ask the agent to perform a task, it checks available skills for relevance. If a match is found, the skill's content is injected into the agent's context, giving it detailed instructions for the task.
+The agent sees a lightweight list of available skill names and descriptions. When a skill is relevant, it uses `skill_lookup` to load the full instructions. For a multi-file skill, that first lookup also returns a manifest so the agent can request only the supporting files it needs.
 
 Skills differ from memory:
+
 - **Memory** = facts the agent has learned (declarative knowledge)
 - **Skills** = instructions for how to do things (procedural knowledge)
 
 ## Skill Structure
 
-A skill is a markdown file with a specific structure:
+A filesystem skill is a directory with a required `SKILL.md`:
 
-```markdown
-# Skill Name
-
-## Description
-When this skill applies — used for matching against user requests.
-
-## Instructions
-Detailed steps, commands, code examples, and best practices.
-
-## References
-Links to documentation, API references, etc.
+```text
+my-skill/
+├── SKILL.md
+├── scripts/
+│   └── run.sh
+├── references/
+│   └── api.md
+└── templates/
+    └── config.yaml
 ```
 
-The `Description` section is critical — the agent uses it to determine when to load the skill.
+`SKILL.md` uses YAML frontmatter for its name, description, and optional requirements:
+
+```markdown
+---
+name: my-skill
+description: When and why the agent should use this skill
+requires:
+  binaries: [example-cli]
+---
+
+# My Skill
+
+Detailed steps, commands, examples, and best practices.
+```
+
+The description is critical because it tells the agent when the skill applies. Requirements can describe supported operating systems, required binaries, and required environment variables.
+
+## Filesystem Discovery
+
+Astonish loads filesystem skills from the configured user skills directory first and then from each configured extra skills root in order.
+
+If two skills have the same name ignoring case, the later root wins:
+
+```text
+configured user directory < first extra root < ... < last extra root
+```
+
+An optional skill allowlist is applied case-insensitively after the roots are merged. Built-in skills remain available unless a same-named filesystem skill overrides them.
+
+## Availability by Mode
+
+### Code
+
+Code sessions use only built-in and filesystem skills. They do not load platform, organization, or team skills from the database.
+
+### Platform
+
+Platform-connected sessions combine filesystem/built-in skills with managed scopes. Same-named skills are resolved case-insensitively with this precedence:
+
+```text
+filesystem and built-ins < platform < organization < team
+```
+
+A team skill therefore overrides an organization, platform, or filesystem skill with the same name. Skills with different names are combined and remain available.
 
 ## Managing Skills
 
-Skills are managed through the platform at three scopes:
+Managed skills are available at three platform scopes:
 
 | Scope | Managed By | Available To |
 |-------|------------|-------------|
 | Platform | Platform admin | All users |
-| Org | Org admin | All org members |
+| Organization | Organization admin | All organization members |
 | Team | Team admin | Team members |
 
 ### In Studio
 
-Studio provides the primary interface for skill management:
+Depending on your permissions and deployment, Studio lets you:
 
 - Browse available skills
-- Create and edit skills
-- Install skills from ClawHub (community repository)
-- Configure skill scoping (team/org)
+- Create and edit managed skills
+- Install skills from ClawHub
+- Configure platform, organization, or team scope
 
 ### CLI
 
-The CLI provides read access to skills (requires platform connection):
+The CLI provides skill management commands:
 
 ```bash
 astonish skills list              # List available skills
@@ -63,28 +105,63 @@ astonish skills create <name>     # Create a new skill template
 The CLI command is `astonish skills` (plural), not `astonish skill`.
 :::
 
+### Agent-Created Local Skills
+
+The agent's `create_skill` tool creates a scaffold only in the configured local user skills directory. It never creates a platform, organization, or team database skill and never writes to an extra skills root.
+
+Creation does not overwrite anything. The tool rejects an existing skill directory and creates `SKILL.md` exclusively.
+
+### Terminal `/skills`
+
+In a terminal session with local skill-listing support, enter:
+
+```text
+/skills
+```
+
+The command displays available skill summaries directly; it does not send a request to the model. If the active backend does not expose local skill summaries, the terminal reports that `/skills` is unsupported.
+
 ## ClawHub Community Skills
 
-The [ClawHub](https://github.com/astonish-clawhub) organization hosts community-contributed skills covering common tools and workflows. Install them via Studio or CLI.
+The [ClawHub](https://github.com/astonish-clawhub) organization hosts community-contributed skills covering common tools and workflows. Multi-file packages retain their auxiliary files so the agent can discover and load scripts, references, and templates as needed.
 
-## Agent Tool: skill_lookup
+## Agent Tool: `skill_lookup`
 
-During chat, the agent can search for relevant skills using the `skill_lookup` tool:
+Load a skill's main instructions by name:
 
-```
+```yaml
 skill_lookup:
-  name: "docker"
+  name: docker
 ```
 
-This loads the full skill instructions into the agent's context for the current task.
+The response includes `SKILL.md` content and, for multi-file skills, a recursive manifest. Load a specific supporting file with a relative path:
+
+```yaml
+skill_lookup:
+  name: docker
+  file: references/best-practices.md
+```
+
+You can equivalently supply `path` and `filename` separately.
+
+### Auxiliary-File Safety
+
+Filesystem auxiliary-file access is constrained for safety:
+
+- Manifests recurse through nested directories but include regular files only and do not follow symlinks.
+- File paths must be clean and relative; absolute paths and `..` traversal are rejected.
+- Symlinks are resolved before a file is read, and the target must remain inside the skill directory.
+- Each auxiliary-file read is limited to **256 KiB**; larger files are rejected.
+
+These protections prevent a skill from using a path or symlink to read unrelated host files.
 
 ## Cascading Access
 
 Skills cascade through the platform hierarchy (see [Cascading Defaults](../platform/cascading-defaults.md)):
 
-- Platform skills are available to everyone
-- Org skills are available to all org members
-- Team skills are available to team members
-- Skills from higher scopes cannot be removed at lower scopes, only supplemented
+- Platform skills are available to everyone.
+- Organization skills are available to all organization members.
+- Team skills are available to team members.
+- Lower, more specific scopes override same-named higher-scope skills; they supplement skills with different names.
 
 See [Sub-agents](./sub-agents.md) for how delegated tasks inherit skill access, and [Configuration](../configuration/mcp-servers.md) for MCP servers (another way to extend agent capabilities).

--- a/pkg/agent/sub_agent.go
+++ b/pkg/agent/sub_agent.go
@@ -54,11 +54,11 @@ type SubTaskProgressEvent struct {
 	ToolResult any    `json:"tool_result,omitempty"` // Tool result (for task_tool_result)
 	Text       string `json:"text,omitempty"`        // Text output (for task_text)
 	// Fields for plan_announced
-	PlanGoal         string         `json:"plan_goal,omitempty"`          // Plan title (for plan_announced)
-	PlanSteps        []PlanStepInfo `json:"plan_steps,omitempty"`         // Plan steps (for plan_announced)
-	PlanContext      string         `json:"plan_context,omitempty"`       // Context section (for plan_announced)
+	PlanGoal         string         `json:"plan_goal,omitempty"`           // Plan title (for plan_announced)
+	PlanSteps        []PlanStepInfo `json:"plan_steps,omitempty"`          // Plan steps (for plan_announced)
+	PlanContext      string         `json:"plan_context,omitempty"`        // Context section (for plan_announced)
 	PlanWhatNotToDo  string         `json:"plan_what_not_to_do,omitempty"` // What not to change (for plan_announced)
-	PlanVerification string         `json:"plan_verification,omitempty"`  // End-to-end smoke test (for plan_announced)
+	PlanVerification string         `json:"plan_verification,omitempty"`   // End-to-end smoke test (for plan_announced)
 	// Fields for plan_step_update
 	StepName   string `json:"step_name,omitempty"`   // Step name to update (for plan_step_update)
 	StepStatus string `json:"step_status,omitempty"` // New step status: running, complete, failed (for plan_step_update)
@@ -1525,10 +1525,15 @@ func (m *SubAgentManager) buildChildPrompt(ctx context.Context, task SubAgentTas
 	}
 
 	// Inject skill index so sub-agents know which skills exist and can
-	// call skill_lookup to load them on demand.
-	if m.SkillIndex != "" {
+	// call skill_lookup to load them on demand. A request-scoped platform index
+	// takes precedence over the manager's static filesystem fallback.
+	skillIndex := m.SkillIndex
+	if overrides := PromptOverridesFromContext(ctx); overrides != nil && overrides.SkillIndex != "" {
+		skillIndex = overrides.SkillIndex
+	}
+	if skillIndex != "" {
 		sb.WriteString("\n")
-		sb.WriteString(m.SkillIndex)
+		sb.WriteString(skillIndex)
 	}
 
 	return sb.String()

--- a/pkg/agent/sub_agent_test.go
+++ b/pkg/agent/sub_agent_test.go
@@ -247,6 +247,26 @@ func TestSubAgentManager_BuildChildPromptNoInstructions(t *testing.T) {
 	}
 }
 
+func TestSubAgentManager_BuildChildPromptPrefersRequestSkillIndex(t *testing.T) {
+	mgr := NewSubAgentManager(SubAgentConfig{})
+	mgr.SkillIndex = "STATIC SKILL INDEX"
+	task := SubAgentTask{Name: "worker", Description: "Use a skill"}
+
+	ctx := WithPromptOverrides(context.Background(), &PromptOverrides{SkillIndex: "REQUEST SKILL INDEX"})
+	prompt := mgr.buildChildPrompt(ctx, task)
+	if !contains(prompt, "REQUEST SKILL INDEX") {
+		t.Fatal("prompt missing request-scoped skill index")
+	}
+	if contains(prompt, "STATIC SKILL INDEX") {
+		t.Fatal("prompt included static skill index despite request-scoped override")
+	}
+
+	fallback := mgr.buildChildPrompt(context.Background(), task)
+	if !contains(fallback, "STATIC SKILL INDEX") {
+		t.Fatal("prompt missing static skill index fallback")
+	}
+}
+
 func TestSubAgentManager_BuildChildPromptWithHTTPTools(t *testing.T) {
 	mgr := NewSubAgentManager(SubAgentConfig{})
 	mgr.ToolGroups = map[string]*ToolGroup{

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -234,6 +234,9 @@ type StudioChatComponents struct {
 	ShutdownSandbox   func() // stops containers without destroying (for daemon shutdown)
 	Cleanup           func()
 	SandboxPool       sandbox.ToolNodePool // for adaptive InvalidateSandboxClient
+	// FilesystemSkills is a copy of the exact filesystem skill slice used to
+	// initialize this runtime. Platform DB scopes overlay it at request time.
+	FilesystemSkills []skills.Skill
 }
 
 // ChatManager manages a singleton chat agent for Studio chat.
@@ -1066,16 +1069,11 @@ func StudioChatHandler(w http.ResponseWriter, r *http.Request) {
 		runner.InjectDrillReportStore(svc.DrillReports)
 	}
 
-	// Inject tenant-scoped skill stores into the runner context so that
-	// the skill_lookup tool can resolve skills from platform, org, and team stores.
-	if svc := store.FromRequest(r); svc != nil && (svc.PlatformSkills != nil || svc.Skills != nil || svc.TeamSkills != nil) {
+	// DB-backed skills are a platform-only runtime capability. Overlay them on
+	// the exact filesystem slice used to initialize this component set.
+	if svc := store.FromRequest(r); svc != nil && svc.Mode == store.ModePlatform {
 		runner.InjectSkillStores(svc.PlatformSkills, svc.Skills, svc.TeamSkills)
-
-		// Build and inject a merged skill index (platform + org + team) so the LLM
-		// sees custom platform skills in the "Available Skills" section of the system prompt.
-		if merged := buildMergedSkillIndex(r.Context(), svc.PlatformSkills, svc.Skills, svc.TeamSkills); merged != "" {
-			runner.InjectSkillIndex(merged)
-		}
+		runner.InjectSkillIndex(buildMergedSkillIndex(r.Context(), comp.FilesystemSkills, svc.PlatformSkills, svc.Skills, svc.TeamSkills))
 	}
 
 	// Inject tenant-scoped MCP server stores into the runner context so that
@@ -1696,83 +1694,54 @@ func extractAppFromSystemContext(systemContext string) (code, title string) {
 	return code, title
 }
 
-// buildMergedSkillIndex builds a skill index string containing platform skills
-// plus any org-level and team-level skills from the platform DB.
-// This is used to populate the "Available Skills" section in the system prompt
-// so the LLM knows about custom platform skills and will call skill_lookup for them.
-func buildMergedSkillIndex(ctx context.Context, platformStore, orgStore, teamStore store.SkillStore) string {
-	var all []skills.Skill
+// buildMergedSkillIndex overlays platform, org, and team DB skills on the
+// filesystem base. Names are matched case-insensitively and later scopes win.
+func buildMergedSkillIndex(ctx context.Context, filesystem []skills.Skill, platformStore, orgStore, teamStore store.SkillStore) string {
+	all := append([]skills.Skill(nil), filesystem...)
 
-	// 1. Platform skills (base layer, inherited by all orgs/teams)
-	if platformStore != nil {
-		if platformSkills, err := platformStore.LoadAll(ctx); err == nil {
-			for _, s := range platformSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "platform",
-				})
-			}
+	for _, tier := range []struct {
+		name  string
+		store store.SkillStore
+	}{
+		{name: "platform", store: platformStore},
+		{name: "org", store: orgStore},
+		{name: "team", store: teamStore},
+	} {
+		if tier.store == nil {
+			continue
+		}
+		stored, err := tier.store.LoadAll(ctx)
+		if err != nil {
+			continue
+		}
+		for _, s := range stored {
+			all = append(all, skills.Skill{
+				Name:        s.Name,
+				Description: s.Description,
+				OS:          s.OS,
+				RequireBins: s.RequireBins,
+				RequireEnv:  s.RequireEnv,
+				Source:      tier.name,
+			})
 		}
 	}
 
-	// 2. Org skills (if store available)
-	if orgStore != nil {
-		if orgSkills, err := orgStore.LoadAll(ctx); err == nil {
-			for _, s := range orgSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "org",
-				})
-			}
-		}
-	}
-
-	// 3. Team skills (highest priority, can override org/platform names)
-	if teamStore != nil {
-		if teamSkills, err := teamStore.LoadAll(ctx); err == nil {
-			for _, s := range teamSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "team",
-				})
-			}
-		}
-	}
-
-	if len(all) == 0 {
-		// Even with no platform/org/team skills, BuildSkillIndex will include
-		// built-in skills (e.g. generative-ui). Pass empty slice.
-		return skills.BuildSkillIndex(nil)
-	}
-
-	// Deduplicate preferring later entries (team > org > platform).
-	// Reverse-iterate and collect, then reverse to preserve original order — O(n).
-	seen := make(map[string]bool, len(all))
-	var deduped []skills.Skill
+	seen := make(map[string]struct{}, len(all))
+	deduped := make([]skills.Skill, 0, len(all))
 	for i := len(all) - 1; i >= 0; i-- {
-		name := strings.ToLower(all[i].Name)
-		if !seen[name] {
-			seen[name] = true
-			deduped = append(deduped, all[i])
+		name := strings.ToLower(strings.TrimSpace(all[i].Name))
+		if name == "" {
+			continue
 		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		deduped = append(deduped, all[i])
 	}
-	// Reverse to restore platform → org → team display order
 	for i, j := 0, len(deduped)-1; i < j; i, j = i+1, j-1 {
 		deduped[i], deduped[j] = deduped[j], deduped[i]
 	}
-
 	return skills.BuildSkillIndex(deduped)
 }
 

--- a/pkg/api/chat_handlers_test.go
+++ b/pkg/api/chat_handlers_test.go
@@ -10,13 +10,65 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/SAP/astonish/pkg/agent"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
+	"github.com/gorilla/mux"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
 )
+
+type apiSkillStore struct {
+	skills []store.Skill
+}
+
+func (s *apiSkillStore) LoadAll(context.Context) ([]store.Skill, error) { return s.skills, nil }
+func (s *apiSkillStore) Get(_ context.Context, name string) (*store.Skill, error) {
+	for i := range s.skills {
+		if strings.EqualFold(s.skills[i].Name, name) {
+			return &s.skills[i], nil
+		}
+	}
+	return nil, nil
+}
+func (s *apiSkillStore) Save(context.Context, *store.Skill) error    { return nil }
+func (s *apiSkillStore) Delete(context.Context, string) error        { return nil }
+func (s *apiSkillStore) List(context.Context) ([]store.Skill, error) { return s.skills, nil }
+func (s *apiSkillStore) UpdateValidationStatus(context.Context, string, string, string) error {
+	return nil
+}
+func (s *apiSkillStore) ListFiles(context.Context, string) ([]store.SkillFile, error) {
+	return nil, nil
+}
+func (s *apiSkillStore) GetFile(context.Context, string, string, string) (*store.SkillFile, error) {
+	return nil, nil
+}
+func (s *apiSkillStore) SaveFile(context.Context, string, *store.SkillFile) error { return nil }
+func (s *apiSkillStore) DeleteFile(context.Context, string, string, string) error { return nil }
+
+func TestBuildMergedSkillIndex_FilesystemBaseAndCaseInsensitiveLaterWins(t *testing.T) {
+	filesystem := []skills.Skill{
+		{Name: "filesystem-only", Description: "filesystem survives"},
+		{Name: "Shared", Description: "filesystem overridden"},
+	}
+	platform := &apiSkillStore{skills: []store.Skill{{Name: "SHARED", Description: "platform overridden"}}}
+	org := &apiSkillStore{skills: []store.Skill{{Name: "shared", Description: "org overridden"}}}
+	team := &apiSkillStore{skills: []store.Skill{{Name: "sHaReD", Description: "team wins"}}}
+
+	result := buildMergedSkillIndex(context.Background(), filesystem, platform, org, team)
+	if !strings.Contains(result, "filesystem survives") || !strings.Contains(result, "team wins") {
+		t.Fatalf("merged index missing base or winning entry:\n%s", result)
+	}
+	for _, overridden := range []string{"filesystem overridden", "platform overridden", "org overridden"} {
+		if strings.Contains(result, overridden) {
+			t.Errorf("overridden entry %q should not be rendered", overridden)
+		}
+	}
+	if count := strings.Count(strings.ToLower(result), "**shared**"); count != 1 {
+		t.Errorf("expected one rendered shared entry, got %d", count)
+	}
+}
 
 // testEvents implements session.Events for testing.
 type testEvents []*session.Event
@@ -310,33 +362,33 @@ func TestReconstructActiveApp_NoAppPreviews(t *testing.T) {
 
 func TestExtractAppFromSystemContext(t *testing.T) {
 	tests := []struct {
-		name       string
-		ctx        string
-		wantCode   string
-		wantTitle  string
+		name      string
+		ctx       string
+		wantCode  string
+		wantTitle string
 	}{
 		{
-			name:     "valid refinement context",
-			ctx:      "## Active App Refinement\n\nSome text.\n\n### Current Source Code\n\n```jsx\nfunction WeatherApp() {\n  return <div>Hello</div>\n}\nexport default WeatherApp\n```\n",
-			wantCode: "function WeatherApp() {\n  return <div>Hello</div>\n}\nexport default WeatherApp",
+			name:      "valid refinement context",
+			ctx:       "## Active App Refinement\n\nSome text.\n\n### Current Source Code\n\n```jsx\nfunction WeatherApp() {\n  return <div>Hello</div>\n}\nexport default WeatherApp\n```\n",
+			wantCode:  "function WeatherApp() {\n  return <div>Hello</div>\n}\nexport default WeatherApp",
 			wantTitle: "Weather App",
 		},
 		{
-			name:     "no refinement marker",
-			ctx:      "Some random system context without the marker",
-			wantCode: "",
+			name:      "no refinement marker",
+			ctx:       "Some random system context without the marker",
+			wantCode:  "",
 			wantTitle: "",
 		},
 		{
-			name:     "refinement marker but no code block",
-			ctx:      "## Active App Refinement\n\nNo code here.",
-			wantCode: "",
+			name:      "refinement marker but no code block",
+			ctx:       "## Active App Refinement\n\nNo code here.",
+			wantCode:  "",
 			wantTitle: "",
 		},
 		{
-			name:     "empty system context",
-			ctx:      "",
-			wantCode: "",
+			name:      "empty system context",
+			ctx:       "",
+			wantCode:  "",
 			wantTitle: "",
 		},
 	}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -43,6 +43,10 @@ type ChannelManager struct {
 	modelName    string
 	toolCount    int
 
+	// Filesystem skills are loaded once when the manager is created, then used
+	// as the base beneath request-scoped platform DB skills.
+	filesystemSkills []skills.Skill
+
 	// LLM provider pool for per-message provider resolution.
 	// When set, each inbound message resolves the effective provider from
 	// the 3-tier DB cascade (Platform → Org → Team) and caches LLM instances.
@@ -210,9 +214,10 @@ type FleetSessionStartResult struct {
 
 // ChannelManagerConfig holds optional configuration for NewChannelManager.
 type ChannelManagerConfig struct {
-	ProviderName string
-	ModelName    string
-	ToolCount    int
+	ProviderName     string
+	ModelName        string
+	ToolCount        int
+	FilesystemSkills []skills.Skill
 }
 
 // NewChannelManager creates a new ChannelManager with the given ChatAgent
@@ -237,6 +242,7 @@ func NewChannelManager(chatAgent *agent.ChatAgent, sessSvc session.Service, logg
 		m.providerName = cfg.ProviderName
 		m.modelName = cfg.ModelName
 		m.toolCount = cfg.ToolCount
+		m.filesystemSkills = append([]skills.Skill(nil), cfg.FilesystemSkills...)
 	}
 	return m
 }
@@ -711,12 +717,10 @@ func (m *ChannelManager) handleInbound(ctx context.Context, msg InboundMessage) 
 	if pinnedGroups := m.consumePinnedToolGroups(route.SessionKey); len(pinnedGroups) > 0 {
 		overrides.PinnedToolGroups = pinnedGroups
 	}
-	// Build merged skill index (platform + org + team) so the LLM knows about
-	// all available skills — matching parity with the Studio Chat path.
+	// Build the full runtime cascade from the filesystem base and platform-only
+	// request stores. Personal/code mode has no SkillStores in its context.
 	if ss := store.SkillStoresFromContext(ctx); ss != nil {
-		if idx := buildChannelSkillIndex(ctx, ss); idx != "" {
-			overrides.SkillIndex = idx
-		}
+		overrides.SkillIndex = buildChannelSkillIndex(ctx, m.filesystemSkills, ss)
 	}
 	ctx = agent.WithPromptOverrides(ctx, overrides)
 
@@ -1343,80 +1347,57 @@ func (m *ChannelManager) sendTypingLoop(ctx context.Context, ch Channel, target 
 	}
 }
 
-// buildChannelSkillIndex constructs a merged skill index from all available
-// skill stores (platform + org + team) for injection into the system prompt.
-// This gives channel agents the same skill awareness as Studio Chat.
-func buildChannelSkillIndex(ctx context.Context, ss *store.SkillStores) string {
-	var all []skills.Skill
+// buildChannelSkillIndex overlays platform, org, and team DB skills on the
+// preloaded filesystem base. Names are matched case-insensitively and later
+// scopes win, yielding one rendered entry per skill name.
+func buildChannelSkillIndex(ctx context.Context, filesystem []skills.Skill, ss *store.SkillStores) string {
+	all := append([]skills.Skill(nil), filesystem...)
+	if ss == nil {
+		return skills.BuildSkillIndex(all)
+	}
 
-	// Platform skills (base layer, inherited by all orgs/teams)
-	if ss.Platform != nil {
-		if platformSkills, err := ss.Platform.LoadAll(ctx); err == nil {
-			for _, s := range platformSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "platform",
-				})
-			}
+	for _, tier := range []struct {
+		name  string
+		store store.SkillStore
+	}{
+		{name: "platform", store: ss.Platform},
+		{name: "org", store: ss.Org},
+		{name: "team", store: ss.Team},
+	} {
+		if tier.store == nil {
+			continue
+		}
+		stored, err := tier.store.LoadAll(ctx)
+		if err != nil {
+			continue
+		}
+		for _, s := range stored {
+			all = append(all, skills.Skill{
+				Name:        s.Name,
+				Description: s.Description,
+				OS:          s.OS,
+				RequireBins: s.RequireBins,
+				RequireEnv:  s.RequireEnv,
+				Source:      tier.name,
+			})
 		}
 	}
 
-	// Org skills
-	if ss.Org != nil {
-		if orgSkills, err := ss.Org.LoadAll(ctx); err == nil {
-			for _, s := range orgSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "org",
-				})
-			}
-		}
-	}
-
-	// Team skills (highest priority, can override org/platform names)
-	if ss.Team != nil {
-		if teamSkills, err := ss.Team.LoadAll(ctx); err == nil {
-			for _, s := range teamSkills {
-				all = append(all, skills.Skill{
-					Name:        s.Name,
-					Description: s.Description,
-					OS:          s.OS,
-					RequireBins: s.RequireBins,
-					RequireEnv:  s.RequireEnv,
-					Source:      "team",
-				})
-			}
-		}
-	}
-
-	if len(all) == 0 {
-		// Even with no platform/org/team skills, BuildSkillIndex will include
-		// built-in skills (e.g. generative-ui). Pass empty slice.
-		return skills.BuildSkillIndex(nil)
-	}
-
-	// Deduplicate preferring later entries (team > org > platform).
-	seen := make(map[string]bool, len(all))
-	var deduped []skills.Skill
+	seen := make(map[string]struct{}, len(all))
+	deduped := make([]skills.Skill, 0, len(all))
 	for i := len(all) - 1; i >= 0; i-- {
-		name := strings.ToLower(all[i].Name)
-		if !seen[name] {
-			seen[name] = true
-			deduped = append(deduped, all[i])
+		name := strings.ToLower(strings.TrimSpace(all[i].Name))
+		if name == "" {
+			continue
 		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		deduped = append(deduped, all[i])
 	}
-	// Reverse to restore platform → org → team display order
 	for i, j := 0, len(deduped)-1; i < j; i, j = i+1, j-1 {
 		deduped[i], deduped[j] = deduped[j], deduped[i]
 	}
-
 	return skills.BuildSkillIndex(deduped)
 }

--- a/pkg/channels/skill_index_test.go
+++ b/pkg/channels/skill_index_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 )
 
@@ -24,9 +25,9 @@ func (m *mockSkillStore) Get(_ context.Context, name string) (*store.Skill, erro
 	}
 	return nil, nil
 }
-func (m *mockSkillStore) Save(_ context.Context, _ *store.Skill) error            { return nil }
-func (m *mockSkillStore) Delete(_ context.Context, _ string) error                 { return nil }
-func (m *mockSkillStore) List(_ context.Context) ([]store.Skill, error)            { return m.skills, nil }
+func (m *mockSkillStore) Save(_ context.Context, _ *store.Skill) error  { return nil }
+func (m *mockSkillStore) Delete(_ context.Context, _ string) error      { return nil }
+func (m *mockSkillStore) List(_ context.Context) ([]store.Skill, error) { return m.skills, nil }
 func (m *mockSkillStore) UpdateValidationStatus(_ context.Context, _, _, _ string) error {
 	return nil
 }
@@ -54,7 +55,7 @@ func TestBuildChannelSkillIndex_MergesAllTiers(t *testing.T) {
 		}},
 	}
 
-	result := buildChannelSkillIndex(context.Background(), ss)
+	result := buildChannelSkillIndex(context.Background(), nil, ss)
 
 	if result == "" {
 		t.Fatal("expected non-empty skill index")
@@ -85,7 +86,7 @@ func TestBuildChannelSkillIndex_DeduplicatesTeamWins(t *testing.T) {
 		}},
 	}
 
-	result := buildChannelSkillIndex(context.Background(), ss)
+	result := buildChannelSkillIndex(context.Background(), nil, ss)
 
 	if result == "" {
 		t.Fatal("expected non-empty skill index")
@@ -118,7 +119,7 @@ func TestBuildChannelSkillIndex_EmptyStores(t *testing.T) {
 		Team:     &mockSkillStore{skills: nil},
 	}
 
-	result := buildChannelSkillIndex(context.Background(), ss)
+	result := buildChannelSkillIndex(context.Background(), nil, ss)
 
 	// Even with no user/platform skills, built-in skills are always included
 	if !strings.Contains(result, "generative-ui") {
@@ -130,7 +131,7 @@ func TestBuildChannelSkillIndex_EmptyStores(t *testing.T) {
 func TestBuildChannelSkillIndex_NilStores(t *testing.T) {
 	// All nil
 	ss := &store.SkillStores{}
-	result := buildChannelSkillIndex(context.Background(), ss)
+	result := buildChannelSkillIndex(context.Background(), nil, ss)
 	// Built-in skills are always present
 	if !strings.Contains(result, "generative-ui") {
 		t.Error("expected built-in generative-ui skill even with nil stores")
@@ -142,7 +143,7 @@ func TestBuildChannelSkillIndex_NilStores(t *testing.T) {
 			{Name: "team-only", Description: "Only team skill"},
 		}},
 	}
-	result = buildChannelSkillIndex(context.Background(), ss)
+	result = buildChannelSkillIndex(context.Background(), nil, ss)
 	if !strings.Contains(result, "team-only") {
 		t.Error("team-only skill missing when Platform and Org are nil")
 	}
@@ -161,12 +162,50 @@ func TestBuildChannelSkillIndex_OrgOverridesPlatform(t *testing.T) {
 		Team: &mockSkillStore{skills: nil},
 	}
 
-	result := buildChannelSkillIndex(context.Background(), ss)
+	result := buildChannelSkillIndex(context.Background(), nil, ss)
 
 	if !strings.Contains(result, "Org version wins over platform") {
 		t.Error("org should override platform when team has no override")
 	}
 	if strings.Contains(result, "Platform version") {
 		t.Error("platform version should be overridden by org")
+	}
+}
+
+func TestBuildChannelSkillIndex_FilesystemBaseAndCaseInsensitiveLaterWins(t *testing.T) {
+	filesystem := []skills.Skill{
+		{Name: "filesystem-only", Description: "filesystem survives"},
+		{Name: "Shared", Description: "filesystem overridden"},
+	}
+	ss := &store.SkillStores{
+		Platform: &mockSkillStore{skills: []store.Skill{{Name: "SHARED", Description: "platform overridden"}}},
+		Org:      &mockSkillStore{skills: []store.Skill{{Name: "shared", Description: "org overridden"}}},
+		Team:     &mockSkillStore{skills: []store.Skill{{Name: "sHaReD", Description: "team wins"}}},
+	}
+
+	result := buildChannelSkillIndex(context.Background(), filesystem, ss)
+	if !strings.Contains(result, "filesystem survives") {
+		t.Error("filesystem-only skill missing from cascade")
+	}
+	if !strings.Contains(result, "team wins") {
+		t.Error("team skill should win case-insensitively")
+	}
+	for _, overridden := range []string{"filesystem overridden", "platform overridden", "org overridden"} {
+		if strings.Contains(result, overridden) {
+			t.Errorf("overridden entry %q should not be rendered", overridden)
+		}
+	}
+	if count := strings.Count(strings.ToLower(result), "**shared**"); count != 1 {
+		t.Errorf("expected one rendered shared entry, got %d", count)
+	}
+}
+
+func TestNewChannelManager_CopiesFilesystemSkills(t *testing.T) {
+	configured := []skills.Skill{{Name: "cached", Description: "loaded once"}}
+	manager := NewChannelManager(nil, nil, nil, &ChannelManagerConfig{FilesystemSkills: configured})
+	configured[0].Description = "mutated"
+
+	if got := manager.filesystemSkills[0].Description; got != "loaded once" {
+		t.Fatalf("manager filesystem skills = %q, want an initialization-time copy", got)
 	}
 }

--- a/pkg/daemon/platform_channel_config_test.go
+++ b/pkg/daemon/platform_channel_config_test.go
@@ -6,9 +6,31 @@ import (
 	"testing"
 
 	"github.com/SAP/astonish/pkg/config"
+	"github.com/SAP/astonish/pkg/launcher"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/store/entstore"
 )
+
+func TestChannelManagerConfigFromFactoryResult_CopiesFilesystemSkills(t *testing.T) {
+	configured := []skills.Skill{{Name: "initialized", Description: "factory value"}}
+	result := &launcher.ChatFactoryResult{
+		ProviderName:     "provider",
+		ModelName:        "model",
+		FilesystemSkills: configured,
+	}
+
+	cfg := channelManagerConfigFromFactoryResult(result)
+	configured[0].Description = "mutated"
+	result.FilesystemSkills[0].Name = "changed"
+
+	if cfg.ProviderName != "provider" || cfg.ModelName != "model" {
+		t.Fatalf("provider/model = %s/%s", cfg.ProviderName, cfg.ModelName)
+	}
+	if got := cfg.FilesystemSkills[0]; got.Name != "initialized" || got.Description != "factory value" {
+		t.Fatalf("filesystem skill = %+v, want copied initialization-time value", got)
+	}
+}
 
 func TestLoadChannelsConfigFromDB_NilBackend(t *testing.T) {
 	cfg := loadChannelsConfigFromDB(nil, nil)

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	a2apkg "github.com/SAP/astonish/pkg/a2a"
 	"github.com/SAP/astonish/pkg/agent"
 	"github.com/SAP/astonish/pkg/api"
-	a2apkg "github.com/SAP/astonish/pkg/a2a"
 	"github.com/SAP/astonish/pkg/browser"
 	"github.com/SAP/astonish/pkg/channels"
 	a2achan "github.com/SAP/astonish/pkg/channels/a2a"
@@ -40,6 +40,7 @@ import (
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	"github.com/SAP/astonish/pkg/scheduler"
 	persistentsession "github.com/SAP/astonish/pkg/session"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/store/entstore"
 	"github.com/SAP/astonish/pkg/tools"
@@ -49,6 +50,18 @@ import (
 type RunConfig struct {
 	Port  int
 	Debug bool
+}
+
+func channelManagerConfigFromFactoryResult(result *launcher.ChatFactoryResult) *channels.ChannelManagerConfig {
+	if result == nil {
+		return nil
+	}
+	return &channels.ChannelManagerConfig{
+		ProviderName:     result.ProviderName,
+		ModelName:        result.ModelName,
+		ToolCount:        len(result.InternalTools),
+		FilesystemSkills: append([]skills.Skill(nil), result.FilesystemSkills...),
+	}
 }
 
 // Run starts the daemon in the foreground. It starts the Studio HTTP server,
@@ -349,11 +362,7 @@ func Run(cfg RunConfig) error {
 			return nil, fmt.Errorf("channels enabled but no ChatAgent available — restart the daemon")
 		}
 
-		mgr := channels.NewChannelManager(factoryResult.ChatAgent, factoryResult.SessionService, log.Default(), &channels.ChannelManagerConfig{
-			ProviderName: factoryResult.ProviderName,
-			ModelName:    factoryResult.ModelName,
-			ToolCount:    len(factoryResult.InternalTools),
-		})
+		mgr := channels.NewChannelManager(factoryResult.ChatAgent, factoryResult.SessionService, log.Default(), channelManagerConfigFromFactoryResult(factoryResult))
 
 		if factoryResult.CredentialStore != nil {
 			mgr.SetRedactor(factoryResult.CredentialStore.Redactor())

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -27,6 +27,7 @@ import (
 	incus "github.com/SAP/astonish/pkg/sandbox/incus"
 	"github.com/SAP/astonish/pkg/sandbox/openshell"
 	persistentsession "github.com/SAP/astonish/pkg/session"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/tools"
 	"google.golang.org/adk/model"
@@ -45,9 +46,9 @@ type ChatFactoryConfig struct {
 	WorkspaceDir string
 	IsDaemon     bool // When true, always run indexing/watchers (we ARE the daemon).
 
-	// PlatformMode indicates multi-tenant platform mode. When true, skills are
-	// resolved per-request from context-injected stores (platform → org → team).
-	// The filesystem user skill directory is NOT read.
+	// PlatformMode indicates multi-tenant platform mode. When true, DB skills are
+	// resolved per-request from context-injected stores (platform → org → team)
+	// ahead of the configured filesystem cascade.
 	PlatformMode bool
 
 	// CodeMode indicates the local, single-user Astonish Code runtime (the
@@ -117,6 +118,9 @@ type ChatFactoryResult struct {
 	StartupNotices        []string
 	PromptBuilder         *agent.SystemPromptBuilder
 	CredentialStore       *credentials.Store // Encrypted credential store (nil if unavailable)
+	// FilesystemSkills is the exact configured filesystem slice loaded and wired
+	// into skill lookup for this runtime.
+	FilesystemSkills []skills.Skill
 
 	// Cleanup aggregates all deferred cleanups (embedder, MCP, file watcher).
 	// The caller must call this when the ChatAgent is no longer needed.
@@ -181,11 +185,12 @@ func mainThreadToolAllowlist() map[string]bool {
 		// Graph-Optimized Plan mode phase transitions — MUST be main-thread:
 		// they advance the per-session GraphPlanState owned by the main ChatAgent.
 		// Sub-agents have no ActiveGraphPlan; calling these from a sub-agent would fail silently.
-		"gplan_reads":    true,
-		"gplan_gaps":     true,
-		"gplan_finalize": true,
+		"gplan_reads":        true,
+		"gplan_gaps":         true,
+		"gplan_finalize":     true,
 		"resolve_credential": true,
 		"skill_lookup":       true,
+		"create_skill":       true,
 		// Platform web search must be main-thread always-on. If it only lives in
 		// the "web" group, ToolIndex may never inject it and the agent claims
 		// "no web search tools" even when General selects Perplexity.
@@ -201,6 +206,16 @@ func optionalCredentialResolver(store *credentials.Store) credentials.Credential
 		return nil
 	}
 	return store
+}
+
+func skillLookupMode(platformMode, codeMode bool) tools.SkillLookupMode {
+	if platformMode {
+		return tools.SkillLookupModePlatform
+	}
+	if codeMode {
+		return tools.SkillLookupModeCode
+	}
+	return tools.SkillLookupModeLocal
 }
 
 // NewWiredChatAgent creates a fully-wired ChatAgent ready for use by any caller
@@ -524,15 +539,27 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 
 	// --- 2h. Initialize skills system → deferred category ---
 	var skillIndex string
+	var filesystemSkills []skills.Skill
 	var skillToolSlice []tool.Tool
 	var skillLookupTool tool.Tool // hoisted for SubAgentManager wiring
 	if cfg.AppConfig != nil && cfg.AppConfig.Skills.IsSkillsEnabled() {
-		// In platform mode, skills are resolved per-request from context-injected stores
-		// (platform → org → team). The static index is empty; the per-request merged index
-		// is injected by InjectSkillIndex in chat_handlers.go.
-		// The skill_lookup tool is still created (with an empty static index) so it can
-		// resolve skills from context stores at runtime.
-		skillTool, stErr := tools.NewSkillLookupTool(nil)
+		lookupMode := skillLookupMode(cfg.PlatformMode, cfg.CodeMode)
+
+		// Load the configured filesystem cascade in every runtime mode. Platform
+		// requests layer DB skills over this static baseline via PromptOverrides.
+		loadedFilesystemSkills, loadErr := skills.LoadSkills(
+			cfg.AppConfig.Skills.GetUserSkillsDir(),
+			cfg.AppConfig.Skills.ExtraDirs,
+			cfg.AppConfig.Skills.Allowlist,
+		)
+		if loadErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to load filesystem skills: %w", loadErr)
+		}
+		filesystemSkills = loadedFilesystemSkills
+		skillIndex = skills.BuildSkillIndex(filesystemSkills)
+
+		skillTool, stErr := tools.NewSkillLookupTool(filesystemSkills, lookupMode)
 		if stErr != nil {
 			if cfg.DebugMode {
 				slog.Warn("failed to create skill_lookup tool", "error", stErr)
@@ -541,8 +568,21 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			skillToolSlice = append(skillToolSlice, skillTool)
 			skillLookupTool = skillTool // keep reference for sub-agent injection
 		}
+
+		// Skill creation is a personal-runtime capability. Bind it to the same
+		// configured user root used by the loader; never expose it in platform mode.
+		if !cfg.PlatformMode {
+			createSkillTool, createErr := tools.NewCreateSkillTool(cfg.AppConfig.Skills.GetUserSkillsDir())
+			if createErr != nil {
+				if cfg.DebugMode {
+					slog.Warn("failed to create create_skill tool", "error", createErr)
+				}
+			} else {
+				skillToolSlice = append(skillToolSlice, createSkillTool)
+			}
+		}
 		if cfg.DebugMode {
-			slog.Debug("skills system initialized", "component", "chat-factory", "platform", cfg.PlatformMode)
+			slog.Debug("skills system initialized", "component", "chat-factory", "platform", cfg.PlatformMode, "filesystem_skills", len(filesystemSkills))
 		}
 	}
 
@@ -719,9 +759,9 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			if len(emailToolsSlice) > 0 {
 				emailToolsSlice = sandbox.WrapToolsWithPool(emailToolsSlice, pool)
 			}
-			if len(skillToolSlice) > 0 {
-				skillToolSlice = sandbox.WrapToolsWithPool(skillToolSlice, pool)
-			}
+			// Skill tools manage/read the configured host-side skill roots and must
+			// not be sandbox-wrapped; wrapping would reinterpret those paths inside
+			// the sandbox and create scaffolds in the wrong filesystem.
 			// Note: browserToolsSlice NOT wrapped — browser tools call the
 			// Manager directly (which connects to Chromium in the sandbox via CDP).
 
@@ -883,9 +923,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			if len(emailToolsSlice) > 0 {
 				emailToolsSlice = sandbox.WrapToolsWithNode(emailToolsSlice, nodePool)
 			}
-			if len(skillToolSlice) > 0 {
-				skillToolSlice = sandbox.WrapToolsWithNode(skillToolSlice, nodePool)
-			}
+			// Skill tools stay host-side; see the pool-backed sandbox path above.
 			// Note: browserToolsSlice is intentionally NOT wrapped — Manager
 			// drives in-container Chromium via SandboxEnabled callbacks.
 
@@ -2053,6 +2091,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		StartupNotices:        startupNotices,
 		PromptBuilder:         promptBuilder,
 		CredentialStore:       credStore,
+		FilesystemSkills:      append([]skills.Skill(nil), filesystemSkills...),
 		Cleanup:               cleanup,
 		ShutdownSandbox:       shutdownSandbox,
 		SandboxPool:           resultPool,

--- a/pkg/launcher/chat_factory_test.go
+++ b/pkg/launcher/chat_factory_test.go
@@ -57,6 +57,36 @@ func TestMainThreadToolAllowlist_CoreEditingTools(t *testing.T) {
 	}
 }
 
+func TestMainThreadToolAllowlist_SkillTools(t *testing.T) {
+	allow := mainThreadToolAllowlist()
+	for _, name := range []string{"skill_lookup", "create_skill"} {
+		if !allow[name] {
+			t.Errorf("expected skill tool %q in the main-thread allowlist", name)
+		}
+	}
+}
+
+func TestSkillLookupMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformMode bool
+		codeMode     bool
+		want         string
+	}{
+		{name: "local", want: "local"},
+		{name: "code", codeMode: true, want: "code"},
+		{name: "platform", platformMode: true, want: "platform"},
+		{name: "platform takes precedence", platformMode: true, codeMode: true, want: "platform"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(skillLookupMode(tt.platformMode, tt.codeMode)); got != tt.want {
+				t.Fatalf("skillLookupMode(%v, %v) = %q, want %q", tt.platformMode, tt.codeMode, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestMainThreadToolAllowlist_InteractiveTerminalTools guards the fix for the
 // interactive-terminal drive loop: shell_command runs in a PTY and can return
 // waiting_for_input=true, so the top-level agent must directly hold the process_*

--- a/pkg/launcher/studio.go
+++ b/pkg/launcher/studio.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/SAP/astonish/pkg/agent"
 	"github.com/SAP/astonish/pkg/api"
 	"github.com/SAP/astonish/pkg/sandbox"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 	"github.com/SAP/astonish/pkg/tools"
 	"github.com/SAP/astonish/web"
+	"github.com/gorilla/mux"
 )
 
 // studioBackend is the minimal interface that StudioServer needs from the
@@ -31,15 +32,38 @@ type studioBackend interface {
 	NewToolVectorStore(ctx context.Context) (agent.ToolVectorStore, error)
 }
 
+func studioChatComponentsFromFactoryResult(result *ChatFactoryResult, sandboxEnabled bool) *api.StudioChatComponents {
+	if result == nil {
+		return nil
+	}
+	return &api.StudioChatComponents{
+		ChatAgent:         result.ChatAgent,
+		LLM:               result.LLM,
+		SwappableLLM:      result.SwappableLLM,
+		SessionService:    result.SessionService,
+		ProviderName:      result.ProviderName,
+		ModelName:         result.ModelName,
+		Compactor:         result.Compactor,
+		InternalToolCount: len(result.InternalTools),
+		MemoryActive:      result.MemorySearchAvailable,
+		SandboxEnabled:    sandboxEnabled,
+		StartupNotices:    result.StartupNotices,
+		ShutdownSandbox:   result.ShutdownSandbox,
+		Cleanup:           result.Cleanup,
+		SandboxPool:       result.SandboxPool,
+		FilesystemSkills:  append([]skills.Skill(nil), result.FilesystemSkills...),
+	}
+}
+
 // StudioServer wraps the HTTP server with lifecycle management.
 type StudioServer struct {
-	server        *http.Server
-	listener      net.Listener
-	port          int
-	platformAuth  *api.PlatformAuth   // non-nil in platform mode
-	backend       studioBackend       // non-nil in platform mode
-	tenantMW      func(http.Handler) http.Handler // tenant resolution middleware
-	services      *store.Services
+	server       *http.Server
+	listener     net.Listener
+	port         int
+	platformAuth *api.PlatformAuth               // non-nil in platform mode
+	backend      studioBackend                   // non-nil in platform mode
+	tenantMW     func(http.Handler) http.Handler // tenant resolution middleware
+	services     *store.Services
 }
 
 // StudioOption configures optional StudioServer behavior.
@@ -91,19 +115,19 @@ func NewStudioServer(port int, opts ...StudioOption) (*StudioServer, error) {
 
 	// Wire Studio Chat initialization (lazy, runs on first chat request)
 	isPlatform := s.platformAuth != nil // capture for closure
-	backendRef := s.backend            // capture for closure
+	backendRef := s.backend             // capture for closure
 	api.SetStudioChatInitFunc(func(ctx context.Context) (*api.StudioChatComponents, error) {
 		appCfg := api.EffectiveAppConfigFromContext(ctx, isPlatform)
 
 		factoryCfg := &ChatFactoryConfig{
-			AppConfig:     appCfg,
-			ProviderName:  appCfg.General.DefaultProvider,
-			ModelName:     appCfg.General.DefaultModel,
-			DebugMode:     false,
-			AutoApprove:   false,
-			WorkspaceDir:  "",
-			IsDaemon:      false,
-			PlatformMode:  isPlatform,
+			AppConfig:    appCfg,
+			ProviderName: appCfg.General.DefaultProvider,
+			ModelName:    appCfg.General.DefaultModel,
+			DebugMode:    false,
+			AutoApprove:  false,
+			WorkspaceDir: "",
+			IsDaemon:     false,
+			PlatformMode: isPlatform,
 		}
 
 		// In platform mode, create ToolIndex for dynamic tool discovery.
@@ -133,22 +157,7 @@ func NewStudioServer(port int, opts ...StudioOption) (*StudioServer, error) {
 			})
 		}
 
-		return &api.StudioChatComponents{
-			ChatAgent:         result.ChatAgent,
-			LLM:               result.LLM,
-			SwappableLLM:      result.SwappableLLM,
-			SessionService:    result.SessionService,
-			ProviderName:      result.ProviderName,
-			ModelName:         result.ModelName,
-			Compactor:         result.Compactor,
-			InternalToolCount: len(result.InternalTools),
-			MemoryActive:      result.MemorySearchAvailable,
-			SandboxEnabled:    sandbox.IsSandboxEnabled(&appCfg.Sandbox),
-			StartupNotices:    result.StartupNotices,
-			ShutdownSandbox:   result.ShutdownSandbox,
-			Cleanup:           result.Cleanup,
-			SandboxPool:       result.SandboxPool,
-		}, nil
+		return studioChatComponentsFromFactoryResult(result, sandbox.IsSandboxEnabled(&appCfg.Sandbox)), nil
 	})
 
 	// Wire a pre-warm context builder for auto-PreWarm on Reset().
@@ -283,7 +292,6 @@ func (s *StudioServer) Serve() error {
 func (s *StudioServer) Shutdown(ctx context.Context) error {
 	return s.server.Shutdown(ctx)
 }
-
 
 // getWebAssets returns the web assets filesystem
 // Priority: 1. Filesystem (for dev), 2. Embedded (for production)

--- a/pkg/launcher/studio_test.go
+++ b/pkg/launcher/studio_test.go
@@ -1,0 +1,23 @@
+package launcher
+
+import (
+	"testing"
+
+	"github.com/SAP/astonish/pkg/skills"
+)
+
+func TestStudioChatComponentsFromFactoryResult_CopiesFilesystemSkills(t *testing.T) {
+	configured := []skills.Skill{{Name: "initialized", Description: "factory value"}}
+	result := &ChatFactoryResult{FilesystemSkills: configured}
+
+	components := studioChatComponentsFromFactoryResult(result, true)
+	configured[0].Description = "mutated"
+	result.FilesystemSkills[0].Name = "changed"
+
+	if !components.SandboxEnabled {
+		t.Fatal("expected sandbox flag to be forwarded")
+	}
+	if got := components.FilesystemSkills[0]; got.Name != "initialized" || got.Description != "factory value" {
+		t.Fatalf("filesystem skill = %+v, want copied initialization-time value", got)
+	}
+}

--- a/pkg/launcher/tui_chat.go
+++ b/pkg/launcher/tui_chat.go
@@ -221,6 +221,19 @@ func (b *lazyCodeBackend) RespondSubAgentAuth(choice string) bool {
 	return false
 }
 
+func (b *lazyCodeBackend) ListLocalSkills(ctx context.Context) ([]backend.SkillSummary, error) {
+	if b.inner == nil {
+		return nil, fmt.Errorf("code backend not opened")
+	}
+	capability, ok := b.inner.(backend.LocalSkillsBackend)
+	if !ok {
+		return nil, fmt.Errorf("code backend does not support local skills")
+	}
+	return capability.ListLocalSkills(ctx)
+}
+
+var _ backend.LocalSkillsBackend = (*lazyCodeBackend)(nil)
+
 // platformBackend implements backend.Backend over Studio REST/SSE.
 type platformBackend struct {
 	client      *client.Client

--- a/pkg/launcher/tui_chat_test.go
+++ b/pkg/launcher/tui_chat_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/SAP/astonish/pkg/client"
+	"github.com/SAP/astonish/pkg/skills"
+	"github.com/SAP/astonish/pkg/tui/backend"
 	"github.com/SAP/astonish/pkg/tui/events"
 )
 
@@ -328,4 +330,18 @@ func TestPlatformBackendDeleteActiveSessionResetsModelToCascade(t *testing.T) {
 	if info.Provider != "cascade-provider" || info.Model != "cascade-model" {
 		t.Fatalf("after delete active = %s/%s", info.Provider, info.Model)
 	}
+}
+
+func TestLazyCodeBackendForwardsLocalSkills(t *testing.T) {
+	inner := &localAgentBackend{filesystemSkills: []skills.Skill{{Name: "local", Description: "Local", Source: "project"}}}
+	b := &lazyCodeBackend{inner: inner}
+
+	got, err := b.ListLocalSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[1].Name != "local" {
+		t.Fatalf("forwarded skills = %+v", got)
+	}
+	var _ backend.LocalSkillsBackend = b
 }

--- a/pkg/launcher/tui_code.go
+++ b/pkg/launcher/tui_code.go
@@ -25,6 +25,7 @@ import (
 	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/provider"
 	persistentsession "github.com/SAP/astonish/pkg/session"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/tools/ripgrep"
 	"github.com/SAP/astonish/pkg/tui"
 	"github.com/SAP/astonish/pkg/tui/backend"
@@ -232,6 +233,7 @@ func RunCodeTUI(ctx context.Context, cfg *CodeConfig) error {
 		configured:             result.ProviderConfigured,
 		resumed:                cfg.SessionID != "",
 		notices:                result.StartupNotices,
+		filesystemSkills:       append([]skills.Skill(nil), result.FilesystemSkills...),
 		subAgentAuthReqCh:      make(chan agent.SubAgentAuthRequest, 1),
 		subAgentAuthRespCh:     make(chan agent.SubAgentAuthResponse, 1),
 	}
@@ -362,6 +364,7 @@ func buildCodeBackend(ctx context.Context, cfg *CodeConfig) (backend.Backend, er
 		model:                  result.ModelName,
 		configured:             result.ProviderConfigured,
 		notices:                result.StartupNotices,
+		filesystemSkills:       append([]skills.Skill(nil), result.FilesystemSkills...),
 		subAgentAuthReqCh:      make(chan agent.SubAgentAuthRequest, 1),
 		subAgentAuthRespCh:     make(chan agent.SubAgentAuthResponse, 1),
 	}
@@ -473,6 +476,9 @@ type localAgentBackend struct {
 	debug      bool
 	workingDir string
 	notices    []string
+	// filesystemSkills is the exact initialization-time slice wired into the
+	// runtime skill lookup. It is not reloaded when /skills is invoked.
+	filesystemSkills []skills.Skill
 
 	mu          sync.Mutex
 	sessionID   string
@@ -512,6 +518,58 @@ type localAgentBackend struct {
 	// main-thread approvals would be misrouted and the turn would freeze.
 	subAgentAuthPending bool
 }
+
+func (b *localAgentBackend) ListLocalSkills(ctx context.Context) ([]backend.SkillSummary, error) {
+	_ = ctx
+	// Re-scan the filesystem on every call so skills added or removed since
+	// startup are immediately visible without restarting the process.
+	var liveSkills []skills.Skill
+	if b.appConfig != nil && b.appConfig.Skills.IsSkillsEnabled() {
+		loaded, err := skills.LoadSkills(
+			b.appConfig.Skills.GetUserSkillsDir(),
+			b.appConfig.Skills.ExtraDirs,
+			b.appConfig.Skills.Allowlist,
+		)
+		if err == nil {
+			liveSkills = loaded
+		} else {
+			// Fall back to the startup snapshot rather than surfacing an error.
+			liveSkills = b.filesystemSkills
+		}
+	} else {
+		liveSkills = b.filesystemSkills
+	}
+
+	merged := make(map[string]skills.Skill)
+	for _, skill := range skills.BuiltinSkills() {
+		merged[strings.ToLower(skill.Name)] = skill
+	}
+	for _, skill := range liveSkills {
+		merged[strings.ToLower(skill.Name)] = skill
+	}
+
+	summaries := make([]backend.SkillSummary, 0, len(merged))
+	for _, skill := range merged {
+		missing := skill.MissingRequirements()
+		summaries = append(summaries, backend.SkillSummary{
+			Name:        skill.Name,
+			Description: skill.Description,
+			Source:      skill.Source,
+			Eligible:    len(missing) == 0,
+			Missing:     append([]string(nil), missing...),
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		left, right := strings.ToLower(summaries[i].Name), strings.ToLower(summaries[j].Name)
+		if left == right {
+			return summaries[i].Name < summaries[j].Name
+		}
+		return left < right
+	})
+	return summaries, nil
+}
+
+var _ backend.LocalSkillsBackend = (*localAgentBackend)(nil)
 
 // contextEstimateInterval is the minimum wall-clock gap between mid-turn
 // context-occupancy estimates. It keeps the header's "Context" figure moving

--- a/pkg/launcher/tui_code_test.go
+++ b/pkg/launcher/tui_code_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/SAP/astonish/pkg/config"
 	"github.com/SAP/astonish/pkg/sandbox"
 	persistentsession "github.com/SAP/astonish/pkg/session"
+	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/tui/backend"
 	"github.com/SAP/astonish/pkg/tui/events"
 	adkmodel "google.golang.org/adk/model"
@@ -2902,5 +2903,30 @@ func TestRespondSubAgentAuth_DenyPropagates(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for the sub-agent to receive the denial")
+	}
+}
+
+func TestLocalAgentBackendListLocalSkills(t *testing.T) {
+	b := &localAgentBackend{filesystemSkills: []skills.Skill{
+		{Name: "zeta", Description: "Zeta skill", Source: "project"},
+		{Name: "Generative-UI", Description: "Override", Source: "user", RequireBins: []string{"definitely-missing-astonish-test-bin"}},
+		{Name: "alpha", Description: "Alpha skill", Source: "extra"},
+	}}
+
+	got, err := b.ListLocalSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("skills = %+v", got)
+	}
+	if got[0].Name != "alpha" || got[1].Name != "Generative-UI" || got[2].Name != "zeta" {
+		t.Fatalf("skills not sorted: %+v", got)
+	}
+	if got[1].Description != "Override" || got[1].Source != "user" {
+		t.Fatalf("filesystem skill did not override builtin: %+v", got[1])
+	}
+	if got[1].Eligible || len(got[1].Missing) != 1 || got[1].Missing[0] != "definitely-missing-astonish-test-bin" {
+		t.Fatalf("eligibility = %+v", got[1])
 	}
 }

--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -227,9 +228,44 @@ func splitFrontmatter(data []byte) ([]byte, string, error) {
 	return []byte(strings.Join(frontLines, "\n")), strings.Join(bodyLines, "\n"), nil
 }
 
-// LoadSkills was the file-based loader for personal mode.
-// It has been removed in v3 (platform DB is the only source of truth for custom skills).
-// Use the platform/org/team SkillStore.LoadAll() for skills at each tier.
+// LoadSkills loads filesystem skills from the user directory followed by each
+// extra directory. Later directories override earlier definitions by name.
+// Name matching for overrides and allowlist filtering is case-insensitive.
+func LoadSkills(userDir string, extraDirs []string, allowlist []string) ([]Skill, error) {
+	byName := make(map[string]*Skill)
+
+	if userDir != "" {
+		loadSkillsFromDir(userDir, "user", byName)
+	}
+	for _, dir := range extraDirs {
+		if dir != "" {
+			loadSkillsFromDir(dir, "extra", byName)
+		}
+	}
+
+	allowed := make(map[string]struct{}, len(allowlist))
+	for _, name := range allowlist {
+		allowed[strings.ToLower(name)] = struct{}{}
+	}
+
+	result := make([]Skill, 0, len(byName))
+	for _, skill := range byName {
+		if len(allowed) > 0 {
+			if _, ok := allowed[strings.ToLower(skill.Name)]; !ok {
+				continue
+			}
+		}
+		result = append(result, *skill)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := strings.ToLower(result[i].Name), strings.ToLower(result[j].Name)
+		if left == right {
+			return result[i].Name < result[j].Name
+		}
+		return left < right
+	})
+	return result, nil
+}
 
 // loadSkillsFromDir loads skills from a directory on disk.
 // Each immediate subdirectory containing a SKILL.md is loaded.
@@ -261,7 +297,7 @@ func loadSkillsFromDir(dir string, source string, byName map[string]*Skill) {
 		} else {
 			skill.Directory = skillDir
 		}
-		byName[skill.Name] = skill
+		byName[strings.ToLower(skill.Name)] = skill
 	}
 }
 

--- a/pkg/skills/loader_test.go
+++ b/pkg/skills/loader_test.go
@@ -152,11 +152,7 @@ func TestFilterEligible(t *testing.T) {
 func TestLoadSkillsFromDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a skill directory
-	skillDir := filepath.Join(tmpDir, "my-tool")
-	os.MkdirAll(skillDir, 0755)
-	content := []byte("---\nname: my-tool\ndescription: \"My custom tool\"\n---\n\n# My Tool\n")
-	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0644)
+	writeTestSkill(t, tmpDir, "my-tool", "my-tool", "My custom tool", "# My Tool")
 
 	byName := make(map[string]*Skill)
 	loadSkillsFromDir(tmpDir, "user", byName)
@@ -170,5 +166,111 @@ func TestLoadSkillsFromDir(t *testing.T) {
 	}
 	if skill.Source != "user" {
 		t.Errorf("Source = %q, want %q", skill.Source, "user")
+	}
+	wantDir, err := filepath.Abs(filepath.Join(tmpDir, "my-tool"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skill.Directory != wantDir {
+		t.Errorf("Directory = %q, want %q", skill.Directory, wantDir)
+	}
+	if skill.FilePath != filepath.Join(tmpDir, "my-tool", "SKILL.md") {
+		t.Errorf("FilePath = %q", skill.FilePath)
+	}
+	if skill.Content != "# My Tool" {
+		t.Errorf("Content = %q", skill.Content)
+	}
+}
+
+func TestLoadSkillsSourcesOverridesAllowlistAndSort(t *testing.T) {
+	userDir := t.TempDir()
+	extraOne := t.TempDir()
+	extraTwo := t.TempDir()
+
+	writeTestSkill(t, userDir, "zulu", "Zulu", "user zulu", "user zulu")
+	writeTestSkill(t, userDir, "shared", "Shared", "user shared", "user shared")
+	writeTestSkill(t, extraOne, "alpha", "alpha", "extra alpha", "extra alpha")
+	writeTestSkill(t, extraOne, "shared", "sHaReD", "first override", "first override")
+	writeTestSkill(t, extraTwo, "shared", "SHARED", "last override", "last override")
+	writeTestSkill(t, extraTwo, "bravo", "Bravo", "extra bravo", "extra bravo")
+
+	sk, err := LoadSkills(userDir, []string{extraOne, extraTwo}, []string{"ALPHA", "shared", "BRAVO"})
+	if err != nil {
+		t.Fatalf("LoadSkills failed: %v", err)
+	}
+	if len(sk) != 3 {
+		t.Fatalf("got %d skills, want 3: %#v", len(sk), sk)
+	}
+	wantNames := []string{"alpha", "Bravo", "SHARED"}
+	for i, want := range wantNames {
+		if sk[i].Name != want {
+			t.Errorf("skill[%d].Name = %q, want %q", i, sk[i].Name, want)
+		}
+	}
+	if sk[2].Description != "last override" || sk[2].Content != "last override" {
+		t.Errorf("override did not retain winning skill: %#v", sk[2])
+	}
+	if sk[2].Source != "extra" {
+		t.Errorf("winning Source = %q, want extra", sk[2].Source)
+	}
+	wantDir, _ := filepath.Abs(filepath.Join(extraTwo, "shared"))
+	if sk[2].Directory != wantDir || sk[2].FilePath != filepath.Join(extraTwo, "shared", "SKILL.md") {
+		t.Errorf("winning filesystem metadata not retained: %#v", sk[2])
+	}
+}
+
+func TestLoadSkillsEmptyAllowlistAndInvalidInputs(t *testing.T) {
+	userDir := t.TempDir()
+	writeTestSkill(t, userDir, "valid", "Valid", "valid skill", "valid body")
+
+	if err := os.WriteFile(filepath.Join(userDir, "SKILL.md"), []byte("not a child skill"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(userDir, "missing-file"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	invalidDir := filepath.Join(userDir, "invalid")
+	if err := os.Mkdir(invalidDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(invalidDir, "SKILL.md"), []byte("invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sk, err := LoadSkills(userDir, []string{"", filepath.Join(userDir, "does-not-exist")}, nil)
+	if err != nil {
+		t.Fatalf("LoadSkills failed: %v", err)
+	}
+	if len(sk) != 1 || sk[0].Name != "Valid" {
+		t.Fatalf("got %#v, want only Valid", sk)
+	}
+	if sk[0].Source != "user" {
+		t.Errorf("Source = %q, want user", sk[0].Source)
+	}
+}
+
+func TestLoadSkillsCaseInsensitiveDedupeWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "a-first", "Duplicate", "first", "first")
+	writeTestSkill(t, root, "z-last", "duplicate", "last", "last")
+
+	sk, err := LoadSkills(root, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sk) != 1 || sk[0].Description != "last" {
+		t.Fatalf("got %#v, want deterministic last directory override", sk)
+	}
+}
+
+func writeTestSkill(t *testing.T, root, dirname, name, description, body string) {
+	t.Helper()
+	dir := filepath.Join(root, dirname)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("---\nname: " + name + "\ndescription: \"" + description + "\"\nmetadata:\n  custom: retained\n---\n\n" + body + "\n")
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), content, 0644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/tools/create_skill.go
+++ b/pkg/tools/create_skill.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/SAP/astonish/pkg/safepath"
+	"github.com/SAP/astonish/pkg/skills"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// CreateSkillArgs defines the arguments for create_skill.
+type CreateSkillArgs struct {
+	Name    string `json:"name" jsonschema:"New skill name using only ASCII letters, digits, hyphens, and underscores (e.g. Deploy_K8s)"`
+	Content string `json:"content,omitempty" jsonschema:"Optional full SKILL.md content to write (including YAML frontmatter). When omitted a scaffold template is generated automatically."`
+}
+
+// CreateSkillResult describes the newly-created filesystem skill.
+type CreateSkillResult struct {
+	Name      string `json:"name"`
+	Directory string `json:"directory,omitempty"`
+	File      string `json:"file,omitempty"`
+	Content   string `json:"content,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// createSkillMu serializes the portable read-directory/case-insensitive-name
+// check with leaf creation. os.Mkdir remains the atomic guard for exact-name
+// races, including creators outside this process.
+var createSkillMu sync.Mutex
+
+// CreateSkill creates a skill under the injected root. The root is captured by
+// the constructor rather than accepted from tool arguments.
+func CreateSkill(root string) func(tool.Context, CreateSkillArgs) (CreateSkillResult, error) {
+	return func(_ tool.Context, args CreateSkillArgs) (result CreateSkillResult, err error) {
+		name := strings.TrimSpace(args.Name)
+		result.Name = name
+		if !validSkillName(name) {
+			result.Error = "invalid skill name: use ASCII letters, digits, hyphens, or underscores"
+			return result, nil
+		}
+		if root == "" {
+			result.Error = "skill root is not configured"
+			return result, nil
+		}
+		rootAbs, err := filepath.Abs(root)
+		if err != nil {
+			result.Error = "skill root is invalid"
+			return result, nil
+		}
+		if err := os.MkdirAll(rootAbs, 0755); err != nil {
+			result.Error = fmt.Sprintf("failed to prepare skill root: %v", err)
+			return result, nil
+		}
+
+		skillDir := filepath.Join(rootAbs, name)
+		if err := safepath.ContainedWithin(skillDir, rootAbs); err != nil {
+			result.Error = "invalid skill path"
+			return result, nil
+		}
+
+		createSkillMu.Lock()
+		defer createSkillMu.Unlock()
+
+		entries, err := os.ReadDir(rootAbs)
+		if err != nil {
+			result.Error = fmt.Sprintf("failed to inspect skill root: %v", err)
+			return result, nil
+		}
+		for _, entry := range entries {
+			if strings.EqualFold(entry.Name(), name) {
+				result.Error = fmt.Sprintf("skill %q already exists", name)
+				return result, nil
+			}
+		}
+		if err := os.Mkdir(skillDir, 0755); err != nil {
+			if os.IsExist(err) {
+				result.Error = fmt.Sprintf("skill %q already exists", name)
+			} else {
+				result.Error = fmt.Sprintf("failed to create skill %q: %v", name, err)
+			}
+			return result, nil
+		}
+		cleanup := true
+		defer func() {
+			if cleanup {
+				_ = os.RemoveAll(skillDir)
+			}
+		}()
+
+		template := skills.NewSkillTemplate(name)
+		// If the caller supplied explicit content, use it; otherwise fall back
+		// to the scaffold template so the file is never empty.
+		// If the supplied content lacks YAML frontmatter (--- delimiters), prepend
+		// a minimal frontmatter block so the skill is always loadable by ParseSkillFile.
+		fileContent := template
+		if strings.TrimSpace(args.Content) != "" {
+			fileContent = ensureSkillFrontmatter(args.Content, name)
+		}
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		f, err := os.OpenFile(skillFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			result.Error = fmt.Sprintf("failed to create skill file: %v", err)
+			return result, nil
+		}
+		if _, err = f.WriteString(fileContent); err != nil {
+			_ = f.Close()
+			result.Error = fmt.Sprintf("failed to write skill file: %v", err)
+			return result, nil
+		}
+		if err = f.Close(); err != nil {
+			result.Error = fmt.Sprintf("failed to close skill file: %v", err)
+			return result, nil
+		}
+		cleanup = false
+		result.Directory = skillDir
+		result.File = skillFile
+		result.Content = fileContent
+		return result, nil
+	}
+}
+
+// ensureSkillFrontmatter returns content with a valid YAML frontmatter block.
+// If content already starts with a --- delimited block that contains both
+// "name:" and "description:" fields, it is returned unchanged. Otherwise a
+// minimal frontmatter block is prepended so ParseSkillFile can load the skill.
+func ensureSkillFrontmatter(content, name string) string {
+	trimmed := strings.TrimSpace(content)
+	// Detect whether a frontmatter block is already present and valid:
+	// it must start with "---", have a closing "---", and contain name/description.
+	if strings.HasPrefix(trimmed, "---") {
+		// Find closing ---
+		rest := trimmed[3:]
+		end := strings.Index(rest, "\n---")
+		if end >= 0 {
+			front := rest[:end]
+			if strings.Contains(front, "name:") && strings.Contains(front, "description:") {
+				return content // already valid
+			}
+		}
+	}
+	// No valid frontmatter — prepend a minimal one. Use a placeholder description
+	// that the user can edit later. The skill name comes from the directory name arg.
+	header := fmt.Sprintf("---\nname: %s\ndescription: \"TODO: describe what this skill does\"\nrequire_bins: []\n---\n\n", name)
+	return header + trimmed
+}
+
+func validSkillName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	for _, c := range []byte(name) {
+		if !((c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// NewCreateSkillTool creates a create_skill tool bound to root.
+func NewCreateSkillTool(root string) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "create_skill",
+		Description: "Create a new local skill scaffold in the configured skills directory. After trimming, the name must use only ASCII letters, digits, hyphens, and underscores. Existing skills are never overwritten. Optionally pass 'content' with the full SKILL.md body to write real content instead of the boilerplate template. IMPORTANT: the content MUST begin with a YAML frontmatter block delimited by '---' lines containing at least 'name:' and 'description:' fields — without it the skill cannot be loaded. If you omit frontmatter it will be auto-injected with a placeholder description, so always include a meaningful description in the frontmatter.",
+	}, CreateSkill(root))
+}

--- a/pkg/tools/create_skill_test.go
+++ b/pkg/tools/create_skill_test.go
@@ -1,0 +1,285 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestCreateSkillCreatesFreshTemplate(t *testing.T) {
+	root := t.TempDir()
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "deploy-k8s"})
+	if err != nil || result.Error != "" {
+		t.Fatalf("create failed: %#v err=%v", result, err)
+	}
+	wantFile := filepath.Join(root, "deploy-k8s", "SKILL.md")
+	if result.File != wantFile || result.Directory != filepath.Dir(wantFile) {
+		t.Fatalf("unexpected paths: %#v", result)
+	}
+	data, err := os.ReadFile(wantFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != result.Content || !strings.Contains(string(data), "name: deploy-k8s") {
+		t.Fatalf("unexpected template: %q", data)
+	}
+	info, err := os.Stat(wantFile)
+	if err != nil || info.Mode().Perm() != 0644 {
+		t.Fatalf("mode=%v err=%v", info.Mode(), err)
+	}
+}
+
+func TestCreateSkillAcceptsApprovedNamesAfterTrimming(t *testing.T) {
+	for _, input := range []string{"Upper", "a_b", "-start", "end-", "two--hyphens", "_", "A0-z_9", "  Trim_Me--  "} {
+		t.Run(input, func(t *testing.T) {
+			root := t.TempDir()
+			want := strings.TrimSpace(input)
+			result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: input})
+			if err != nil || result.Error != "" {
+				t.Fatalf("name %q was rejected: %#v err=%v", input, result, err)
+			}
+			if result.Name != want || result.Directory != filepath.Join(root, want) {
+				t.Fatalf("name was not trimmed/preserved: %#v", result)
+			}
+			if !strings.Contains(result.Content, "name: "+want) {
+				t.Fatalf("template does not preserve name %q: %q", want, result.Content)
+			}
+		})
+	}
+}
+
+func TestCreateSkillRejectsInvalidName(t *testing.T) {
+	root := t.TempDir()
+	invalid := []string{
+		"", "   ", "with space", "with\tspace", "line\nbreak",
+		"../escape", ".", "..", "a..b", "a/b", `a\b`,
+		"é", "技能", "name!", "name.", "name@host", "a:b", "a,b",
+	}
+	for _, name := range invalid {
+		result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: name})
+		if err != nil || result.Error == "" {
+			t.Errorf("name %q was not rejected: %#v err=%v", name, result, err)
+		}
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("invalid names created entries: %v err=%v", entries, err)
+	}
+}
+
+func TestCreateSkillNeverOverwrites(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "existing")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(file, []byte("keep me"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "existing"})
+	if err != nil || result.Error == "" {
+		t.Fatalf("expected conflict: %#v err=%v", result, err)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil || string(data) != "keep me" {
+		t.Fatalf("existing file changed: %q err=%v", data, err)
+	}
+}
+
+func TestCreateSkillRejectsCaseInsensitiveDuplicate(t *testing.T) {
+	root := t.TempDir()
+	first, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "Foo"})
+	if err != nil || first.Error != "" {
+		t.Fatalf("first create failed: %#v err=%v", first, err)
+	}
+
+	duplicate, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "foo"})
+	if err != nil || duplicate.Error == "" {
+		t.Fatalf("expected case-insensitive conflict: %#v err=%v", duplicate, err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "Foo" {
+		t.Fatalf("unexpected root entries after conflict: %v", entries)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "Foo", "SKILL.md"))
+	if err != nil || !strings.Contains(string(data), "name: Foo") {
+		t.Fatalf("original skill changed: %q err=%v", data, err)
+	}
+}
+
+func TestCreateSkillConcurrentCallsCreateExactlyOnce(t *testing.T) {
+	root := t.TempDir()
+	const callers = 16
+	results := make(chan CreateSkillResult, callers)
+	errs := make(chan error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "Concurrent_Skill"})
+			results <- result
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+	}
+	successes := 0
+	for result := range results {
+		if result.Error == "" {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful creations=%d, want 1", successes)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "Concurrent_Skill", "SKILL.md"))
+	if err != nil || !strings.Contains(string(data), "name: Concurrent_Skill") {
+		t.Fatalf("invalid winning skill file: %q err=%v", data, err)
+	}
+}
+
+func TestCreateSkillCleansPartialDirectory(t *testing.T) {
+	parent := t.TempDir()
+	rootFile := filepath.Join(parent, "not-a-directory")
+	if err := os.WriteFile(rootFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := CreateSkill(rootFile)(nil, CreateSkillArgs{Name: "new-skill"})
+	if err != nil || result.Error == "" {
+		t.Fatalf("expected root error: %#v err=%v", result, err)
+	}
+	if _, err := os.Stat(filepath.Join(rootFile, "new-skill")); err == nil {
+		t.Fatal("partial directory remains")
+	}
+}
+
+func TestNewCreateSkillTool(t *testing.T) {
+	toolInst, err := NewCreateSkillTool(t.TempDir())
+	if err != nil || toolInst.Name() != "create_skill" {
+		t.Fatalf("tool=%v err=%v", toolInst, err)
+	}
+}
+
+func TestCreateSkillWritesProvidedContent(t *testing.T) {
+	root := t.TempDir()
+	custom := `---
+name: my-custom
+description: "A fully custom skill"
+require_bins: []
+---
+
+# My Custom Skill
+
+Custom body.
+`
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "my-custom", Content: custom})
+	if err != nil || result.Error != "" {
+		t.Fatalf("create failed: %#v err=%v", result, err)
+	}
+	data, err := os.ReadFile(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != custom {
+		t.Fatalf("file content mismatch:\ngot:  %q\nwant: %q", data, custom)
+	}
+	if result.Content != custom {
+		t.Fatalf("result.Content mismatch:\ngot:  %q\nwant: %q", result.Content, custom)
+	}
+}
+
+func TestCreateSkillUsesTemplateWhenContentEmpty(t *testing.T) {
+	root := t.TempDir()
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "scaffold-only", Content: ""})
+	if err != nil || result.Error != "" {
+		t.Fatalf("create failed: %#v err=%v", result, err)
+	}
+	data, err := os.ReadFile(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "name: scaffold-only") {
+		t.Fatalf("expected template content, got: %q", data)
+	}
+}
+
+func TestCreateSkillUsesTemplateWhenContentWhitespace(t *testing.T) {
+	root := t.TempDir()
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "ws-only", Content: "   \n\t  "})
+	if err != nil || result.Error != "" {
+		t.Fatalf("create failed: %#v err=%v", result, err)
+	}
+	data, err := os.ReadFile(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "name: ws-only") {
+		t.Fatalf("expected template content, got: %q", data)
+	}
+}
+
+func TestEnsureSkillFrontmatterPreservesValidFrontmatter(t *testing.T) {
+	content := "---\nname: my-skill\ndescription: \"good\"\nrequire_bins: []\n---\n\n# Body\n"
+	got := ensureSkillFrontmatter(content, "my-skill")
+	if got != content {
+		t.Fatalf("expected content unchanged, got:\n%s", got)
+	}
+}
+
+func TestEnsureSkillFrontmatterInjectsMissingFrontmatter(t *testing.T) {
+	content := "# My Skill\n\nSome body text.\n"
+	got := ensureSkillFrontmatter(content, "my-skill")
+	if !strings.HasPrefix(got, "---\n") {
+		t.Fatalf("expected injected frontmatter, got:\n%s", got)
+	}
+	if !strings.Contains(got, "name: my-skill") {
+		t.Fatalf("expected name in injected frontmatter, got:\n%s", got)
+	}
+	if !strings.Contains(got, "description:") {
+		t.Fatalf("expected description in injected frontmatter, got:\n%s", got)
+	}
+	if !strings.Contains(got, "# My Skill") {
+		t.Fatalf("expected original body preserved, got:\n%s", got)
+	}
+}
+
+func TestCreateSkillAutoInjectsFrontmatterWhenMissing(t *testing.T) {
+	root := t.TempDir()
+	// Content without frontmatter — simulates what the agent wrote for openstack
+	body := "# OpenStack API\n\nInteract with OpenStack services via REST APIs.\n"
+	result, err := CreateSkill(root)(nil, CreateSkillArgs{Name: "openstack", Content: body})
+	if err != nil || result.Error != "" {
+		t.Fatalf("create failed: %#v err=%v", result, err)
+	}
+	data, err := os.ReadFile(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.HasPrefix(s, "---\n") {
+		t.Fatalf("expected SKILL.md to start with frontmatter, got:\n%s", s)
+	}
+	if !strings.Contains(s, "name: openstack") {
+		t.Fatalf("expected name in frontmatter, got:\n%s", s)
+	}
+	if !strings.Contains(s, "# OpenStack API") {
+		t.Fatalf("expected original body preserved, got:\n%s", s)
+	}
+}

--- a/pkg/tools/skill_lookup.go
+++ b/pkg/tools/skill_lookup.go
@@ -2,15 +2,28 @@ package tools
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/SAP/astonish/pkg/safepath"
 	"github.com/SAP/astonish/pkg/skills"
 	"github.com/SAP/astonish/pkg/store"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
+)
+
+const maxSkillFileBytes = 256 * 1024
+
+// SkillLookupMode controls which skill sources the lookup is allowed to use.
+type SkillLookupMode string
+
+const (
+	SkillLookupModeLocal    SkillLookupMode = "local"
+	SkillLookupModeCode     SkillLookupMode = "code"
+	SkillLookupModePlatform SkillLookupMode = "platform"
 )
 
 // SkillLookupArgs defines the arguments for the skill_lookup tool.
@@ -26,265 +39,318 @@ type SkillLookupResult struct {
 	Name                string              `json:"name"`
 	Description         string              `json:"description"`
 	Content             string              `json:"content"`
-	File                string              `json:"file,omitempty"`       // When a specific file was requested
-	Directory           string              `json:"directory,omitempty"`  // Legacy (disk-based skills)
-	Files               []string            `json:"files,omitempty"`      // Flat list of files (for compatibility)
-	FilesManifest       map[string][]string `json:"files_manifest,omitempty"` // Structured: path -> [filenames]
+	File                string              `json:"file,omitempty"`
+	Directory           string              `json:"directory,omitempty"`
+	Files               []string            `json:"files,omitempty"`
+	FilesManifest       map[string][]string `json:"files_manifest,omitempty"`
 	MissingRequirements []string            `json:"missing_requirements,omitempty"`
 	Error               string              `json:"error,omitempty"`
 }
 
-// SkillLookup returns full skill content by name.
-// All installed skills are indexed (eligible and ineligible) so the agent can
-// discover skills that need setup and guide the user through configuration.
+// SkillLookup returns full skill content by name. Platform mode consults tenant
+// stores in team > org > platform order before filesystem and builtin skills.
+// Local and Code modes never consult context-injected stores.
 //
-// At runtime, this function checks the context for tenant-scoped skill
-// stores (platform + org + team) injected via store.WithSkillStores.
-// Resolution order: team > org > platform > static/builtin (team wins on name collision).
-func SkillLookup(allSkills []skills.Skill) func(ctx tool.Context, args SkillLookupArgs) (SkillLookupResult, error) {
-	// Build index: start with built-in skills, then overlay caller-provided
-	// (filesystem-based) skills. User-provided skills override builtins on
-	// name collision.
+// The variadic mode preserves source compatibility until all launcher call sites
+// are migrated. An omitted mode retains the historical platform behavior.
+func SkillLookup(allSkills []skills.Skill, modes ...SkillLookupMode) func(ctx tool.Context, args SkillLookupArgs) (SkillLookupResult, error) {
+	mode := lookupMode(modes)
 	builtins := skills.BuiltinSkills()
 	staticIndex := make(map[string]*skills.Skill, len(builtins)+len(allSkills))
 	for i := range builtins {
-		staticIndex[builtins[i].Name] = &builtins[i]
+		staticIndex[strings.ToLower(builtins[i].Name)] = &builtins[i]
 	}
 	for i := range allSkills {
-		staticIndex[allSkills[i].Name] = &allSkills[i]
+		staticIndex[strings.ToLower(allSkills[i].Name)] = &allSkills[i]
 	}
 
 	return func(ctx tool.Context, args SkillLookupArgs) (SkillLookupResult, error) {
-		if args.Name == "" {
+		if strings.TrimSpace(args.Name) == "" {
 			return SkillLookupResult{Error: "name is required"}, nil
 		}
-
 		name := strings.ToLower(strings.TrimSpace(args.Name))
 
-		// Check tenant-scoped stores (team > org > platform)
-		if ctx != nil {
+		if mode == SkillLookupModePlatform && ctx != nil {
 			if ss := store.SkillStoresFromContext(ctx); ss != nil {
-				// Team store takes highest priority
-				if ss.Team != nil {
-					if skill, err := ss.Team.Get(ctx, name); err == nil && skill != nil {
-						return handlePlatformSkillLookup(ctx, ss.Team, skill, args), nil
+				for _, skillStore := range []store.SkillStore{ss.Team, ss.Org, ss.Platform} {
+					if skillStore == nil {
+						continue
 					}
-				}
-				// Then org store
-				if ss.Org != nil {
-					if skill, err := ss.Org.Get(ctx, name); err == nil && skill != nil {
-						return handlePlatformSkillLookup(ctx, ss.Org, skill, args), nil
-					}
-				}
-				// Then platform store (lowest DB tier)
-				if ss.Platform != nil {
-					if skill, err := ss.Platform.Get(ctx, name); err == nil && skill != nil {
-						return handlePlatformSkillLookup(ctx, ss.Platform, skill, args), nil
+					if skill, err := skillStore.Get(ctx, name); err == nil && skill != nil {
+						return handlePlatformSkillLookup(ctx, skillStore, skill, args), nil
 					}
 				}
 			}
 		}
 
-		// Fall back to static/filesystem index (personal mode only)
 		skill, ok := staticIndex[name]
 		if !ok {
-			names := collectAllSkillNames(staticIndex, ctx)
+			names := collectAllSkillNames(staticIndex, ctx, mode)
 			if len(names) == 0 {
-				return SkillLookupResult{
-					Error: fmt.Sprintf("skill %q not found. No skills are configured.", args.Name),
-				}, nil
+				return SkillLookupResult{Error: fmt.Sprintf("skill %q not found. No skills are configured.", args.Name)}, nil
 			}
-			return SkillLookupResult{
-				Error: fmt.Sprintf("skill %q not found. Available: %s", args.Name, strings.Join(names, ", ")),
-			}, nil
+			return SkillLookupResult{Error: fmt.Sprintf("skill %q not found. Available: %s", args.Name, strings.Join(names, ", "))}, nil
 		}
-
-		result := SkillLookupResult{
-			Name:        skill.Name,
-			Description: skill.Description,
-			Content:     skill.Content,
-		}
-
-		// Include missing requirements so the agent can guide setup
-		if missing := skill.MissingRequirements(); len(missing) > 0 {
-			result.MissingRequirements = missing
-		}
-
-		// Include directory and file listing for disk-based skills
-		if skill.Directory != "" {
-			result.Directory = skill.Directory
-			if entries, err := os.ReadDir(skill.Directory); err == nil {
-				for _, e := range entries {
-					if !e.IsDir() {
-						result.Files = append(result.Files, e.Name())
-					}
-				}
-			}
-		}
-
-		return result, nil
+		return handleFilesystemSkillLookup(skill, args), nil
 	}
 }
 
-// storeSkillToResult converts a store.Skill to a SkillLookupResult.
-func storeSkillToResult(s *store.Skill) SkillLookupResult {
-	// Parse the raw content to extract the body (after frontmatter)
-	parsed, err := skills.ParseSkillFile("store:"+s.Name, []byte(s.Content))
+func lookupMode(modes []SkillLookupMode) SkillLookupMode {
+	if len(modes) == 0 {
+		return SkillLookupModePlatform
+	}
+	return modes[0]
+}
+
+func handleFilesystemSkillLookup(skill *skills.Skill, args SkillLookupArgs) SkillLookupResult {
+	result := SkillLookupResult{Name: skill.Name, Description: skill.Description, Content: skill.Content}
+	if missing := skill.MissingRequirements(); len(missing) > 0 {
+		result.MissingRequirements = missing
+	}
+	if skill.Directory == "" {
+		if requestedFile(args) != "" {
+			result.Content = ""
+			result.Error = fmt.Sprintf("skill %q has no filesystem files", skill.Name)
+		}
+		return result
+	}
+
+	root, err := filepath.EvalSymlinks(skill.Directory)
 	if err != nil {
-		// If parsing fails, return the raw content
-		return SkillLookupResult{
-			Name:        s.Name,
-			Description: s.Description,
-			Content:     s.Content,
+		result.Error = fmt.Sprintf("failed to access files for skill %q", skill.Name)
+		return result
+	}
+	root, err = filepath.Abs(root)
+	if err != nil {
+		result.Error = fmt.Sprintf("failed to access files for skill %q", skill.Name)
+		return result
+	}
+	result.Directory = root
+
+	if filePath := requestedFile(args); filePath != "" {
+		cleaned, err := cleanSkillRelativePath(filePath)
+		if err != nil {
+			result.Content = ""
+			result.Error = err.Error()
+			return result
+		}
+		data, err := readContainedSkillFile(root, cleaned)
+		result.Content = ""
+		if err != nil {
+			result.Error = fmt.Sprintf("failed to load file %q from skill %q: %v", cleaned, skill.Name, err)
+			return result
+		}
+		result.File = cleaned
+		result.Content = string(data)
+		return result
+	}
+
+	files, manifest, err := filesystemSkillManifest(root)
+	if err != nil {
+		result.Error = fmt.Sprintf("failed to list files for skill %q: %v", skill.Name, err)
+		return result
+	}
+	result.Files = files
+	result.FilesManifest = manifest
+	return result
+}
+
+func requestedFile(args SkillLookupArgs) string {
+	filePath := strings.TrimSpace(args.File)
+	if filePath == "" && strings.TrimSpace(args.Filename) != "" {
+		filePath = strings.TrimSpace(args.Filename)
+		if strings.TrimSpace(args.Path) != "" {
+			filePath = strings.TrimSpace(args.Path) + "/" + filePath
 		}
 	}
-	result := SkillLookupResult{
-		Name:        parsed.Name,
-		Description: parsed.Description,
-		Content:     parsed.Content,
+	return filePath
+}
+
+func cleanSkillRelativePath(path string) (string, error) {
+	if path == "" || strings.Contains(path, "\\") || filepath.IsAbs(path) {
+		return "", fmt.Errorf("invalid file path: must be a clean relative path without '..' or leading '/'")
 	}
+	cleaned := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+	if cleaned == "." || cleaned != path || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("invalid file path: must be a clean relative path without '..' or leading '/'")
+	}
+	return cleaned, nil
+}
+
+func readContainedSkillFile(root, relative string) ([]byte, error) {
+	candidate := filepath.Join(root, filepath.FromSlash(relative))
+	if err := safepath.ContainedWithin(candidate, root); err != nil {
+		return nil, fmt.Errorf("path escapes skill directory")
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("file not found")
+		}
+		return nil, fmt.Errorf("file is not accessible")
+	}
+	if err := safepath.ContainedWithin(resolved, root); err != nil {
+		return nil, fmt.Errorf("path escapes skill directory through a symlink")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("path is not a regular file")
+	}
+	f, err := os.Open(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("file is not accessible")
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxSkillFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("file is not readable")
+	}
+	if len(data) > maxSkillFileBytes {
+		return nil, fmt.Errorf("file exceeds 256KiB limit")
+	}
+	return data, nil
+}
+
+func filesystemSkillManifest(root string) ([]string, map[string][]string, error) {
+	var files []string
+	manifest := make(map[string][]string)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("path escapes skill directory")
+		}
+		rel = filepath.ToSlash(rel)
+		files = append(files, rel)
+		dir, name := filepath.ToSlash(filepath.Dir(rel)), filepath.Base(rel)
+		if dir == "." {
+			dir = ""
+		}
+		manifest[dir] = append(manifest[dir], name)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Strings(files)
+	for dir := range manifest {
+		sort.Strings(manifest[dir])
+	}
+	if len(manifest) == 0 {
+		manifest = nil
+	}
+	return files, manifest, nil
+}
+
+func storeSkillToResult(s *store.Skill) SkillLookupResult {
+	parsed, err := skills.ParseSkillFile("store:"+s.Name, []byte(s.Content))
+	if err != nil {
+		return SkillLookupResult{Name: s.Name, Description: s.Description, Content: s.Content}
+	}
+	result := SkillLookupResult{Name: parsed.Name, Description: parsed.Description, Content: parsed.Content}
 	if missing := parsed.MissingRequirements(); len(missing) > 0 {
 		result.MissingRequirements = missing
 	}
 	return result
 }
 
-// collectAllSkillNames gathers skill names from static index + context stores.
-func collectAllSkillNames(staticIndex map[string]*skills.Skill, ctx tool.Context) []string {
+func collectAllSkillNames(staticIndex map[string]*skills.Skill, ctx tool.Context, mode SkillLookupMode) []string {
 	nameSet := make(map[string]struct{}, len(staticIndex))
-	for n := range staticIndex {
-		nameSet[n] = struct{}{}
+	for _, skill := range staticIndex {
+		nameSet[skill.Name] = struct{}{}
 	}
-
-	if ctx != nil {
+	if mode == SkillLookupModePlatform && ctx != nil {
 		if ss := store.SkillStoresFromContext(ctx); ss != nil {
-			if ss.Platform != nil {
-				if platformSkills, err := ss.Platform.List(ctx); err == nil {
-					for _, s := range platformSkills {
-						nameSet[s.Name] = struct{}{}
-					}
+			for _, skillStore := range []store.SkillStore{ss.Platform, ss.Org, ss.Team} {
+				if skillStore == nil {
+					continue
 				}
-			}
-			if ss.Org != nil {
-				if orgSkills, err := ss.Org.List(ctx); err == nil {
-					for _, s := range orgSkills {
-						nameSet[s.Name] = struct{}{}
-					}
-				}
-			}
-			if ss.Team != nil {
-				if teamSkills, err := ss.Team.List(ctx); err == nil {
-					for _, s := range teamSkills {
-						nameSet[s.Name] = struct{}{}
+				if stored, err := skillStore.List(ctx); err == nil {
+					for _, skill := range stored {
+						nameSet[skill.Name] = struct{}{}
 					}
 				}
 			}
 		}
 	}
-
 	names := make([]string, 0, len(nameSet))
-	for n := range nameSet {
-		names = append(names, n)
+	for name := range nameSet {
+		names = append(names, name)
 	}
 	sort.Strings(names)
 	return names
 }
 
-// NewSkillLookupTool creates the skill_lookup tool.
-func NewSkillLookupTool(allSkills []skills.Skill) (tool.Tool, error) {
+// NewSkillLookupTool creates the skill_lookup tool. See SkillLookup for the
+// temporary omitted-mode compatibility behavior.
+func NewSkillLookupTool(allSkills []skills.Skill, modes ...SkillLookupMode) (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
 		Name: "skill_lookup",
 		Description: "Load full instructions for a CLI tool skill by name. " +
 			"Use this to learn how to use a CLI tool or workflow before executing commands. " +
 			"If a skill references environment variables for auth, resolve them from the credential store. " +
 			"Check the Available Skills list in the system prompt for valid skill names.",
-	}, SkillLookup(allSkills))
+	}, SkillLookup(allSkills, modes...))
 }
 
-// handlePlatformSkillLookup handles skill_lookup for skills coming from platform stores (DB).
-// It supports fetching specific auxiliary files and returns a files manifest when loading the main skill.
-// SECURITY: Skills with non-usable validation_status are blocked at runtime.
-func handlePlatformSkillLookup(ctx tool.Context, store store.SkillStore, skill *store.Skill, args SkillLookupArgs) SkillLookupResult {
-	// Runtime validation gate — only skills with usable status can be loaded
+func handlePlatformSkillLookup(ctx tool.Context, skillStore store.SkillStore, skill *store.Skill, args SkillLookupArgs) SkillLookupResult {
 	if !skills.IsUsableStatus(skill.ValidationStatus) {
-		return SkillLookupResult{
-			Name: skill.Name,
-			Error: fmt.Sprintf("Skill %q is blocked (validation_status: %q). "+
-				"A team member must validate and acknowledge any critical security issues "+
-				"in Settings → Skills before this skill can be used.", skill.Name, skill.ValidationStatus),
-		}
+		return SkillLookupResult{Name: skill.Name, Error: fmt.Sprintf("Skill %q is blocked (validation_status: %q). A team member must validate and acknowledge any critical security issues in Settings → Skills before this skill can be used.", skill.Name, skill.ValidationStatus)}
 	}
-	// Determine if user asked for a specific file
-	filePath := strings.TrimSpace(args.File)
-	if filePath == "" && args.Filename != "" {
-		if args.Path != "" {
-			filePath = args.Path + "/" + args.Filename
-		} else {
-			filePath = args.Filename
-		}
-	}
-
-	if filePath != "" {
-		// Canonicalize and validate for path traversal
-		cleaned := filepath.ToSlash(filepath.Clean(filePath))
-		if cleaned != filePath || strings.Contains(cleaned, "..") || strings.HasPrefix(cleaned, "/") {
-			return SkillLookupResult{
-				Name:  skill.Name,
-				Error: "invalid file path: must be a clean relative path without '..' or leading '/'",
-			}
-		}
-		filePath = cleaned
-
-		// Specific file requested
-		// Normalize path/filename
-		dir, name := "", filePath
-		if idx := strings.LastIndex(filePath, "/"); idx != -1 {
-			dir = filePath[:idx]
-			name = filePath[idx+1:]
-		}
-		f, err := store.GetFile(ctx, skill.Name, dir, name)
+	if filePath := requestedFile(args); filePath != "" {
+		cleaned, err := cleanSkillRelativePath(filePath)
 		if err != nil {
-			// DB error — distinct from "file not found"
-			return SkillLookupResult{
-				Name:  skill.Name,
-				Error: fmt.Sprintf("failed to load file %q from skill %q (database error)", filePath, skill.Name),
-			}
+			return SkillLookupResult{Name: skill.Name, Error: err.Error()}
 		}
-		if f != nil {
-			return SkillLookupResult{
-				Name:      skill.Name,
-				File:      filePath,
-				Content:   f.Content,
-				Directory: "", // not meaningful for DB-backed files
-			}
+		dir, name := filepath.ToSlash(filepath.Dir(cleaned)), filepath.Base(cleaned)
+		if dir == "." {
+			dir = ""
 		}
-		// File not found
-		return SkillLookupResult{
-			Name:  skill.Name,
-			Error: fmt.Sprintf("file %q not found in skill %q", filePath, skill.Name),
+		f, err := skillStore.GetFile(ctx, skill.Name, dir, name)
+		if err != nil {
+			return SkillLookupResult{Name: skill.Name, Error: fmt.Sprintf("failed to load file %q from skill %q (database error)", cleaned, skill.Name)}
 		}
+		if f == nil {
+			return SkillLookupResult{Name: skill.Name, Error: fmt.Sprintf("file %q not found in skill %q", cleaned, skill.Name)}
+		}
+		if len(f.Content) > maxSkillFileBytes {
+			return SkillLookupResult{Name: skill.Name, Error: fmt.Sprintf("file %q exceeds 256KiB limit", cleaned)}
+		}
+		return SkillLookupResult{Name: skill.Name, File: cleaned, Content: f.Content}
 	}
 
-	// Default: return main skill content + files manifest
 	result := storeSkillToResult(skill)
-
-	// Attach files manifest from the new skill_files table
-	if files, err := store.ListFiles(ctx, skill.Name); err == nil && len(files) > 0 {
-		manifest := make(map[string][]string)
+	if files, err := skillStore.ListFiles(ctx, skill.Name); err == nil && len(files) > 0 {
+		result.FilesManifest = make(map[string][]string)
 		for _, f := range files {
-			manifest[f.Path] = append(manifest[f.Path], f.Filename)
-		}
-		// For backward compat with existing result shape, also populate flat Files list
-		for _, f := range files {
+			result.FilesManifest[f.Path] = append(result.FilesManifest[f.Path], f.Filename)
 			full := f.Filename
 			if f.Path != "" {
 				full = f.Path + "/" + f.Filename
 			}
 			result.Files = append(result.Files, full)
 		}
-		// Also expose structured manifest (new field)
-		result.FilesManifest = manifest
+		sort.Strings(result.Files)
+		for path := range result.FilesManifest {
+			sort.Strings(result.FilesManifest[path])
+		}
 	}
-
 	return result
 }

--- a/pkg/tools/skill_lookup_test.go
+++ b/pkg/tools/skill_lookup_test.go
@@ -1,107 +1,179 @@
 package tools
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/SAP/astonish/pkg/skills"
+	"github.com/SAP/astonish/pkg/store"
 )
 
 func TestSkillLookupFound(t *testing.T) {
-	allSkills := []skills.Skill{
-		{Name: "test-skill", Description: "A test skill", Content: "# Test\n\nHello world.", RequireBins: []string{"echo"}},
-	}
-
-	fn := SkillLookup(allSkills)
+	fn := SkillLookup([]skills.Skill{{Name: "test-skill", Description: "A test skill", Content: "# Test\n\nHello world.", RequireBins: []string{"echo"}}}, SkillLookupModeLocal)
 	result, err := fn(nil, SkillLookupArgs{Name: "test-skill"})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	if err != nil || result.Error != "" {
+		t.Fatalf("lookup failed: result=%#v err=%v", result, err)
 	}
-	if result.Error != "" {
-		t.Fatalf("Unexpected error in result: %s", result.Error)
-	}
-	if result.Name != "test-skill" {
-		t.Errorf("Name = %q, want %q", result.Name, "test-skill")
-	}
-	if result.Content != "# Test\n\nHello world." {
-		t.Errorf("Content = %q, want expected content", result.Content)
+	if result.Name != "test-skill" || result.Content != "# Test\n\nHello world." {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 
 func TestSkillLookupNotFound(t *testing.T) {
-	allSkills := []skills.Skill{
-		{Name: "existing", Description: "Exists", Content: "content", RequireBins: []string{"echo"}},
-	}
-
-	fn := SkillLookup(allSkills)
+	fn := SkillLookup([]skills.Skill{{Name: "existing", Description: "Exists", Content: "content"}}, SkillLookupModeLocal)
 	result, err := fn(nil, SkillLookupArgs{Name: "nonexistent"})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if result.Error == "" {
-		t.Error("Expected error for nonexistent skill")
-	}
-	if !containsStr(result.Error, "existing") {
-		t.Errorf("Error should list available skills, got: %s", result.Error)
+	if err != nil || !strings.Contains(result.Error, "existing") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
 	}
 }
 
 func TestSkillLookupEmptyName(t *testing.T) {
-	fn := SkillLookup(nil)
-	result, err := fn(nil, SkillLookupArgs{Name: ""})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if result.Error == "" {
-		t.Error("Expected error for empty name")
+	result, err := SkillLookup(nil, SkillLookupModeLocal)(nil, SkillLookupArgs{})
+	if err != nil || result.Error == "" {
+		t.Fatalf("expected validation error: %#v err=%v", result, err)
 	}
 }
 
 func TestSkillLookupIneligibleReturnsWithMissingReqs(t *testing.T) {
-	allSkills := []skills.Skill{
-		{Name: "missing-bin", Description: "Missing", Content: "content", RequireBins: []string{"nonexistent_xyz123"}},
+	fn := SkillLookup([]skills.Skill{{Name: "missing-bin", Description: "Missing", Content: "content", RequireBins: []string{"nonexistent_xyz123"}}}, SkillLookupModeLocal)
+	result, err := fn(nil, SkillLookupArgs{Name: "missing-bin"})
+	if err != nil || result.Error != "" || len(result.MissingRequirements) == 0 || !strings.Contains(result.MissingRequirements[0], "nonexistent_xyz123") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+}
+
+func TestSkillLookupFilesystemNestedReadAndRecursiveManifest(t *testing.T) {
+	root := t.TempDir()
+	writeLookupFile(t, root, "SKILL.md", "main")
+	writeLookupFile(t, root, "scripts/deploy.sh", "deploy")
+	writeLookupFile(t, root, "references/nested/api.md", "api")
+	skill := skills.Skill{Name: "disk", Description: "disk", Content: "body", Directory: root}
+	fn := SkillLookup([]skills.Skill{skill}, SkillLookupModeLocal)
+
+	manifest, err := fn(nil, SkillLookupArgs{Name: "disk"})
+	if err != nil || manifest.Error != "" {
+		t.Fatalf("manifest failed: %#v err=%v", manifest, err)
+	}
+	want := []string{"SKILL.md", "references/nested/api.md", "scripts/deploy.sh"}
+	if strings.Join(manifest.Files, ",") != strings.Join(want, ",") {
+		t.Fatalf("files=%v want=%v", manifest.Files, want)
+	}
+	if got := manifest.FilesManifest["references/nested"]; len(got) != 1 || got[0] != "api.md" {
+		t.Fatalf("manifest=%#v", manifest.FilesManifest)
 	}
 
-	fn := SkillLookup(allSkills)
-	result, err := fn(nil, SkillLookupArgs{Name: "missing-bin"})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	file, err := fn(nil, SkillLookupArgs{Name: "disk", Path: "references/nested", Filename: "api.md"})
+	if err != nil || file.Error != "" || file.File != "references/nested/api.md" || file.Content != "api" {
+		t.Fatalf("nested read failed: %#v err=%v", file, err)
 	}
-	if result.Error != "" {
-		t.Errorf("Ineligible skill should be found, not return error: %s", result.Error)
+}
+
+func TestSkillLookupFilesystemRejectsTraversalSymlinksAndOversize(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
 	}
-	if result.Name != "missing-bin" {
-		t.Errorf("Name = %q, want %q", result.Name, "missing-bin")
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
 	}
-	if result.Content != "content" {
-		t.Errorf("Content = %q, want %q", result.Content, "content")
+	writeLookupFile(t, root, "large.txt", strings.Repeat("x", maxSkillFileBytes+1))
+	fn := SkillLookup([]skills.Skill{{Name: "disk", Description: "disk", Directory: root}}, SkillLookupModeCode)
+
+	for _, file := range []string{"../secret.txt", "escape", "large.txt"} {
+		result, err := fn(nil, SkillLookupArgs{Name: "disk", File: file})
+		if err != nil || result.Error == "" || result.Content != "" {
+			t.Errorf("file %q should be rejected: %#v err=%v", file, result, err)
+		}
 	}
-	if len(result.MissingRequirements) == 0 {
-		t.Error("Expected MissingRequirements to be populated for ineligible skill")
+	manifest, _ := fn(nil, SkillLookupArgs{Name: "disk"})
+	for _, file := range manifest.Files {
+		if file == "escape" {
+			t.Fatalf("symlink leaked into manifest: %v", manifest.Files)
+		}
 	}
-	if !containsStr(result.MissingRequirements[0], "nonexistent_xyz123") {
-		t.Errorf("MissingRequirements should mention missing binary, got: %v", result.MissingRequirements)
+}
+
+func TestSkillLookupModesAndPlatformPrecedence(t *testing.T) {
+	platform := &lookupSkillStore{skills: []store.Skill{{Name: "shared", Description: "platform", Content: skillDocument("shared", "platform"), ValidationStatus: skills.ValidationStatusClean}}}
+	org := &lookupSkillStore{skills: []store.Skill{{Name: "shared", Description: "org", Content: skillDocument("shared", "org"), ValidationStatus: skills.ValidationStatusClean}}}
+	team := &lookupSkillStore{skills: []store.Skill{{Name: "shared", Description: "team", Content: skillDocument("shared", "team"), ValidationStatus: skills.ValidationStatusClean}}}
+	base := store.WithSkillStores(context.Background(), &store.SkillStores{Platform: platform, Org: org, Team: team})
+	ctx := &mockToolCtx{Context: base}
+	filesystem := []skills.Skill{{Name: "shared", Description: "filesystem", Content: "filesystem"}}
+
+	for _, mode := range []SkillLookupMode{SkillLookupModeLocal, SkillLookupModeCode} {
+		result, err := SkillLookup(filesystem, mode)(ctx, SkillLookupArgs{Name: "shared"})
+		if err != nil || result.Content != "filesystem" {
+			t.Fatalf("mode %s touched stores: %#v err=%v", mode, result, err)
+		}
+	}
+	if platform.getCalls != 0 || org.getCalls != 0 || team.getCalls != 0 {
+		t.Fatalf("local modes touched DB stores: platform=%d org=%d team=%d", platform.getCalls, org.getCalls, team.getCalls)
+	}
+
+	result, err := SkillLookup(filesystem, SkillLookupModePlatform)(ctx, SkillLookupArgs{Name: "shared"})
+	if err != nil || result.Content != "team" {
+		t.Fatalf("team did not win: %#v err=%v", result, err)
+	}
+	if team.getCalls != 1 || org.getCalls != 0 || platform.getCalls != 0 {
+		t.Fatalf("unexpected precedence calls: platform=%d org=%d team=%d", platform.getCalls, org.getCalls, team.getCalls)
 	}
 }
 
 func TestNewSkillLookupTool(t *testing.T) {
-	allSkills := []skills.Skill{
-		{Name: "test", Description: "Test", Content: "content", RequireBins: []string{"echo"}},
-	}
-
-	toolInst, err := NewSkillLookupTool(allSkills)
-	if err != nil {
-		t.Fatalf("NewSkillLookupTool failed: %v", err)
-	}
-	if toolInst.Name() != "skill_lookup" {
-		t.Errorf("Name = %q, want %q", toolInst.Name(), "skill_lookup")
+	toolInst, err := NewSkillLookupTool(nil, SkillLookupModeLocal)
+	if err != nil || toolInst.Name() != "skill_lookup" {
+		t.Fatalf("tool=%v err=%v", toolInst, err)
 	}
 }
 
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
+func writeLookupFile(t *testing.T, root, relative, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func skillDocument(name, body string) string {
+	return "---\nname: " + name + "\ndescription: test\n---\n\n" + body
+}
+
+type lookupSkillStore struct {
+	skills   []store.Skill
+	getCalls int
+}
+
+func (m *lookupSkillStore) LoadAll(context.Context) ([]store.Skill, error) { return m.skills, nil }
+func (m *lookupSkillStore) Get(_ context.Context, name string) (*store.Skill, error) {
+	m.getCalls++
+	for i := range m.skills {
+		if m.skills[i].Name == name {
+			return &m.skills[i], nil
 		}
 	}
-	return false
+	return nil, nil
 }
+func (m *lookupSkillStore) Save(context.Context, *store.Skill) error { return nil }
+func (m *lookupSkillStore) Delete(context.Context, string) error     { return nil }
+func (m *lookupSkillStore) List(context.Context) ([]store.Skill, error) {
+	return m.skills, nil
+}
+func (m *lookupSkillStore) UpdateValidationStatus(context.Context, string, string, string) error {
+	return nil
+}
+func (m *lookupSkillStore) ListFiles(context.Context, string) ([]store.SkillFile, error) {
+	return nil, nil
+}
+func (m *lookupSkillStore) GetFile(context.Context, string, string, string) (*store.SkillFile, error) {
+	return nil, nil
+}
+func (m *lookupSkillStore) SaveFile(context.Context, string, *store.SkillFile) error { return nil }
+func (m *lookupSkillStore) DeleteFile(context.Context, string, string, string) error { return nil }

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -189,6 +189,7 @@ type model struct {
 	modelPicker      modelPickerState
 	providerPicker   providerPickerState
 	webSearchPicker  webSearchPickerState
+	skillsPicker     skillsPickerState
 	fileViewer       fileViewerState
 	delegationDetail delegationDetailState
 	// slash command completion popup (active when composer starts with /)
@@ -419,6 +420,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.webSearchPicker.open {
 			return m.handleWebSearchPickerKey(msg)
 		}
+		if m.skillsPicker.open {
+			return m.handleSkillsPickerKey(msg)
+		}
 		if m.rollback.open {
 			return m.handleRollbackKey(msg)
 		}
@@ -636,6 +640,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case perplexityOptionsLoadedMsg:
 		return m.applyPerplexityOptionsLoaded(msg)
+
+	case skillsLoadedMsg:
+		return m.applySkillsLoaded(msg)
 
 	case perplexityConfiguredMsg:
 		return m.applyPerplexityConfigured(msg)
@@ -858,6 +865,9 @@ func (m *model) syncSlashCompletion() {
 	}
 	if m.compactionCap() != nil {
 		extra = append(extra, compactSlashCommand)
+	}
+	if m.localSkillsCap() != nil {
+		extra = append(extra, skillsSlashCommand)
 	}
 	matches := filterSlashCommands(query, extra...)
 	cursor := m.slash.cursor
@@ -1137,7 +1147,7 @@ func isClipboardPasteKey(msg tea.KeyMsg) bool {
 }
 
 func (m model) tryPasteImage() (tea.Model, tea.Cmd, bool) {
-	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.fileViewer.open {
+	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.skillsPicker.open || m.fileViewer.open {
 		return m, nil, false
 	}
 	if m.tr.Streaming && !m.tr.Awaiting {
@@ -1159,7 +1169,7 @@ func (m model) tryPasteImage() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m model) insertPastedImage(data []byte, mimeType string) (tea.Model, tea.Cmd) {
-	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.fileViewer.open {
+	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.skillsPicker.open || m.fileViewer.open {
 		return m, nil
 	}
 	prevH := m.composerTextHeight()
@@ -1183,7 +1193,7 @@ func (m model) insertPastedImage(data []byte, mimeType string) (tea.Model, tea.C
 }
 
 func (m model) handlePaste(text string) (tea.Model, tea.Cmd) {
-	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.fileViewer.open {
+	if m.sessions.open || m.rollback.open || m.modelPicker.open || m.providerPicker.open || m.webSearchPicker.open || m.skillsPicker.open || m.fileViewer.open {
 		return m, nil
 	}
 	if m.tr.Streaming && !m.tr.Awaiting {
@@ -1846,7 +1856,7 @@ func (m model) handleSlash(text string) (tea.Model, tea.Cmd) {
 	m.ta.Reset()
 	switch {
 	case text == "/help" || text == "/?":
-		m.tr.Apply(events.NewSystem(helpText(m.providerAdmin() != nil, m.webSearchAdmin() != nil, m.rollbackCap() != nil, m.compactionCap() != nil)))
+		m.tr.Apply(events.NewSystem(helpText(m.providerAdmin() != nil, m.webSearchAdmin() != nil, m.rollbackCap() != nil, m.compactionCap() != nil, m.localSkillsCap() != nil)))
 	case text == "/files":
 		cwd, _ := os.Getwd()
 		m.tr.Apply(events.NewSystem("Type `@` plus part of a local path to attach file context from " + cwd + "."))
@@ -1873,6 +1883,8 @@ func (m model) handleSlash(text string) (tea.Model, tea.Cmd) {
 		return m.openRollbackPicker()
 	case text == "/compact":
 		return m.runCompact()
+	case text == "/skills":
+		return m.openSkillsPicker()
 	default:
 		// Pass through to backend as a normal message so server/local slash handlers can run later.
 		m.history = append(m.history, text)
@@ -1896,7 +1908,8 @@ func (m model) handleSlash(text string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func helpText(providerAdmin bool, webSearch bool, rollback bool, compaction bool) string {
+func helpText(providerAdmin bool, webSearch bool, rollback bool, compaction bool, localSkillsCapability ...bool) string {
+	localSkills := len(localSkillsCapability) > 0 && localSkillsCapability[0]
 	providerLine := ""
 	if providerAdmin {
 		providerLine = "\n  /provider      Manage local providers (add/remove)"
@@ -1913,12 +1926,16 @@ func helpText(providerAdmin bool, webSearch bool, rollback bool, compaction bool
 	if compaction {
 		compactLine = "\n  /compact       Compact the conversation context to free up the window"
 	}
+	skillsLine := ""
+	if localSkills {
+		skillsLine = "\n  /skills        List local runtime skills"
+	}
 	return strings.TrimSpace(`
 Commands:
   /help          Show this help (/?)
   /status        Show session / provider / model
   /sessions      Open sessions picker (also ctrl+l)
-  /model         Choose provider and model` + providerLine + webSearchLine + rollbackLine + compactLine + `
+  /model         Choose provider and model` + providerLine + webSearchLine + rollbackLine + compactLine + skillsLine + `
   /new           Start a new session (also ctrl+n)
   /files         Show @file context help
   /plan          Toggle plan-only mode (also shift+tab)
@@ -3321,7 +3338,7 @@ func (m model) viewContent() string {
 
 	// Completion popups sit just above the composer (filter-as-you-type).
 	composerBlock := m.renderComposer()
-	if !m.tr.Awaiting && !m.sessions.open && !m.rollback.open && !m.modelPicker.open && !m.providerPicker.open && !m.webSearchPicker.open {
+	if !m.tr.Awaiting && !m.sessions.open && !m.rollback.open && !m.modelPicker.open && !m.providerPicker.open && !m.webSearchPicker.open && !m.skillsPicker.open {
 		switch {
 		case m.slash.active && len(m.slash.matches) > 0:
 			composerBlock = lipgloss.JoinVertical(lipgloss.Left,
@@ -3383,6 +3400,9 @@ func (m model) viewContent() string {
 			lipgloss.WithWhitespaceChars(" "),
 			lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(lipgloss.Color("#000000"))),
 		))
+	}
+	if m.skillsPicker.open {
+		return m.renderSkillsOverlay()
 	}
 	if m.rollback.open {
 		overlay := m.renderRollbackOverlay()

--- a/pkg/tui/backend/backend.go
+++ b/pkg/tui/backend/backend.go
@@ -110,6 +110,21 @@ type NetworkGrantBackend interface {
 	DenyNetworkGrant(ctx context.Context, sessionID string, denial events.NetworkDenial, sandboxName string) error
 }
 
+// SkillSummary describes one skill available to the local runtime.
+type SkillSummary struct {
+	Name        string
+	Description string
+	Source      string
+	Eligible    bool
+	Missing     []string
+}
+
+// LocalSkillsBackend is an optional capability implemented by local code-mode
+// backends. Platform backends intentionally do not expose this capability.
+type LocalSkillsBackend interface {
+	ListLocalSkills(ctx context.Context) ([]SkillSummary, error)
+}
+
 // ProviderInstance is one configured provider entry shown in the /provider
 // manager overlay.
 type ProviderInstance struct {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -24,6 +24,10 @@ var builtInSlashCommands = []slashCommand{
 	{Name: "exit", Aliases: []string{"quit", "q"}, Description: "Quit the terminal app"},
 }
 
+var skillsSlashCommand = slashCommand{
+	Name: "skills", Description: "List local runtime skills",
+}
+
 // providerSlashCommand is offered only when the backend supports local provider
 // management (code mode). It is not part of the always-on palette.
 var providerSlashCommand = slashCommand{

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -69,7 +69,7 @@ func TestParseSlashInput(t *testing.T) {
 // tell the user that Esc cancels the current turn (Claude Code / OpenCode
 // style), not only ctrl+c. See cancelInFlightTurn.
 func TestHelpText_DocumentsEscCancel(t *testing.T) {
-	h := helpText(false, false, false, false)
+	h := helpText(false, false, false, false, false)
 	if !strings.Contains(h, "esc") {
 		t.Fatalf("help text missing esc key:\n%s", h)
 	}
@@ -83,7 +83,7 @@ func TestHelpText_DocumentsEscCancel(t *testing.T) {
 // TestHelpText_ListsAllBuiltInCommands keeps /help in sync with the command
 // palette so no supported command is silently missing from help.
 func TestHelpText_ListsAllBuiltInCommands(t *testing.T) {
-	h := helpText(false, false, false, false)
+	h := helpText(false, false, false, false, false)
 	for _, cmd := range builtInSlashCommands {
 		if !strings.Contains(h, "/"+cmd.Name) {
 			t.Errorf("help text missing command /%s:\n%s", cmd.Name, h)
@@ -94,11 +94,11 @@ func TestHelpText_ListsAllBuiltInCommands(t *testing.T) {
 // TestHelpText_CapabilityGatedCommands ensures /provider, /websearch, and /rollback appear
 // only when their backend capability is available.
 func TestHelpText_CapabilityGatedCommands(t *testing.T) {
-	off := helpText(false, false, false, false)
-	if strings.Contains(off, "/provider") || strings.Contains(off, "/rollback") || strings.Contains(off, "/websearch") {
+	off := helpText(false, false, false, false, false)
+	if strings.Contains(off, "/provider") || strings.Contains(off, "/rollback") || strings.Contains(off, "/websearch") || strings.Contains(off, "/skills") {
 		t.Fatalf("gated commands should be hidden when unavailable:\n%s", off)
 	}
-	on := helpText(true, true, true, true)
+	on := helpText(true, true, true, true, true)
 	if !strings.Contains(on, "/provider") {
 		t.Errorf("help text missing /provider when provider admin available:\n%s", on)
 	}
@@ -114,5 +114,8 @@ func TestHelpText_CapabilityGatedCommands(t *testing.T) {
 	}
 	if !strings.Contains(on, "/compact") {
 		t.Errorf("help text missing /compact when compaction available:\n%s", on)
+	}
+	if !strings.Contains(on, "/skills") {
+		t.Errorf("help text missing /skills when local skills available:\n%s", on)
 	}
 }

--- a/pkg/tui/skills.go
+++ b/pkg/tui/skills.go
@@ -1,0 +1,209 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/SAP/astonish/pkg/tui/backend"
+	"github.com/SAP/astonish/pkg/tui/events"
+)
+
+const localSkillsOnlyNotice = "/skills is available only in local code mode."
+
+// skillsPickerState holds the /skills overlay state.
+type skillsPickerState struct {
+	open    bool
+	loading bool
+	err     string
+	items   []backend.SkillSummary
+	cursor  int
+}
+
+// skillsLoadedMsg is returned by the async load command.
+type skillsLoadedMsg struct {
+	items []backend.SkillSummary
+	err   error
+}
+
+func (m model) localSkillsCap() backend.LocalSkillsBackend {
+	if sb, ok := m.backend.(backend.LocalSkillsBackend); ok {
+		return sb
+	}
+	return nil
+}
+
+// openSkillsPicker opens the /skills overlay and kicks off the async load.
+func (m model) openSkillsPicker() (tea.Model, tea.Cmd) {
+	capability := m.localSkillsCap()
+	if capability == nil {
+		m.tr.Apply(events.NewSystem(localSkillsOnlyNotice))
+		m.refreshViewport()
+		return m, nil
+	}
+	if m.tr.Streaming && !m.tr.Awaiting {
+		return m, nil
+	}
+	m.skillsPicker = skillsPickerState{open: true, loading: true}
+	m.slash = slashCompletion{}
+	m.files = fileCompletion{}
+	m.ta.Reset()
+	return m, m.loadSkillsCmd()
+}
+
+func (m model) loadSkillsCmd() tea.Cmd {
+	capability := m.localSkillsCap()
+	return func() tea.Msg {
+		if capability == nil {
+			return skillsLoadedMsg{err: fmt.Errorf("local skills not available")}
+		}
+		items, err := capability.ListLocalSkills(context.Background())
+		return skillsLoadedMsg{items: items, err: err}
+	}
+}
+
+func (m model) applySkillsLoaded(msg skillsLoadedMsg) (tea.Model, tea.Cmd) {
+	if !m.skillsPicker.open {
+		return m, nil
+	}
+	m.skillsPicker.loading = false
+	if msg.err != nil {
+		m.skillsPicker.err = msg.err.Error()
+	} else {
+		m.skillsPicker.items = msg.items
+		m.skillsPicker.cursor = 0
+	}
+	return m, nil
+}
+
+func (m model) handleSkillsPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "esc", "ctrl+c":
+		m.skillsPicker = skillsPickerState{}
+		return m, nil
+	case "up", "k":
+		if m.skillsPicker.cursor > 0 {
+			m.skillsPicker.cursor--
+		}
+		return m, nil
+	case "down", "j":
+		if m.skillsPicker.cursor < len(m.skillsPicker.items)-1 {
+			m.skillsPicker.cursor++
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) renderSkillsPickerOverlay() string {
+	th := m.theme
+	w := m.width
+	if w < 40 {
+		w = 40
+	}
+	h := m.height - 4
+	if h < 8 {
+		h = 8
+	}
+
+	var body strings.Builder
+	body.WriteString(th.Header.Render("Skills") + th.Muted.Render("  ↑↓ move  esc close") + "\n\n")
+
+	if m.skillsPicker.loading {
+		body.WriteString(th.Muted.Render("Loading…"))
+	} else if m.skillsPicker.err != "" {
+		body.WriteString(th.Error.Render(m.skillsPicker.err))
+	} else if len(m.skillsPicker.items) == 0 {
+		body.WriteString(th.Muted.Render("No skills loaded. Add a skill folder to ~/.config/astonish/skills/."))
+	} else {
+		maxRows := h - 4
+		if maxRows < 3 {
+			maxRows = 3
+		}
+		start := 0
+		if m.skillsPicker.cursor >= maxRows {
+			start = m.skillsPicker.cursor - maxRows + 1
+		}
+		end := start + maxRows
+		if end > len(m.skillsPicker.items) {
+			end = len(m.skillsPicker.items)
+		}
+		for i := start; i < end; i++ {
+			skill := m.skillsPicker.items[i]
+			status := "eligible"
+			statusStyle := th.Success
+			if !skill.Eligible {
+				status = "unavailable"
+				statusStyle = th.Muted
+			}
+			src := first(skill.Source, "user")
+			mark := "  "
+			nameStyle := th.Text
+			if i == m.skillsPicker.cursor {
+				mark = "› "
+				nameStyle = th.Brand
+			}
+			// Name line
+			namePart := nameStyle.Render(mark + skill.Name)
+			tagPart := th.Muted.Render(" ["+src+"] ") + statusStyle.Render(status)
+			body.WriteString(namePart + tagPart + "\n")
+			// Description line (indented)
+			desc := skill.Description
+			if desc != "" {
+				maxDesc := w - 6
+				if maxDesc < 20 {
+					maxDesc = 20
+				}
+				descRunes := []rune(desc)
+				if len(descRunes) > maxDesc {
+					desc = string(descRunes[:maxDesc-1]) + "…"
+				}
+				body.WriteString(th.Muted.Render("    "+desc) + "\n")
+			}
+			// Missing requirements (if any)
+			if len(skill.Missing) > 0 {
+				body.WriteString(th.Error.Render("    Missing: "+strings.Join(skill.Missing, ", ")) + "\n")
+			}
+		}
+	}
+
+	box := th.InputBorderFocus.
+		Width(w-2).
+		MaxHeight(h).
+		Padding(1, 2).
+		Render(body.String())
+	return m.paintCompletionPopup(box, w-2)
+}
+
+// formatSkillSummaries is kept for use in tests.
+func formatSkillSummaries(summaries []backend.SkillSummary) string {
+	if len(summaries) == 0 {
+		return "No local skills are loaded."
+	}
+	var out strings.Builder
+	out.WriteString("Local skills:")
+	for _, skill := range summaries {
+		status := "eligible"
+		if !skill.Eligible {
+			status = "unavailable"
+		}
+		fmt.Fprintf(&out, "\n\n- %s [%s, %s] — %s", skill.Name, first(skill.Source, "unknown"), status, skill.Description)
+		if len(skill.Missing) > 0 {
+			fmt.Fprintf(&out, "\n  Missing: %s", strings.Join(skill.Missing, ", "))
+		}
+	}
+	return out.String()
+}
+
+// renderSkillsOverlayStyle returns a placed overlay string for use in viewContent.
+func (m model) renderSkillsOverlay() string {
+	overlay := m.renderSkillsPickerOverlay()
+	return m.paintBackground(lipgloss.Place(m.width, m.screenHeight(), lipgloss.Center, lipgloss.Center, overlay,
+		lipgloss.WithWhitespaceChars(" "),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(lipgloss.Color("#000000"))),
+	))
+}

--- a/pkg/tui/skills_test.go
+++ b/pkg/tui/skills_test.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/SAP/astonish/pkg/tui/backend"
+	"github.com/SAP/astonish/pkg/tui/events"
+)
+
+type skillsTestBackend struct {
+	staticBackend
+	summaries []backend.SkillSummary
+	runTurns  int
+}
+
+func (b *skillsTestBackend) ListLocalSkills(context.Context) ([]backend.SkillSummary, error) {
+	return b.summaries, nil
+}
+
+func (b *skillsTestBackend) RunTurn(context.Context, string, backend.TurnOptions) (<-chan events.Event, error) {
+	b.runTurns++
+	return nil, nil
+}
+
+func TestFormatSkillSummaries(t *testing.T) {
+	got := formatSkillSummaries([]backend.SkillSummary{
+		{Name: "alpha", Description: "Alpha", Source: "project", Eligible: true},
+		{Name: "beta", Description: "Beta", Source: "user", Missing: []string{"docker", "git"}},
+	})
+	for _, want := range []string{"alpha [project, eligible]", "beta [user, unavailable]", "Missing: docker, git"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted skills missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSkillsCompletionCapabilityGated(t *testing.T) {
+	without := newModel(context.Background(), Config{Backend: staticBackend{}})
+	without.ta.SetValue("/ski")
+	without.syncSlashCompletion()
+	if without.slash.active {
+		t.Fatalf("platform completion exposed /skills: %+v", without.slash.matches)
+	}
+
+	with := newModel(context.Background(), Config{Backend: &skillsTestBackend{}})
+	with.ta.SetValue("/ski")
+	with.syncSlashCompletion()
+	if !with.slash.active || len(with.slash.matches) != 1 || with.slash.matches[0].Name != "skills" {
+		t.Fatalf("local completion missing /skills: %+v", with.slash.matches)
+	}
+}
+
+// TestSkillsPickerOpenAndClose verifies that /skills opens the picker overlay
+// (returns a load command), and that pressing Esc closes it.
+func TestSkillsPickerOpenAndClose(t *testing.T) {
+	local := &skillsTestBackend{summaries: []backend.SkillSummary{
+		{Name: "alpha", Description: "Alpha", Source: "project", Eligible: true},
+	}}
+	m := newModel(context.Background(), Config{Backend: local})
+
+	// /skills should open the picker and return a load command — not run a turn.
+	next, cmd := m.handleSlash("/skills")
+	got := next.(model)
+	if local.runTurns != 0 {
+		t.Fatalf("/skills ran a turn: turns=%d", local.runTurns)
+	}
+	if !got.skillsPicker.open {
+		t.Fatalf("skillsPicker should be open after /skills")
+	}
+	if !got.skillsPicker.loading {
+		t.Fatalf("skillsPicker should be loading after /skills")
+	}
+	if cmd == nil {
+		t.Fatalf("expected a load command from /skills, got nil")
+	}
+
+	// Simulate receiving the loaded items.
+	loaded, cmd2 := got.applySkillsLoaded(skillsLoadedMsg{items: local.summaries})
+	got = loaded.(model)
+	if cmd2 != nil {
+		t.Fatalf("applySkillsLoaded should return nil cmd, got %v", cmd2)
+	}
+	if got.skillsPicker.loading {
+		t.Fatalf("picker should stop loading after items received")
+	}
+	if len(got.skillsPicker.items) != 1 || got.skillsPicker.items[0].Name != "alpha" {
+		t.Fatalf("unexpected items: %+v", got.skillsPicker.items)
+	}
+
+	// Esc should close the picker.
+	closed, _ := got.handleSkillsPickerKey(tea.KeyPressMsg{Code: tea.KeyEsc})
+	gotClosed := closed.(model)
+	if gotClosed.skillsPicker.open {
+		t.Fatalf("skillsPicker should be closed after Esc")
+	}
+}
+
+// TestSkillsPickerUnsupportedBackendShowsNotice verifies that on a backend that
+// does not implement LocalSkillsBackend, /skills writes the notice into the
+// transcript (not the picker).
+func TestSkillsPickerUnsupportedBackendShowsNotice(t *testing.T) {
+	platform := newModel(context.Background(), Config{Backend: staticBackend{}})
+	next, cmd := platform.handleSlash("/skills")
+	got := next.(model)
+	if got.skillsPicker.open {
+		t.Fatalf("picker should not open on unsupported backend")
+	}
+	if cmd != nil {
+		t.Fatalf("unexpected command: %v", cmd)
+	}
+	if len(got.tr.Items) == 0 || got.tr.Items[len(got.tr.Items)-1].Content != localSkillsOnlyNotice {
+		t.Fatalf("unsupported notice = %+v", got.tr.Items)
+	}
+}
+
+// TestSkillsPickerCursorNavigation verifies up/down key movement.
+func TestSkillsPickerCursorNavigation(t *testing.T) {
+	local := &skillsTestBackend{summaries: []backend.SkillSummary{
+		{Name: "a", Description: "A", Source: "user", Eligible: true},
+		{Name: "b", Description: "B", Source: "user", Eligible: true},
+		{Name: "c", Description: "C", Source: "user", Eligible: true},
+	}}
+	m := newModel(context.Background(), Config{Backend: local})
+	next, _ := m.handleSlash("/skills")
+	m = next.(model)
+	next2, _ := m.applySkillsLoaded(skillsLoadedMsg{items: local.summaries})
+	m = next2.(model)
+
+	// Initially at 0.
+	if m.skillsPicker.cursor != 0 {
+		t.Fatalf("initial cursor = %d", m.skillsPicker.cursor)
+	}
+
+	// Down twice.
+	m2, _ := m.handleSkillsPickerKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	m3, _ := m2.(model).handleSkillsPickerKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m3.(model).skillsPicker.cursor != 2 {
+		t.Fatalf("cursor after 2 downs = %d", m3.(model).skillsPicker.cursor)
+	}
+
+	// Down past end — stays at max.
+	m4, _ := m3.(model).handleSkillsPickerKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m4.(model).skillsPicker.cursor != 2 {
+		t.Fatalf("cursor clamped = %d", m4.(model).skillsPicker.cursor)
+	}
+
+	// Up once.
+	m5, _ := m4.(model).handleSkillsPickerKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	if m5.(model).skillsPicker.cursor != 1 {
+		t.Fatalf("cursor after up = %d", m5.(model).skillsPicker.cursor)
+	}
+}


### PR DESCRIPTION
## Summary

Three bugs fixed in the skills system:

### 1. `/skills` now opens a picker overlay
Previously `/skills` dumped inline text into the chat transcript. It now opens a full-screen navigable overlay matching the `/sessions` and `/model` UX:
- Header: `Skills  ↑↓ move  esc close`
- Each skill shows: name, `[source]` tag, `eligible`/`unavailable` status, description line, and missing requirements (in red)
- Arrow keys / `j`/`k` navigate; `esc` closes
- Load is async — a `Loading…` state is shown while the filesystem scan runs
- On unsupported backends (platform/chat), still shows the "only in local code mode" notice

### 2. Live reload on every `/skills` call
`ListLocalSkills` previously returned the frozen startup snapshot from `filesystemSkills`. It now calls `skills.LoadSkills()` on every invocation so skills added to the folder since startup are immediately visible — no restart needed. Falls back to the startup snapshot on scan error.

### 3. `create_skill` writes content + auto-injects frontmatter
- Added optional `content` field: when provided, writes that content instead of the boilerplate scaffold template.
- Added `ensureSkillFrontmatter`: if supplied content has no valid YAML frontmatter (`---` delimiters with `name:` and `description:`), a minimal block is auto-injected so `ParseSkillFile` can always load the skill.
- **Root cause of reported bug:** the agent wrote a `SKILL.md` without frontmatter; `splitFrontmatter` returned an error and `loadSkillsFromDir` silently skipped the file, so it never appeared in `/skills`.
- Updated tool description to clearly warn that frontmatter is required.

## Files changed
| Package | Change |
|---------|--------|
| `pkg/tui/skills.go` | New file — `skillsPickerState`, overlay render, key handler, async load |
| `pkg/tui/app.go` | Wired skills picker into model struct, Update, viewContent, handleSlash |
| `pkg/tui/skills_test.go` | New file — picker open/close/load/navigation tests |
| `pkg/launcher/tui_code.go` | `ListLocalSkills` re-scans filesystem on every call |
| `pkg/launcher/tui_chat.go` | `lazyCodeBackend` forwards `ListLocalSkills` |
| `pkg/tools/create_skill.go` | New file — `content` field, `ensureSkillFrontmatter` helper |
| `pkg/tools/create_skill_test.go` | New file — content/frontmatter tests |

## Testing
- All `pkg/tui` tests pass
- All `pkg/tools` tests pass (including 3 new frontmatter tests)
- `go build ./...` clean
- `golangci-lint` 0 issues