### PR TITLE
fix(slides): improve presentation navigation and fullscreen

### DIFF
--- a/pkg/api/csp_test.go
+++ b/pkg/api/csp_test.go
@@ -44,6 +44,31 @@ func TestCSPMiddleware_AllowsBlobMedia(t *testing.T) {
 	}
 }
 
+func TestSlidesDocumentHeadersAllowFullscreenOnlyForPresenter(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		download  bool
+		presenter bool
+		sandboxed bool
+	}{
+		{name: "embedded preview", sandboxed: true},
+		{name: "download", download: true, sandboxed: true},
+		{name: "presenter tab", presenter: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			setSlidesDocumentHeaders(rr, tc.download, tc.presenter)
+			got := rr.Header().Get("Content-Security-Policy")
+			if strings.HasPrefix(got, "sandbox ") != tc.sandboxed {
+				t.Fatalf("CSP = %q, sandboxed = %v", got, tc.sandboxed)
+			}
+			if !strings.Contains(got, "default-src 'none'") {
+				t.Fatalf("CSP lost restrictive defaults: %q", got)
+			}
+		})
+	}
+}
+
 func TestCSPMiddlewarePreservesSlidesPresentationPolicy(t *testing.T) {
 	const presentationCSP = "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'"
 	handler := CSPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/slides_handlers.go
+++ b/pkg/api/slides_handlers.go
@@ -379,7 +379,7 @@ func PresentSlidesHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	setSlidesDocumentHeaders(w, false)
+	setSlidesDocumentHeaders(w, false, r.URL.Query().Get("presenter") == "1")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(result.Bytes)
 }
@@ -389,7 +389,7 @@ func ExportSlidesHTMLHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	setSlidesDocumentHeaders(w, true)
+	setSlidesDocumentHeaders(w, true, false)
 	w.Header().Set("Content-Disposition", attachmentName(mux.Vars(r)["deckSlug"], "html"))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(result.Bytes)
@@ -614,9 +614,13 @@ func bakeDeckThumbnails(ctx context.Context, svc slides.Service, slug, sessionSu
 	}
 }
 
-func setSlidesDocumentHeaders(w http.ResponseWriter, download bool) {
+func setSlidesDocumentHeaders(w http.ResponseWriter, download, presenter bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Content-Security-Policy", "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'")
+	policy := "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+	if !presenter {
+		policy = "sandbox allow-scripts; " + policy
+	}
+	w.Header().Set("Content-Security-Policy", policy)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	if !download {

--- a/pkg/docs/slides/export_html.go
+++ b/pkg/docs/slides/export_html.go
@@ -64,7 +64,7 @@ func (e HTMLExporter) Export(scene SceneGraph) (ExportResult, error) {
 	inheritDeclaredFontsFromTemplate(theme)
 	fillDeclaredFontAssets(theme, assets)
 	writeFontFaces(&body, theme, assets)
-	body.WriteString(`html,body{width:100%;height:100%;margin:0;overflow:hidden}body{background:#111827}ast-deck{display:block;position:relative;width:1920px;height:1080px;overflow:hidden;transform-origin:top left;background:var(--ast-surface);color:var(--ast-ink)}ast-slide{display:none;position:absolute;inset:0;width:1920px;height:1080px;overflow:hidden}ast-slide[active]{display:block}ast-text{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:clip;overflow-y:visible;overflow-clip-margin:0.32em;font-variant-ligatures:none}ast-notes{display:none}`)
+	body.WriteString(`html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#000}ast-deck{display:block;position:absolute;width:1920px;height:1080px;overflow:hidden;transform-origin:top left;background:var(--ast-surface);color:var(--ast-ink)}ast-slide{display:none;position:absolute;inset:0;width:1920px;height:1080px;overflow:hidden}ast-slide[active]{display:block}ast-text{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:clip;overflow-y:visible;overflow-clip-margin:0.32em;font-variant-ligatures:none}ast-notes{display:none}`)
 	if e.Print {
 		// Print layout: paginate one slide per page. The @page box and every
 		// slide are declared in the SAME inch units as the PDF paper (20in x

--- a/pkg/docs/slides/export_html_test.go
+++ b/pkg/docs/slides/export_html_test.go
@@ -21,7 +21,7 @@ func TestHTMLExporterProducesSelfContainedEscapedDocument(t *testing.T) {
 		t.Fatal(err)
 	}
 	doc := string(result.Bytes)
-	for _, want := range []string{"<!doctype html>", "Content-Security-Policy", "sha256-", "html,body{width:100%;height:100%;margin:0;overflow:hidden}", "ast-deck{display:block;position:relative;width:1920px;height:1080px", "ast-slide[active]{display:block}", `<ast-deck schema="1" ratio="16:9">`, `<ast-slide id="intro"`, `<ast-text id="title" x="10" y="20" w="300" h="80" font-token="display">`, "&lt;script&gt;alert(1)&lt;/script&gt;", "window.runtimeReady=true"} {
+	for _, want := range []string{"<!doctype html>", "Content-Security-Policy", "sha256-", "html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#000}", "ast-deck{display:block;position:absolute;width:1920px;height:1080px", "ast-slide[active]{display:block}", `<ast-deck schema="1" ratio="16:9">`, `<ast-slide id="intro"`, `<ast-text id="title" x="10" y="20" w="300" h="80" font-token="display">`, "&lt;script&gt;alert(1)&lt;/script&gt;", "window.runtimeReady=true"} {
 		if !strings.Contains(doc, want) {
 			t.Errorf("document missing %q", want)
 		}

--- a/web/src/api/__tests__/slides.test.ts
+++ b/web/src/api/__tests__/slides.test.ts
@@ -75,8 +75,9 @@ describe('slides API (deck/present/export)', () => {
     })
   })
 
-  it('builds a scoped presentation URL', () => {
+  it('builds scoped presentation URLs', () => {
     expect(slidesPresentationURL('deck-1', 'personal')).toBe('/api/docs/slides/deck-1/present?scope=personal')
+    expect(slidesPresentationURL('deck-1', 'personal', true)).toBe('/api/docs/slides/deck-1/present?scope=personal&presenter=1')
   })
 
   it('builds a scoped, encoded per-slide thumbnail URL', () => {

--- a/web/src/api/slides.ts
+++ b/web/src/api/slides.ts
@@ -177,8 +177,9 @@ export async function fetchSlidesDeck(deckSlug: string, scope: DocsScope = 'pers
   return response.json() as Promise<SlidesDeckResponse>
 }
 
-export function slidesPresentationURL(deckSlug: string, scope: DocsScope = 'personal'): string {
-  return withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/present`, scope)
+export function slidesPresentationURL(deckSlug: string, scope: DocsScope = 'personal', presenter = false): string {
+  const url = withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/present`, scope)
+  return presenter ? `${url}&presenter=1` : url
 }
 
 export async function fetchSlidesPresentation(deckSlug: string, scope: DocsScope = 'personal'): Promise<Blob> {

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -261,7 +261,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   }, [total, focusStripTile])
 
   const present = useCallback(() => {
-    window.open(slidesPresentationURL(deckSlug, scope), '_blank', 'noopener,noreferrer')
+    window.open(slidesPresentationURL(deckSlug, scope, true), '_blank', 'noopener,noreferrer')
   }, [deckSlug, scope])
 
   const exportDeck = useCallback(async (format: SlidesExportFormat) => {

--- a/web/src/components/chat/__tests__/SlidesDeckView.test.tsx
+++ b/web/src/components/chat/__tests__/SlidesDeckView.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../../api/slides', async () => {
     fetchSlidesDeck: vi.fn(),
     exportSlidesDeck: vi.fn(),
     patchSlideMoves: vi.fn(),
-    slidesPresentationURL: vi.fn((slug: string) => `/api/docs/slides/${slug}/present`),
+    slidesPresentationURL: vi.fn((slug: string, _scope?: string, presenter?: boolean) => `/api/docs/slides/${slug}/present${presenter ? '?presenter=1' : ''}`),
   }
 })
 
@@ -51,6 +51,17 @@ describe('SlidesDeckView refresh signal', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('opens Present in presenter mode', async () => {
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+    render(<SlidesDeckView deckSlug="d" refreshSignal={0} />)
+    await waitFor(() => expect(slidesApi.fetchSlidesDeck).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('slides-present'))
+
+    expect(slidesApi.slidesPresentationURL).toHaveBeenCalledWith('d', 'personal', true)
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/d/present?presenter=1', '_blank', 'noopener,noreferrer')
   })
 
   it('fetches the deck once on initial render', async () => {

--- a/web/src/components/docs/slides/SlidesCard.test.tsx
+++ b/web/src/components/docs/slides/SlidesCard.test.tsx
@@ -7,7 +7,7 @@ import SlidesCard from './SlidesCard'
 vi.mock('@/api/slides', () => ({
   exportSlidesDeck: vi.fn(),
   fetchSlidesPresentation: vi.fn(),
-  slidesPresentationURL: vi.fn(() => '/api/docs/slides/migration/present?scope=team'),
+  slidesPresentationURL: vi.fn((_slug: string, _scope: string, presenter?: boolean) => `/api/docs/slides/migration/present?scope=team${presenter ? '&presenter=1' : ''}`),
 }))
 
 const update = {
@@ -62,8 +62,8 @@ describe('SlidesCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Present' }))
 
     await waitFor(() => expect(fetchSlidesPresentation).toHaveBeenCalledWith('migration', 'team'))
-    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team', '_blank', 'noopener,noreferrer')
-    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team')
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team&presenter=1', '_blank', 'noopener,noreferrer')
+    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team', true)
   })
 
   it('reloads the presentation after an empty deck receives its first slide', async () => {
@@ -96,8 +96,8 @@ describe('SlidesCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Present' }))
 
-    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team', '_blank', 'noopener,noreferrer')
-    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team')
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team&presenter=1', '_blank', 'noopener,noreferrer')
+    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team', true)
     expect(fetchSlidesPresentation).toHaveBeenCalledTimes(2)
   })
 

--- a/web/src/components/docs/slides/SlidesCard.tsx
+++ b/web/src/components/docs/slides/SlidesCard.tsx
@@ -85,7 +85,7 @@ export default function SlidesCard({ update, scope = 'personal' }: SlidesCardPro
     try {
       const url = presentationUrlRef.current ?? await loadPresentation()
       if (url && mountedRef.current) {
-        window.open(slidesPresentationURL(update.deckSlug, scope), '_blank', 'noopener,noreferrer')
+        window.open(slidesPresentationURL(update.deckSlug, scope, true), '_blank', 'noopener,noreferrer')
       }
     } finally {
       if (mountedRef.current) setPendingAction(null)

--- a/web/src/components/docs/slides/runtime/AstDeck.ts
+++ b/web/src/components/docs/slides/runtime/AstDeck.ts
@@ -99,7 +99,10 @@ export class AstDeck extends LitElement implements AstDeckElement {
     const parent = this.parentElement
     if (!parent) return
     const scale = Math.min(parent.clientWidth / CANVAS_WIDTH, parent.clientHeight / CANVAS_HEIGHT)
-    if (Number.isFinite(scale) && scale > 0) this.style.transform = `scale(${scale})`
+    if (!Number.isFinite(scale) || scale <= 0) return
+    this.style.transform = `scale(${scale})`
+    this.style.left = `${Math.max(0, (parent.clientWidth - CANVAS_WIDTH * scale) / 2)}px`
+    this.style.top = `${Math.max(0, (parent.clientHeight - CANVAS_HEIGHT * scale) / 2)}px`
   }
 
   private async signalReady(): Promise<void> {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -3,9 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import './index'
 import type { AstDeckElement, AstFragmentElement, AstSlideElement } from './types'
 
-const mountDeck = async () => {
+const mountDeck = async (width = 960, height = 540) => {
   const host = document.createElement('div')
-  Object.defineProperties(host, { clientWidth: { value: 960 }, clientHeight: { value: 540 } })
+  Object.defineProperties(host, { clientWidth: { value: width }, clientHeight: { value: height } })
   host.innerHTML = `<ast-deck no-history>
     <ast-slide id="one"><ast-fragment order="2">B</ast-fragment><ast-fragment order="1">A</ast-fragment></ast-slide>
     <ast-slide id="two"><ast-notes>Notes</ast-notes></ast-slide>
@@ -59,6 +59,9 @@ describe('DeckController', () => {
       expect(button).not.toBeNull()
       return button!
     })
+    expect(start.style.top).toBe('24px')
+    expect(start.style.left).toBe('50%')
+    expect(start.style.transform).toBe('translateX(-50%)')
 
     start.click()
     await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
@@ -73,6 +76,8 @@ describe('DeckController', () => {
     const fragments = [...deck.querySelectorAll('ast-fragment')] as AstFragmentElement[]
 
     expect(deck.style.transform).toBe('scale(0.5)')
+    expect(deck.style.left).toBe('0px')
+    expect(deck.style.top).toBe('0px')
     expect(slides[0].active).toBe(true)
     deck.next()
     expect(fragments[1].revealed).toBe(true)
@@ -81,6 +86,14 @@ describe('DeckController', () => {
     deck.next()
     expect(slides[1].active).toBe(true)
     expect(deck.currentIndex).toBe(1)
+  })
+
+  it('centers the scaled slide when the viewport is taller than 16:9', async () => {
+    const deck = await mountDeck(1920, 1200)
+
+    expect(deck.style.transform).toBe('scale(1)')
+    expect(deck.style.left).toBe('0px')
+    expect(deck.style.top).toBe('60px')
   })
 
   it('accepts navigation messages only from its parent window', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -50,11 +50,34 @@ describe('DeckController', () => {
     expect(deck.currentIndex).toBe(0)
   })
 
-  it('does not advance on click while canvas edit mode is on', async () => {
+  it('navigates from background clicks while canvas edit mode is on', async () => {
     const deck = await mountDeck()
     deck.setAttribute('edit', '')
+    deck.next()
+    deck.next()
+
     deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 800 }))
+    expect(deck.currentIndex).toBe(1)
+
+    deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 100 }))
     expect(deck.currentIndex).toBe(0)
+  })
+
+  it('does not navigate when an editable canvas object is clicked', async () => {
+    const deck = await mountDeck()
+    const slide = deck.querySelector('ast-slide[active]') as HTMLElement
+    const text = document.createElement('ast-text')
+    text.id = 'headline'
+    slide.append(text)
+    deck.setAttribute('edit', '')
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: () => [text, slide, deck],
+    })
+
+    text.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 800 }))
+    expect(deck.currentIndex).toBe(0)
+    expect(deck.fragment).toBe(0)
   })
 
   it('handles keyboard navigation and slide lifecycle events', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -44,17 +44,27 @@ describe('DeckController', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
-  it('retries fullscreen on the first presenter interaction when automatic entry is blocked', async () => {
+  it('offers a user-activated fullscreen fallback when automatic entry is blocked', async () => {
     history.replaceState(null, '', '?presenter=1')
+    let fullscreenElement: Element | null = null
     const requestFullscreen = vi.fn()
       .mockRejectedValueOnce(new Error('user activation required'))
-      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(async () => { fullscreenElement = document.documentElement })
     Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
-    Object.defineProperty(document, 'fullscreenElement', { configurable: true, value: null })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => fullscreenElement })
 
-    await mountDeck()
-    window.dispatchEvent(new PointerEvent('pointerdown'))
+    const deck = await mountDeck()
+    const start = await vi.waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>('button[aria-label="Start slideshow in fullscreen"]')
+      expect(button).not.toBeNull()
+      return button!
+    })
+
+    start.click()
     await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
+    expect(document.fullscreenElement).toBe(document.documentElement)
+    expect(document.body.contains(start)).toBe(false)
+    expect(deck.currentIndex).toBe(0)
   })
 
   it('scales the fixed canvas and advances ordered fragments before slides', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -18,11 +18,45 @@ const mountDeck = async () => {
 
 afterEach(() => {
   document.body.replaceChildren()
-  history.replaceState(null, '', '#')
+  history.replaceState(null, '', location.pathname)
+  Reflect.deleteProperty(document, 'fullscreenElement')
+  Reflect.deleteProperty(document, 'exitFullscreen')
+  Reflect.deleteProperty(document.documentElement, 'requestFullscreen')
   vi.restoreAllMocks()
 })
 
 describe('DeckController', () => {
+  it('enters fullscreen in presenter mode and Escape exits fullscreen and closes the tab', async () => {
+    history.replaceState(null, '', '?presenter=1')
+    let fullscreenElement: Element | null = null
+    const requestFullscreen = vi.fn().mockImplementation(async () => { fullscreenElement = document.documentElement })
+    const exitFullscreen = vi.fn().mockImplementation(async () => { fullscreenElement = null })
+    const close = vi.spyOn(window, 'close').mockImplementation(() => undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+    Object.defineProperty(document, 'exitFullscreen', { configurable: true, value: exitFullscreen })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => fullscreenElement })
+
+    const deck = await mountDeck()
+    await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledOnce())
+
+    deck.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await vi.waitFor(() => expect(exitFullscreen).toHaveBeenCalledOnce())
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('retries fullscreen on the first presenter interaction when automatic entry is blocked', async () => {
+    history.replaceState(null, '', '?presenter=1')
+    const requestFullscreen = vi.fn()
+      .mockRejectedValueOnce(new Error('user activation required'))
+      .mockResolvedValueOnce(undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, value: null })
+
+    await mountDeck()
+    window.dispatchEvent(new PointerEvent('pointerdown'))
+    await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
+  })
+
   it('scales the fixed canvas and advances ordered fragments before slides', async () => {
     const deck = await mountDeck()
     const slides = [...deck.querySelectorAll('ast-slide')] as AstSlideElement[]

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -9,6 +9,9 @@ export class DeckController {
   private index = 0
   private fragment = 0
   private touchStart?: { x: number; y: number }
+  private presenter = new URLSearchParams(location.search).get('presenter') === '1'
+  private enteredFullscreen = false
+  private presenterClosed = false
 
   get currentIndex(): number {
     return this.index
@@ -25,7 +28,13 @@ export class DeckController {
     this.deck.addEventListener('touchstart', this.onTouchStart, { passive: true })
     this.deck.addEventListener('touchend', this.onTouchEnd, { passive: true })
     window.addEventListener('hashchange', this.onHashChange)
+    if (this.presenter) {
+      document.addEventListener('fullscreenchange', this.onFullscreenChange)
+      window.addEventListener('pointerdown', this.onPresenterInteraction, { once: true })
+      window.addEventListener('keydown', this.onPresenterKeyDown)
+    }
     this.applyState(false)
+    if (this.presenter) void this.enterFullscreen()
   }
 
   disconnect(): void {
@@ -34,6 +43,9 @@ export class DeckController {
     this.deck.removeEventListener('touchstart', this.onTouchStart)
     this.deck.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('hashchange', this.onHashChange)
+    document.removeEventListener('fullscreenchange', this.onFullscreenChange)
+    window.removeEventListener('pointerdown', this.onPresenterInteraction)
+    window.removeEventListener('keydown', this.onPresenterKeyDown)
   }
 
   next(): void {
@@ -188,6 +200,54 @@ export class DeckController {
     if (event.defaultPrevented || (event.target as Element).closest('a,button,input,textarea,select')) return
     if (this.deck.hasAttribute('edit') && hitTest(this.deck, event.clientX, event.clientY)) return
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
+  }
+
+  private readonly onPresenterInteraction = (): void => {
+    void this.enterFullscreen()
+  }
+
+  private readonly onPresenterKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      void this.exitPresenter()
+      return
+    }
+    void this.enterFullscreen()
+  }
+
+  private readonly onFullscreenChange = (): void => {
+    if (document.fullscreenElement) {
+      this.enteredFullscreen = true
+      return
+    }
+    if (this.enteredFullscreen) this.closePresenter()
+  }
+
+  private async enterFullscreen(): Promise<void> {
+    if (document.fullscreenElement || !document.documentElement.requestFullscreen) return
+    try {
+      await document.documentElement.requestFullscreen()
+      this.enteredFullscreen = true
+    } catch {
+      // Browsers may require the first interaction in the presentation tab.
+    }
+  }
+
+  private async exitPresenter(): Promise<void> {
+    if (document.fullscreenElement && document.exitFullscreen) {
+      try {
+        await document.exitFullscreen()
+      } catch {
+        // Closing the dedicated presenter tab remains the final fallback.
+      }
+    }
+    this.closePresenter()
+  }
+
+  private closePresenter(): void {
+    if (this.presenterClosed) return
+    this.presenterClosed = true
+    window.close()
   }
 
   private readonly onTouchStart = (event: TouchEvent): void => {

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -252,9 +252,10 @@ export class DeckController {
     button.setAttribute('aria-label', 'Start slideshow in fullscreen')
     Object.assign(button.style, {
       position: 'fixed',
-      inset: '50% auto auto 50%',
+      top: '24px',
+      left: '50%',
       zIndex: '2147483647',
-      transform: 'translate(-50%, -50%)',
+      transform: 'translateX(-50%)',
       padding: '16px 24px',
       border: '2px solid currentColor',
       borderRadius: '12px',

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -12,6 +12,7 @@ export class DeckController {
   private presenter = new URLSearchParams(location.search).get('presenter') === '1'
   private enteredFullscreen = false
   private presenterClosed = false
+  private presenterStart?: HTMLButtonElement
 
   get currentIndex(): number {
     return this.index
@@ -30,7 +31,6 @@ export class DeckController {
     window.addEventListener('hashchange', this.onHashChange)
     if (this.presenter) {
       document.addEventListener('fullscreenchange', this.onFullscreenChange)
-      window.addEventListener('pointerdown', this.onPresenterInteraction, { once: true })
       window.addEventListener('keydown', this.onPresenterKeyDown)
     }
     this.applyState(false)
@@ -44,8 +44,8 @@ export class DeckController {
     this.deck.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('hashchange', this.onHashChange)
     document.removeEventListener('fullscreenchange', this.onFullscreenChange)
-    window.removeEventListener('pointerdown', this.onPresenterInteraction)
     window.removeEventListener('keydown', this.onPresenterKeyDown)
+    this.hidePresenterStart()
   }
 
   next(): void {
@@ -202,7 +202,9 @@ export class DeckController {
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
   }
 
-  private readonly onPresenterInteraction = (): void => {
+  private readonly onPresenterStart = (event: MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
     void this.enterFullscreen()
   }
 
@@ -212,25 +214,67 @@ export class DeckController {
       void this.exitPresenter()
       return
     }
-    void this.enterFullscreen()
+    if (event.target !== this.presenterStart) void this.enterFullscreen()
   }
 
   private readonly onFullscreenChange = (): void => {
     if (document.fullscreenElement) {
       this.enteredFullscreen = true
+      this.hidePresenterStart()
       return
     }
     if (this.enteredFullscreen) this.closePresenter()
   }
 
   private async enterFullscreen(): Promise<void> {
-    if (document.fullscreenElement || !document.documentElement.requestFullscreen) return
+    if (document.fullscreenElement) {
+      this.hidePresenterStart()
+      return
+    }
+    if (!document.documentElement.requestFullscreen) {
+      this.showPresenterStart()
+      return
+    }
     try {
       await document.documentElement.requestFullscreen()
       this.enteredFullscreen = true
+      this.hidePresenterStart()
     } catch {
-      // Browsers may require the first interaction in the presentation tab.
+      this.showPresenterStart()
     }
+  }
+
+  private showPresenterStart(): void {
+    if (this.presenterStart || this.presenterClosed) return
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.textContent = 'Start slideshow'
+    button.setAttribute('aria-label', 'Start slideshow in fullscreen')
+    Object.assign(button.style, {
+      position: 'fixed',
+      inset: '50% auto auto 50%',
+      zIndex: '2147483647',
+      transform: 'translate(-50%, -50%)',
+      padding: '16px 24px',
+      border: '2px solid currentColor',
+      borderRadius: '12px',
+      background: '#ffffff',
+      color: '#172033',
+      font: '600 20px/1.2 system-ui, sans-serif',
+      cursor: 'pointer',
+      boxShadow: '0 8px 30px rgb(0 0 0 / 25%)',
+    })
+    button.addEventListener('click', this.onPresenterStart)
+    document.body.append(button)
+    button.focus()
+    this.presenterStart = button
+  }
+
+  private hidePresenterStart(): void {
+    if (!this.presenterStart) return
+    this.presenterStart.removeEventListener('click', this.onPresenterStart)
+    this.presenterStart.remove()
+    this.presenterStart = undefined
   }
 
   private async exitPresenter(): Promise<void> {

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -1,5 +1,6 @@
 import type { AstFragment } from './AstFragment'
 import type { AstSlide } from './AstSlide'
+import { hitTest } from './EditController'
 import type { DeckChangeDetail, FragmentPolicy } from './types'
 
 const NAVIGATION_KEYS = new Set(['ArrowRight', 'ArrowDown', 'PageDown', ' ', 'ArrowLeft', 'ArrowUp', 'PageUp', 'Home', 'End'])
@@ -184,8 +185,8 @@ export class DeckController {
   }
 
   private readonly onClick = (event: MouseEvent): void => {
-    if (this.deck.hasAttribute('edit')) return
     if (event.defaultPrevented || (event.target as Element).closest('a,button,input,textarea,select')) return
+    if (this.deck.hasAttribute('edit') && hitTest(this.deck, event.clientX, event.clientY)) return
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
   }
 

--- a/web/src/components/docs/slides/runtime/styles.test.ts
+++ b/web/src/components/docs/slides/runtime/styles.test.ts
@@ -10,7 +10,12 @@ import { runtimeStyles } from './styles'
 // each slide with white margins — and spills the page-sized slide onto a
 // trailing blank page. This test locks the print contract so that regression
 // is caught in CI instead of only in an exported PDF.
-describe('slides runtime print styles', () => {
+describe('slides runtime styles', () => {
+  it('centers the positioned slide canvas against a black viewport', () => {
+    expect(runtimeStyles).toContain('html:has(> body > ast-deck), body:has(> ast-deck) { margin:0; width:100%; height:100%; overflow:hidden; background:#000; }')
+    expect(runtimeStyles).toContain('ast-deck { display:block; position:absolute;')
+  })
+
   it('sizes the page and slides to the exact PDF paper (no scale-to-fit)', () => {
     expect(runtimeStyles).toContain('@page { size:20in 11.25in; margin:0; }')
     expect(runtimeStyles).toContain('width:20in!important')

--- a/web/src/components/docs/slides/runtime/styles.ts
+++ b/web/src/components/docs/slides/runtime/styles.ts
@@ -1,5 +1,6 @@
 export const runtimeStyles = `
-  ast-deck { display:block; position:relative; width:1920px; height:1080px; overflow:hidden; transform-origin:top left; background:var(--ast-surface,#fff); color:var(--ast-ink,#172033); }
+  html:has(> body > ast-deck), body:has(> ast-deck) { margin:0; width:100%; height:100%; overflow:hidden; background:#000; }
+  ast-deck { display:block; position:absolute; width:1920px; height:1080px; overflow:hidden; transform-origin:top left; background:var(--ast-surface,#fff); color:var(--ast-ink,#172033); }
   /* Off-screen slides are display:none so their (potentially hundreds of)
      elements are never laid out; content-visibility:auto + contain-intrinsic-size
      lets the browser also skip rendering work for any slide that becomes
@@ -39,6 +40,7 @@ export const runtimeStyles = `
        page-sized slide onto a trailing blank page. */
     @page { size:20in 11.25in; margin:0; }
     html, body { margin:0; padding:0; width:20in; overflow:visible; }
+    body { background:var(--ast-surface,#fff); }
     ast-deck { transform:none!important; position:static!important; width:20in; height:auto; overflow:visible; background:transparent!important; }
     ast-slide { display:block!important; position:relative!important; inset:auto!important; width:20in!important; height:11.25in!important; overflow:hidden; break-inside:avoid; break-after:page; page-break-after:always; }
     ast-slide:last-of-type { break-after:auto; page-break-after:auto; }


### PR DESCRIPTION
## Summary
- preserve slide navigation when clicking empty canvas areas in edit mode
- open presentations in a dedicated tab and enter fullscreen when permitted
- provide a top-centered Start slideshow fallback when browser user activation is required
- close the presenter tab when Escape exits the slideshow
- center slides in fullscreen and windowed presentation modes with black letterboxing
- keep embedded previews and downloaded HTML sandboxed while allowing fullscreen only for presenter responses

## Verification
- `go test ./pkg/api`
- `go test ./pkg/docs/slides`
- `cd web && NODE_OPTIONS="--localstorage-file=/tmp/astonish-vitest-localstorage" npm test` (685 tests)
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `golangci-lint` via commit hook (0 issues)

## Browser verification
Live browser tooling was unavailable in the development environment. The presentation interactions, fallback behavior, centering, and generated document styles are covered by focused tests and production builds.