### PR TITLE
fix(slides): support cloud PPTX and PDF exports

### DIFF
--- a/docker/astonish/Dockerfile
+++ b/docker/astonish/Dockerfile
@@ -65,6 +65,12 @@ RUN node --version && npx --version && uv --version && uvx --version && git --ve
 
 WORKDIR /app
 
+# Install the slide PPTX workers and their production dependencies.
+COPY web/package.json web/package-lock.json /app/web/
+RUN cd /app/web && npm ci --omit=dev --ignore-scripts && npm cache clean --force
+COPY pkg/docs/slides/pptxworker/worker.mjs pkg/docs/slides/pptxworker/import_worker.mjs /app/pkg/docs/slides/pptxworker/
+ENV ASTONISH_ROOT=/app
+
 # Copy the pre-built Linux astonish binary for the target architecture.
 # TARGETARCH is set automatically by docker buildx (amd64 or arm64).
 # Do not give TARGETARCH a default — BuildKit overrides are ignored when a

--- a/pkg/api/csp_test.go
+++ b/pkg/api/csp_test.go
@@ -44,6 +44,31 @@ func TestCSPMiddleware_AllowsBlobMedia(t *testing.T) {
 	}
 }
 
+func TestSlidesDocumentHeadersAllowFullscreenOnlyForPresenter(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		download  bool
+		presenter bool
+		sandboxed bool
+	}{
+		{name: "embedded preview", sandboxed: true},
+		{name: "download", download: true, sandboxed: true},
+		{name: "presenter tab", presenter: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			setSlidesDocumentHeaders(rr, tc.download, tc.presenter)
+			got := rr.Header().Get("Content-Security-Policy")
+			if strings.HasPrefix(got, "sandbox ") != tc.sandboxed {
+				t.Fatalf("CSP = %q, sandboxed = %v", got, tc.sandboxed)
+			}
+			if !strings.Contains(got, "default-src 'none'") {
+				t.Fatalf("CSP lost restrictive defaults: %q", got)
+			}
+		})
+	}
+}
+
 func TestCSPMiddlewarePreservesSlidesPresentationPolicy(t *testing.T) {
 	const presentationCSP = "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'"
 	handler := CSPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/slides_handlers.go
+++ b/pkg/api/slides_handlers.go
@@ -2,14 +2,13 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/SAP/astonish/pkg/docs/slides/pptxworker"
 	"github.com/SAP/astonish/pkg/docs/slides/themes"
 	"github.com/SAP/astonish/pkg/pdfgen"
+	"github.com/SAP/astonish/pkg/sandbox"
 	"github.com/SAP/astonish/pkg/store"
 	webassets "github.com/SAP/astonish/web"
 	"github.com/gorilla/mux"
@@ -395,6 +395,76 @@ func ExportSlidesHTMLHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(result.Bytes)
 }
 
+var (
+	ensureSlidesPDFSandboxSessionFn = ensureSlidesPDFSandboxSession
+	slidesTemplateLayerChainFn      = resolveTemplateLayerChain
+	slidesBaseLayerChainFn          = resolveBaseLayerChain
+	slidesTemplateImageFn           = resolveTemplateImage
+	slidesBaseImageFn               = resolveBaseImage
+)
+
+func slidesPDFSandboxSpec(ctx context.Context, r *http.Request, userID string) sandbox.SessionSpec {
+	templateName := sandbox.BaseTemplateID
+	if svc := store.FromRequest(r); svc != nil && svc.Settings != nil {
+		if settings, err := svc.Settings.Get(ctx); err == nil && settings != nil && settings.TemplateName != "" {
+			templateName = settings.TemplateName
+		}
+	}
+
+	layerChain := slidesTemplateLayerChainFn(ctx, templateName)
+	if len(layerChain) == 0 {
+		layerChain = slidesBaseLayerChainFn(ctx)
+	}
+	image := slidesTemplateImageFn(ctx, templateName)
+	if image == "" {
+		image = slidesBaseImageFn(ctx)
+	}
+
+	return sandbox.SessionSpec{
+		Type:       sandbox.SessionTypeChat,
+		TemplateID: templateName,
+		LayerChain: layerChain,
+		Image:      image,
+		UserID:     userID,
+		Labels:     map[string]string{"purpose": "slides-pdf"},
+	}
+}
+
+func slidesPDFSandboxSessionID(ctx context.Context, r *http.Request, userID string) string {
+	// Include the filesystem source in the ID so a changed base/template does
+	// not reuse a warm pod built from an obsolete layer chain or image.
+	spec := slidesPDFSandboxSpec(ctx, r, userID)
+	source := strings.Join(spec.LayerChain, "\x00") + "\x00" + spec.Image
+	if source != "\x00" {
+		suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(source)))[:12]
+		return "slides-pdf-" + userID + "-" + suffix
+	}
+	return "slides-pdf-" + userID
+}
+
+func ensureSlidesPDFSandboxSession(ctx context.Context, r *http.Request, sessionID, userID string) error {
+	backend, cleanup, err := sandboxBackendForRequest(r)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	spec := slidesPDFSandboxSpec(ctx, r, userID)
+	spec.SessionID = sessionID
+	if _, err := backend.CreateSession(ctx, spec); err != nil {
+		return fmt.Errorf("create slides PDF sandbox: %w", err)
+	}
+	if err := backend.StartSession(ctx, sessionID); err != nil {
+		return fmt.Errorf("start slides PDF sandbox: %w", err)
+	}
+	if err := backend.WaitForSessionReady(ctx, sessionID); err != nil {
+		return fmt.Errorf("wait for slides PDF sandbox: %w", err)
+	}
+	return nil
+}
+
 func ExportSlidesPDFHandler(w http.ResponseWriter, r *http.Request) {
 	// Decide where Chrome renders BEFORE loading the scene, so a misconfigured
 	// sandbox (required but no in-container browser) fails fast with a clear
@@ -409,7 +479,16 @@ func ExportSlidesPDFHandler(w http.ResponseWriter, r *http.Request) {
 	timeout := time.Duration(0) // pdfgen applies its bounded default when 0
 	sessionID := ""
 	if required {
-		sessionID = "slides-pdf-" + effectiveUserID(r) // dedicated per-user PDF session, mirrors app-mcp-<user>
+		userID := effectiveUserID(r)
+		sessionID = slidesPDFSandboxSessionID(r.Context(), r, userID)
+		provisionCtx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
+		err := ensureSlidesPDFSandboxSessionFn(provisionCtx, r, sessionID, userID)
+		cancel()
+		if err != nil {
+			slog.Error("slides PDF: sandbox provisioning failed", "deck", mux.Vars(r)["deckSlug"], "backend", backendLabel, "error", err)
+			http.Error(w, "slides PDF export could not prepare its sandbox: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 		mgr, err := slidesPDFBrowserManagerFn(sessionID)
 		if err != nil {
 			slog.Error("slides PDF: sandbox browser unavailable", "deck", mux.Vars(r)["deckSlug"], "backend", backendLabel, "error", err)
@@ -475,12 +554,15 @@ func ExportSlidesPPTXHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, currentFile, _, _ := runtime.Caller(0)
-	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "../.."))
-
+	workingDir, scriptPath, err := slidesWorkerPaths("worker.mjs")
+	if err != nil {
+		slog.Error("slides PPTX worker unavailable", "deck", deckSlug, "error", err)
+		http.Error(w, "export slides PPTX: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	exporter := slides.PPTXExporter{Runner: pptxworker.Runner{
-		WorkingDir: filepath.Join(repoRoot, "web"),
-		ScriptPath: filepath.Join(repoRoot, "pkg/docs/slides/pptxworker/worker.mjs"),
+		WorkingDir: workingDir,
+		ScriptPath: scriptPath,
 	}}
 	result, err := exporter.Export(r.Context(), scene, r.URL.Query().Get("strictNative") == "true")
 	if err != nil {

--- a/pkg/api/slides_handlers.go
+++ b/pkg/api/slides_handlers.go
@@ -379,7 +379,7 @@ func PresentSlidesHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	setSlidesDocumentHeaders(w, false)
+	setSlidesDocumentHeaders(w, false, r.URL.Query().Get("presenter") == "1")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(result.Bytes)
 }
@@ -389,7 +389,7 @@ func ExportSlidesHTMLHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	setSlidesDocumentHeaders(w, true)
+	setSlidesDocumentHeaders(w, true, false)
 	w.Header().Set("Content-Disposition", attachmentName(mux.Vars(r)["deckSlug"], "html"))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(result.Bytes)
@@ -614,9 +614,13 @@ func bakeDeckThumbnails(ctx context.Context, svc slides.Service, slug, sessionSu
 	}
 }
 
-func setSlidesDocumentHeaders(w http.ResponseWriter, download bool) {
+func setSlidesDocumentHeaders(w http.ResponseWriter, download, presenter bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Content-Security-Policy", "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'")
+	policy := "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+	if !presenter {
+		policy = "sandbox allow-scripts; " + policy
+	}
+	w.Header().Set("Content-Security-Policy", policy)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	if !download {

--- a/pkg/api/slides_handlers_pdf_test.go
+++ b/pkg/api/slides_handlers_pdf_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -99,7 +100,44 @@ func TestSlidesPDFManager_UsesRegisteredCallbacks(t *testing.T) {
 // with the sentinel message and NEVER selects the host manager. Because the
 // handler resolves the browser BEFORE loading the scene, this exercises the
 // real handler without a store service.
+func TestSlidesPDFSandboxSpecUsesConfiguredBaseLayer(t *testing.T) {
+	oldTemplateChain := slidesTemplateLayerChainFn
+	oldBaseChain := slidesBaseLayerChainFn
+	oldTemplateImage := slidesTemplateImageFn
+	oldBaseImage := slidesBaseImageFn
+	defer func() {
+		slidesTemplateLayerChainFn = oldTemplateChain
+		slidesBaseLayerChainFn = oldBaseChain
+		slidesTemplateImageFn = oldTemplateImage
+		slidesBaseImageFn = oldBaseImage
+	}()
+
+	slidesTemplateLayerChainFn = func(context.Context, string) []string { return nil }
+	slidesBaseLayerChainFn = func(context.Context) []string { return []string{"@base", "sha256:browser"} }
+	slidesTemplateImageFn = func(context.Context, string) string { return "" }
+	slidesBaseImageFn = func(context.Context) string { return "registry.example/browser:latest" }
+
+	req := httptest.NewRequest(http.MethodGet, "/api/docs/slides/deck/export/pdf", nil)
+	spec := slidesPDFSandboxSpec(req.Context(), req, "user-1")
+	if got := strings.Join(spec.LayerChain, ","); got != "@base,sha256:browser" {
+		t.Fatalf("LayerChain = %q, want configured base chain", got)
+	}
+	if spec.Image != "registry.example/browser:latest" {
+		t.Fatalf("Image = %q, want configured base image", spec.Image)
+	}
+	if spec.UserID != "user-1" || spec.Labels["purpose"] != "slides-pdf" {
+		t.Fatalf("unexpected session metadata: %+v", spec)
+	}
+	if id := slidesPDFSandboxSessionID(req.Context(), req, "user-1"); !strings.HasPrefix(id, "slides-pdf-user-1-") {
+		t.Fatalf("session ID = %q, want layer-specific suffix", id)
+	}
+}
+
 func TestSlidesPDFHandler_NoFallbackWhenSandboxRequiredButUnavailable(t *testing.T) {
+	oldEnsure := ensureSlidesPDFSandboxSessionFn
+	ensureSlidesPDFSandboxSessionFn = func(context.Context, *http.Request, string, string) error { return nil }
+	defer func() { ensureSlidesPDFSandboxSessionFn = oldEnsure }()
+
 	oldReq := sandboxBrowserRequiredFn
 	sandboxBrowserRequiredFn = func() (bool, string) { return true, "k8s" }
 	defer func() { sandboxBrowserRequiredFn = oldReq }()
@@ -163,4 +201,3 @@ func TestSlidesPDFHandler_SandboxDisabledUsesHostManager(t *testing.T) {
 		t.Fatalf("status = %d, want 503 (scene load unavailable after host manager selected)", rec.Code)
 	}
 }
-

--- a/pkg/api/slides_templates_handlers.go
+++ b/pkg/api/slides_templates_handlers.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -640,11 +639,14 @@ func ImportSlidesTemplateHandler(w http.ResponseWriter, r *http.Request) {
 
 	b64 := base64.StdEncoding.EncodeToString(data)
 
-	_, currentFile, _, _ := runtime.Caller(0)
-	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "../.."))
+	workingDir, scriptPath, err := slidesWorkerPaths("import_worker.mjs")
+	if err != nil {
+		http.Error(w, "import pptx template: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	runner := pptxworker.ImportRunner{
-		WorkingDir: filepath.Join(repoRoot, "web"),
-		ScriptPath: filepath.Join(repoRoot, "pkg/docs/slides/pptxworker/import_worker.mjs"),
+		WorkingDir: workingDir,
+		ScriptPath: scriptPath,
 	}
 
 	resp, err := runner.Run(r.Context(), pptxworker.ImportRequest{PPTXBase64: b64, Mode: "template"})

--- a/pkg/api/slides_worker.go
+++ b/pkg/api/slides_worker.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const astonishRootEnv = "ASTONISH_ROOT"
+
+func slidesWorkerPaths(scriptName string) (workingDir, scriptPath string, err error) {
+	var roots []string
+	if root := os.Getenv(astonishRootEnv); root != "" {
+		roots = append(roots, root)
+	}
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		roots = append(roots, cwd)
+	}
+	if _, currentFile, _, ok := runtime.Caller(0); ok {
+		roots = append(roots, filepath.Clean(filepath.Join(filepath.Dir(currentFile), "../..")))
+	}
+
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		root = filepath.Clean(root)
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		workingDir = filepath.Join(root, "web")
+		scriptPath = filepath.Join(root, "pkg", "docs", "slides", "pptxworker", scriptName)
+		if directoryExists(workingDir) && fileExists(scriptPath) {
+			return workingDir, scriptPath, nil
+		}
+	}
+	return "", "", fmt.Errorf("slides worker %q is not installed; set %s to the Astonish runtime root", scriptName, astonishRootEnv)
+}
+
+func directoryExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/pkg/api/slides_worker_test.go
+++ b/pkg/api/slides_worker_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSlidesWorkerPathsUsesRuntimeRoot(t *testing.T) {
+	root := t.TempDir()
+	workingDir := filepath.Join(root, "web")
+	scriptPath := filepath.Join(root, "pkg", "docs", "slides", "pptxworker", "worker.mjs")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("export {}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(astonishRootEnv, root)
+
+	gotWorkingDir, gotScriptPath, err := slidesWorkerPaths("worker.mjs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotWorkingDir != workingDir || gotScriptPath != scriptPath {
+		t.Fatalf("paths = (%q, %q), want (%q, %q)", gotWorkingDir, gotScriptPath, workingDir, scriptPath)
+	}
+}
+
+func TestSlidesWorkerPathsRejectsIncompleteRuntimeRoot(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(astonishRootEnv, root)
+
+	_, _, err := slidesWorkerPaths("missing-worker.mjs")
+	if err == nil {
+		t.Fatal("expected missing worker error")
+	}
+}

--- a/pkg/docs/slides/export_html.go
+++ b/pkg/docs/slides/export_html.go
@@ -64,7 +64,7 @@ func (e HTMLExporter) Export(scene SceneGraph) (ExportResult, error) {
 	inheritDeclaredFontsFromTemplate(theme)
 	fillDeclaredFontAssets(theme, assets)
 	writeFontFaces(&body, theme, assets)
-	body.WriteString(`html,body{width:100%;height:100%;margin:0;overflow:hidden}body{background:#111827}ast-deck{display:block;position:relative;width:1920px;height:1080px;overflow:hidden;transform-origin:top left;background:var(--ast-surface);color:var(--ast-ink)}ast-slide{display:none;position:absolute;inset:0;width:1920px;height:1080px;overflow:hidden}ast-slide[active]{display:block}ast-text{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:clip;overflow-y:visible;overflow-clip-margin:0.32em;font-variant-ligatures:none}ast-notes{display:none}`)
+	body.WriteString(`html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#000}ast-deck{display:block;position:absolute;width:1920px;height:1080px;overflow:hidden;transform-origin:top left;background:var(--ast-surface);color:var(--ast-ink)}ast-slide{display:none;position:absolute;inset:0;width:1920px;height:1080px;overflow:hidden}ast-slide[active]{display:block}ast-text{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:clip;overflow-y:visible;overflow-clip-margin:0.32em;font-variant-ligatures:none}ast-notes{display:none}`)
 	if e.Print {
 		// Print layout: paginate one slide per page. The @page box and every
 		// slide are declared in the SAME inch units as the PDF paper (20in x

--- a/pkg/docs/slides/export_html_test.go
+++ b/pkg/docs/slides/export_html_test.go
@@ -21,7 +21,7 @@ func TestHTMLExporterProducesSelfContainedEscapedDocument(t *testing.T) {
 		t.Fatal(err)
 	}
 	doc := string(result.Bytes)
-	for _, want := range []string{"<!doctype html>", "Content-Security-Policy", "sha256-", "html,body{width:100%;height:100%;margin:0;overflow:hidden}", "ast-deck{display:block;position:relative;width:1920px;height:1080px", "ast-slide[active]{display:block}", `<ast-deck schema="1" ratio="16:9">`, `<ast-slide id="intro"`, `<ast-text id="title" x="10" y="20" w="300" h="80" font-token="display">`, "&lt;script&gt;alert(1)&lt;/script&gt;", "window.runtimeReady=true"} {
+	for _, want := range []string{"<!doctype html>", "Content-Security-Policy", "sha256-", "html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#000}", "ast-deck{display:block;position:absolute;width:1920px;height:1080px", "ast-slide[active]{display:block}", `<ast-deck schema="1" ratio="16:9">`, `<ast-slide id="intro"`, `<ast-text id="title" x="10" y="20" w="300" h="80" font-token="display">`, "&lt;script&gt;alert(1)&lt;/script&gt;", "window.runtimeReady=true"} {
 		if !strings.Contains(doc, want) {
 			t.Errorf("document missing %q", want)
 		}

--- a/pkg/launcher/pdf_browser.go
+++ b/pkg/launcher/pdf_browser.go
@@ -3,7 +3,6 @@ package launcher
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/SAP/astonish/pkg/sandbox"
@@ -27,24 +26,13 @@ func newBackendPDFResolveFunc(backend sandbox.Backend, sessReg *sandbox.SessionR
 			if err != nil {
 				return "", "", fmt.Errorf("PDF resolve: lookup session: %w", err)
 			}
-			if rec != nil && rec.PodName != "" {
-				return sessionID, "127.0.0.1", nil
+			if rec == nil {
+				return "", "", fmt.Errorf("PDF resolve: session %q was not provisioned", sessionID)
 			}
 		}
 
-		slogArgs := []any{"component", "chat-factory", "backend", backend.Kind(), "sessionID", sessionID}
-		slog.Info("PDF resolve: sandbox not found, creating", slogArgs...)
-
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-
-		if _, err := backend.CreateSession(ctx, sandbox.SessionSpec{
-			SessionID:  sessionID,
-			Type:       sandbox.SessionTypeChat,
-			TemplateID: sandbox.BaseTemplateID,
-		}); err != nil {
-			return "", "", fmt.Errorf("PDF resolve: create session: %w", err)
-		}
 		if err := backend.StartSession(ctx, sessionID); err != nil {
 			return "", "", fmt.Errorf("PDF resolve: start session: %w", err)
 		}

--- a/pkg/launcher/pdf_browser_test.go
+++ b/pkg/launcher/pdf_browser_test.go
@@ -3,6 +3,7 @@ package launcher
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/SAP/astonish/pkg/sandbox"
@@ -24,6 +25,9 @@ func TestNewBackendPDFResolveFunc_ExistingSessionUsesSessionIDHandle(t *testing.
 		t.Fatalf("PutSession: %v", err)
 	}
 	backend := mock.New()
+	if _, err := backend.CreateSession(context.Background(), sandbox.SessionSpec{SessionID: "sess-existing", TemplateID: sandbox.BaseTemplateID}); err != nil {
+		t.Fatalf("seed backend session: %v", err)
+	}
 
 	resolve := newBackendPDFResolveFunc(backend, reg)
 	name, ip, err := resolve("sess-existing")
@@ -33,34 +37,25 @@ func TestNewBackendPDFResolveFunc_ExistingSessionUsesSessionIDHandle(t *testing.
 	if name != "sess-existing" || ip != "127.0.0.1" {
 		t.Fatalf("resolve returned (%q, %q), want (sess-existing, 127.0.0.1)", name, ip)
 	}
-	if calls := backend.CreateSessionCalls(); len(calls) != 0 {
-		t.Fatalf("CreateSession calls = %d, want 0", len(calls))
+	if calls := backend.CreateSessionCalls(); len(calls) != 1 {
+		t.Fatalf("CreateSession calls = %d, want only the seed call", len(calls))
+	}
+	if calls := backend.StartSessionCalls(); len(calls) != 1 || calls[0] != "sess-existing" {
+		t.Fatalf("StartSession calls = %v, want [sess-existing]", calls)
 	}
 }
 
-func TestNewBackendPDFResolveFunc_CreatesMissingSession(t *testing.T) {
+func TestNewBackendPDFResolveFunc_RejectsUnprovisionedSession(t *testing.T) {
 	backend := mock.New()
-	resolve := newBackendPDFResolveFunc(backend, nil)
+	reg := sandbox.NewSessionRegistryFromStore(newMemorySandboxSessionStore())
+	resolve := newBackendPDFResolveFunc(backend, reg)
 
-	name, ip, err := resolve("sess-new")
-	if err != nil {
-		t.Fatalf("resolve: %v", err)
+	_, _, err := resolve("sess-new")
+	if err == nil || !strings.Contains(err.Error(), "was not provisioned") {
+		t.Fatalf("resolve error = %v, want unprovisioned-session error", err)
 	}
-	if name != "sess-new" || ip != "127.0.0.1" {
-		t.Fatalf("resolve returned (%q, %q), want (sess-new, 127.0.0.1)", name, ip)
-	}
-	createCalls := backend.CreateSessionCalls()
-	if len(createCalls) != 1 {
-		t.Fatalf("CreateSession calls = %d, want 1", len(createCalls))
-	}
-	if got := createCalls[0].Spec.SessionID; got != "sess-new" {
-		t.Fatalf("CreateSession SessionID = %q, want sess-new", got)
-	}
-	if got := createCalls[0].Spec.TemplateID; got != sandbox.BaseTemplateID {
-		t.Fatalf("CreateSession TemplateID = %q, want %q", got, sandbox.BaseTemplateID)
-	}
-	if calls := backend.StartSessionCalls(); len(calls) != 1 || calls[0] != "sess-new" {
-		t.Fatalf("StartSession calls = %v, want [sess-new]", calls)
+	if calls := backend.CreateSessionCalls(); len(calls) != 0 {
+		t.Fatalf("CreateSession calls = %d, want 0", len(calls))
 	}
 }
 

--- a/pkg/sandbox/backend_browser_wire.go
+++ b/pkg/sandbox/backend_browser_wire.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -89,6 +90,9 @@ func WireBackendBrowserManager(mgr *browser.Manager, backend Backend, sessReg *S
 }
 
 func startBackendBrowser(ctx context.Context, backend Backend, sessionID string, cfg browser.BrowserConfig) (io.Closer, error) {
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+
 	width := cfg.ViewportWidth
 	if width <= 0 {
 		width = 1920
@@ -102,8 +106,10 @@ func startBackendBrowser(ctx context.Context, backend Backend, sessionID string,
 	encoded := base64.StdEncoding.EncodeToString([]byte(script))
 	wrapper := fmt.Sprintf("eval \"$(echo %s | base64 -d)\"", encoded)
 
+	var stderr bytes.Buffer
 	stream, err := backend.ExecStreaming(ctx, sessionID, ExecStreamSpec{
-		Command: []string{"/usr/local/bin/astonish-shell", "sh", "-c", wrapper},
+		Command:        []string{"/usr/local/bin/astonish-shell", "sh", "-c", wrapper},
+		SeparateStderr: &stderr,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("backend browser: start in session %s: %w", shortSession(sessionID), err)
@@ -111,24 +117,27 @@ func startBackendBrowser(ctx context.Context, backend Backend, sessionID string,
 
 	const doneSentinel = "DONE: browser ready"
 	buf := make([]byte, 4096)
-	var accumulated string
-	deadline := time.Now().Add(45 * time.Second)
-	for time.Now().Before(deadline) {
+	var stdout strings.Builder
+	for {
 		n, readErr := stream.Read(buf)
 		if n > 0 {
-			accumulated += string(buf[:n])
-			if strings.Contains(accumulated, doneSentinel) {
+			_, _ = stdout.Write(buf[:n])
+			if strings.Contains(stdout.String(), doneSentinel) {
 				return &backendBrowserHandle{stream: stream}, nil
 			}
 		}
-		if readErr != nil {
-			stream.Close()
-			return nil, fmt.Errorf("backend browser: launch failed in session %s: %w\nOutput: %s", shortSession(sessionID), readErr, accumulated)
+		if readErr == nil {
+			continue
 		}
-	}
 
-	stream.Close()
-	return nil, fmt.Errorf("backend browser: launch timed out in session %s\nOutput: %s", shortSession(sessionID), accumulated)
+		if ctx.Err() != nil {
+			_ = stream.Close()
+			return nil, fmt.Errorf("backend browser: launch timed out in session %s: %w\nStdout: %s\nStderr: %s", shortSession(sessionID), ctx.Err(), stdout.String(), stderr.String())
+		}
+		exitCode, waitErr := stream.Wait()
+		_ = stream.Close()
+		return nil, fmt.Errorf("backend browser: launch failed in session %s: %w (exit code %d, wait error: %v)\nStdout: %s\nStderr: %s", shortSession(sessionID), readErr, exitCode, waitErr, stdout.String(), stderr.String())
+	}
 }
 
 type backendBrowserHandle struct {

--- a/pkg/sandbox/backend_browser_wire_test.go
+++ b/pkg/sandbox/backend_browser_wire_test.go
@@ -1,6 +1,9 @@
 package sandbox
 
 import (
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -38,6 +41,21 @@ func TestBuildBackendBrowserLaunchScript_UsesSandboxBrowser(t *testing.T) {
 	}
 }
 
+func TestStartBackendBrowserReportsStderrAndExitCode(t *testing.T) {
+	stream := &failedBrowserStream{stdout: strings.NewReader("partial stdout"), exitCode: 127}
+	backend := &browserExecBackend{stream: stream, stderr: "No browser binary found"}
+
+	_, err := startBackendBrowser(context.Background(), backend, "slides-pdf-user", browser.DefaultConfig())
+	if err == nil {
+		t.Fatal("expected launch error")
+	}
+	for _, want := range []string{"exit code 127", "partial stdout", "No browser binary found"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
 func TestWireBackendBrowserManager_K8sOnly(t *testing.T) {
 	mgr := browser.NewManager(browser.DefaultConfig())
 	reg := &SessionRegistry{}
@@ -57,6 +75,31 @@ func TestWireBackendBrowserManager_K8sOnly(t *testing.T) {
 		t.Fatal("WireBackendBrowserManager should not wire non-K8s backend")
 	}
 }
+
+type browserExecBackend struct {
+	interfaceTestStub
+	stream ExecStream
+	stderr string
+}
+
+func (b *browserExecBackend) ExecStreaming(_ context.Context, _ string, spec ExecStreamSpec) (ExecStream, error) {
+	if spec.SeparateStderr == nil {
+		return nil, errors.New("SeparateStderr was not configured")
+	}
+	_, _ = io.WriteString(spec.SeparateStderr, b.stderr)
+	return b.stream, nil
+}
+
+type failedBrowserStream struct {
+	stdout   io.Reader
+	exitCode int
+}
+
+func (s *failedBrowserStream) Read(p []byte) (int, error)  { return s.stdout.Read(p) }
+func (s *failedBrowserStream) Write(p []byte) (int, error) { return len(p), nil }
+func (s *failedBrowserStream) Resize(_, _ int) error       { return nil }
+func (s *failedBrowserStream) Wait() (int, error)          { return s.exitCode, nil }
+func (s *failedBrowserStream) Close() error                { return nil }
 
 type kindOnlyBackend struct {
 	interfaceTestStub

--- a/web/src/api/__tests__/slides.test.ts
+++ b/web/src/api/__tests__/slides.test.ts
@@ -75,8 +75,9 @@ describe('slides API (deck/present/export)', () => {
     })
   })
 
-  it('builds a scoped presentation URL', () => {
+  it('builds scoped presentation URLs', () => {
     expect(slidesPresentationURL('deck-1', 'personal')).toBe('/api/docs/slides/deck-1/present?scope=personal')
+    expect(slidesPresentationURL('deck-1', 'personal', true)).toBe('/api/docs/slides/deck-1/present?scope=personal&presenter=1')
   })
 
   it('builds a scoped, encoded per-slide thumbnail URL', () => {

--- a/web/src/api/slides.ts
+++ b/web/src/api/slides.ts
@@ -177,8 +177,9 @@ export async function fetchSlidesDeck(deckSlug: string, scope: DocsScope = 'pers
   return response.json() as Promise<SlidesDeckResponse>
 }
 
-export function slidesPresentationURL(deckSlug: string, scope: DocsScope = 'personal'): string {
-  return withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/present`, scope)
+export function slidesPresentationURL(deckSlug: string, scope: DocsScope = 'personal', presenter = false): string {
+  const url = withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/present`, scope)
+  return presenter ? `${url}&presenter=1` : url
 }
 
 export async function fetchSlidesPresentation(deckSlug: string, scope: DocsScope = 'personal'): Promise<Blob> {

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -261,7 +261,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   }, [total, focusStripTile])
 
   const present = useCallback(() => {
-    window.open(slidesPresentationURL(deckSlug, scope), '_blank', 'noopener,noreferrer')
+    window.open(slidesPresentationURL(deckSlug, scope, true), '_blank', 'noopener,noreferrer')
   }, [deckSlug, scope])
 
   const exportDeck = useCallback(async (format: SlidesExportFormat) => {

--- a/web/src/components/chat/__tests__/SlidesDeckView.test.tsx
+++ b/web/src/components/chat/__tests__/SlidesDeckView.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../../api/slides', async () => {
     fetchSlidesDeck: vi.fn(),
     exportSlidesDeck: vi.fn(),
     patchSlideMoves: vi.fn(),
-    slidesPresentationURL: vi.fn((slug: string) => `/api/docs/slides/${slug}/present`),
+    slidesPresentationURL: vi.fn((slug: string, _scope?: string, presenter?: boolean) => `/api/docs/slides/${slug}/present${presenter ? '?presenter=1' : ''}`),
   }
 })
 
@@ -51,6 +51,17 @@ describe('SlidesDeckView refresh signal', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('opens Present in presenter mode', async () => {
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+    render(<SlidesDeckView deckSlug="d" refreshSignal={0} />)
+    await waitFor(() => expect(slidesApi.fetchSlidesDeck).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('slides-present'))
+
+    expect(slidesApi.slidesPresentationURL).toHaveBeenCalledWith('d', 'personal', true)
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/d/present?presenter=1', '_blank', 'noopener,noreferrer')
   })
 
   it('fetches the deck once on initial render', async () => {

--- a/web/src/components/docs/slides/SlidesCard.test.tsx
+++ b/web/src/components/docs/slides/SlidesCard.test.tsx
@@ -7,7 +7,7 @@ import SlidesCard from './SlidesCard'
 vi.mock('@/api/slides', () => ({
   exportSlidesDeck: vi.fn(),
   fetchSlidesPresentation: vi.fn(),
-  slidesPresentationURL: vi.fn(() => '/api/docs/slides/migration/present?scope=team'),
+  slidesPresentationURL: vi.fn((_slug: string, _scope: string, presenter?: boolean) => `/api/docs/slides/migration/present?scope=team${presenter ? '&presenter=1' : ''}`),
 }))
 
 const update = {
@@ -62,8 +62,8 @@ describe('SlidesCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Present' }))
 
     await waitFor(() => expect(fetchSlidesPresentation).toHaveBeenCalledWith('migration', 'team'))
-    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team', '_blank', 'noopener,noreferrer')
-    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team')
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team&presenter=1', '_blank', 'noopener,noreferrer')
+    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team', true)
   })
 
   it('reloads the presentation after an empty deck receives its first slide', async () => {
@@ -96,8 +96,8 @@ describe('SlidesCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Present' }))
 
-    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team', '_blank', 'noopener,noreferrer')
-    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team')
+    expect(window.open).toHaveBeenCalledWith('/api/docs/slides/migration/present?scope=team&presenter=1', '_blank', 'noopener,noreferrer')
+    expect(slidesPresentationURL).toHaveBeenCalledWith('migration', 'team', true)
     expect(fetchSlidesPresentation).toHaveBeenCalledTimes(2)
   })
 

--- a/web/src/components/docs/slides/SlidesCard.tsx
+++ b/web/src/components/docs/slides/SlidesCard.tsx
@@ -85,7 +85,7 @@ export default function SlidesCard({ update, scope = 'personal' }: SlidesCardPro
     try {
       const url = presentationUrlRef.current ?? await loadPresentation()
       if (url && mountedRef.current) {
-        window.open(slidesPresentationURL(update.deckSlug, scope), '_blank', 'noopener,noreferrer')
+        window.open(slidesPresentationURL(update.deckSlug, scope, true), '_blank', 'noopener,noreferrer')
       }
     } finally {
       if (mountedRef.current) setPendingAction(null)

--- a/web/src/components/docs/slides/runtime/AstDeck.ts
+++ b/web/src/components/docs/slides/runtime/AstDeck.ts
@@ -99,7 +99,10 @@ export class AstDeck extends LitElement implements AstDeckElement {
     const parent = this.parentElement
     if (!parent) return
     const scale = Math.min(parent.clientWidth / CANVAS_WIDTH, parent.clientHeight / CANVAS_HEIGHT)
-    if (Number.isFinite(scale) && scale > 0) this.style.transform = `scale(${scale})`
+    if (!Number.isFinite(scale) || scale <= 0) return
+    this.style.transform = `scale(${scale})`
+    this.style.left = `${Math.max(0, (parent.clientWidth - CANVAS_WIDTH * scale) / 2)}px`
+    this.style.top = `${Math.max(0, (parent.clientHeight - CANVAS_HEIGHT * scale) / 2)}px`
   }
 
   private async signalReady(): Promise<void> {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -3,9 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import './index'
 import type { AstDeckElement, AstFragmentElement, AstSlideElement } from './types'
 
-const mountDeck = async () => {
+const mountDeck = async (width = 960, height = 540) => {
   const host = document.createElement('div')
-  Object.defineProperties(host, { clientWidth: { value: 960 }, clientHeight: { value: 540 } })
+  Object.defineProperties(host, { clientWidth: { value: width }, clientHeight: { value: height } })
   host.innerHTML = `<ast-deck no-history>
     <ast-slide id="one"><ast-fragment order="2">B</ast-fragment><ast-fragment order="1">A</ast-fragment></ast-slide>
     <ast-slide id="two"><ast-notes>Notes</ast-notes></ast-slide>
@@ -59,6 +59,9 @@ describe('DeckController', () => {
       expect(button).not.toBeNull()
       return button!
     })
+    expect(start.style.top).toBe('24px')
+    expect(start.style.left).toBe('50%')
+    expect(start.style.transform).toBe('translateX(-50%)')
 
     start.click()
     await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
@@ -73,6 +76,8 @@ describe('DeckController', () => {
     const fragments = [...deck.querySelectorAll('ast-fragment')] as AstFragmentElement[]
 
     expect(deck.style.transform).toBe('scale(0.5)')
+    expect(deck.style.left).toBe('0px')
+    expect(deck.style.top).toBe('0px')
     expect(slides[0].active).toBe(true)
     deck.next()
     expect(fragments[1].revealed).toBe(true)
@@ -81,6 +86,14 @@ describe('DeckController', () => {
     deck.next()
     expect(slides[1].active).toBe(true)
     expect(deck.currentIndex).toBe(1)
+  })
+
+  it('centers the scaled slide when the viewport is taller than 16:9', async () => {
+    const deck = await mountDeck(1920, 1200)
+
+    expect(deck.style.transform).toBe('scale(1)')
+    expect(deck.style.left).toBe('0px')
+    expect(deck.style.top).toBe('60px')
   })
 
   it('accepts navigation messages only from its parent window', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -50,11 +50,34 @@ describe('DeckController', () => {
     expect(deck.currentIndex).toBe(0)
   })
 
-  it('does not advance on click while canvas edit mode is on', async () => {
+  it('navigates from background clicks while canvas edit mode is on', async () => {
     const deck = await mountDeck()
     deck.setAttribute('edit', '')
+    deck.next()
+    deck.next()
+
     deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 800 }))
+    expect(deck.currentIndex).toBe(1)
+
+    deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 100 }))
     expect(deck.currentIndex).toBe(0)
+  })
+
+  it('does not navigate when an editable canvas object is clicked', async () => {
+    const deck = await mountDeck()
+    const slide = deck.querySelector('ast-slide[active]') as HTMLElement
+    const text = document.createElement('ast-text')
+    text.id = 'headline'
+    slide.append(text)
+    deck.setAttribute('edit', '')
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: () => [text, slide, deck],
+    })
+
+    text.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 800 }))
+    expect(deck.currentIndex).toBe(0)
+    expect(deck.fragment).toBe(0)
   })
 
   it('handles keyboard navigation and slide lifecycle events', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -44,17 +44,27 @@ describe('DeckController', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
-  it('retries fullscreen on the first presenter interaction when automatic entry is blocked', async () => {
+  it('offers a user-activated fullscreen fallback when automatic entry is blocked', async () => {
     history.replaceState(null, '', '?presenter=1')
+    let fullscreenElement: Element | null = null
     const requestFullscreen = vi.fn()
       .mockRejectedValueOnce(new Error('user activation required'))
-      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(async () => { fullscreenElement = document.documentElement })
     Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
-    Object.defineProperty(document, 'fullscreenElement', { configurable: true, value: null })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => fullscreenElement })
 
-    await mountDeck()
-    window.dispatchEvent(new PointerEvent('pointerdown'))
+    const deck = await mountDeck()
+    const start = await vi.waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>('button[aria-label="Start slideshow in fullscreen"]')
+      expect(button).not.toBeNull()
+      return button!
+    })
+
+    start.click()
     await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
+    expect(document.fullscreenElement).toBe(document.documentElement)
+    expect(document.body.contains(start)).toBe(false)
+    expect(deck.currentIndex).toBe(0)
   })
 
   it('scales the fixed canvas and advances ordered fragments before slides', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -18,11 +18,45 @@ const mountDeck = async () => {
 
 afterEach(() => {
   document.body.replaceChildren()
-  history.replaceState(null, '', '#')
+  history.replaceState(null, '', location.pathname)
+  Reflect.deleteProperty(document, 'fullscreenElement')
+  Reflect.deleteProperty(document, 'exitFullscreen')
+  Reflect.deleteProperty(document.documentElement, 'requestFullscreen')
   vi.restoreAllMocks()
 })
 
 describe('DeckController', () => {
+  it('enters fullscreen in presenter mode and Escape exits fullscreen and closes the tab', async () => {
+    history.replaceState(null, '', '?presenter=1')
+    let fullscreenElement: Element | null = null
+    const requestFullscreen = vi.fn().mockImplementation(async () => { fullscreenElement = document.documentElement })
+    const exitFullscreen = vi.fn().mockImplementation(async () => { fullscreenElement = null })
+    const close = vi.spyOn(window, 'close').mockImplementation(() => undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+    Object.defineProperty(document, 'exitFullscreen', { configurable: true, value: exitFullscreen })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => fullscreenElement })
+
+    const deck = await mountDeck()
+    await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledOnce())
+
+    deck.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await vi.waitFor(() => expect(exitFullscreen).toHaveBeenCalledOnce())
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('retries fullscreen on the first presenter interaction when automatic entry is blocked', async () => {
+    history.replaceState(null, '', '?presenter=1')
+    const requestFullscreen = vi.fn()
+      .mockRejectedValueOnce(new Error('user activation required'))
+      .mockResolvedValueOnce(undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, value: null })
+
+    await mountDeck()
+    window.dispatchEvent(new PointerEvent('pointerdown'))
+    await vi.waitFor(() => expect(requestFullscreen).toHaveBeenCalledTimes(2))
+  })
+
   it('scales the fixed canvas and advances ordered fragments before slides', async () => {
     const deck = await mountDeck()
     const slides = [...deck.querySelectorAll('ast-slide')] as AstSlideElement[]

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -9,6 +9,9 @@ export class DeckController {
   private index = 0
   private fragment = 0
   private touchStart?: { x: number; y: number }
+  private presenter = new URLSearchParams(location.search).get('presenter') === '1'
+  private enteredFullscreen = false
+  private presenterClosed = false
 
   get currentIndex(): number {
     return this.index
@@ -25,7 +28,13 @@ export class DeckController {
     this.deck.addEventListener('touchstart', this.onTouchStart, { passive: true })
     this.deck.addEventListener('touchend', this.onTouchEnd, { passive: true })
     window.addEventListener('hashchange', this.onHashChange)
+    if (this.presenter) {
+      document.addEventListener('fullscreenchange', this.onFullscreenChange)
+      window.addEventListener('pointerdown', this.onPresenterInteraction, { once: true })
+      window.addEventListener('keydown', this.onPresenterKeyDown)
+    }
     this.applyState(false)
+    if (this.presenter) void this.enterFullscreen()
   }
 
   disconnect(): void {
@@ -34,6 +43,9 @@ export class DeckController {
     this.deck.removeEventListener('touchstart', this.onTouchStart)
     this.deck.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('hashchange', this.onHashChange)
+    document.removeEventListener('fullscreenchange', this.onFullscreenChange)
+    window.removeEventListener('pointerdown', this.onPresenterInteraction)
+    window.removeEventListener('keydown', this.onPresenterKeyDown)
   }
 
   next(): void {
@@ -188,6 +200,54 @@ export class DeckController {
     if (event.defaultPrevented || (event.target as Element).closest('a,button,input,textarea,select')) return
     if (this.deck.hasAttribute('edit') && hitTest(this.deck, event.clientX, event.clientY)) return
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
+  }
+
+  private readonly onPresenterInteraction = (): void => {
+    void this.enterFullscreen()
+  }
+
+  private readonly onPresenterKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      void this.exitPresenter()
+      return
+    }
+    void this.enterFullscreen()
+  }
+
+  private readonly onFullscreenChange = (): void => {
+    if (document.fullscreenElement) {
+      this.enteredFullscreen = true
+      return
+    }
+    if (this.enteredFullscreen) this.closePresenter()
+  }
+
+  private async enterFullscreen(): Promise<void> {
+    if (document.fullscreenElement || !document.documentElement.requestFullscreen) return
+    try {
+      await document.documentElement.requestFullscreen()
+      this.enteredFullscreen = true
+    } catch {
+      // Browsers may require the first interaction in the presentation tab.
+    }
+  }
+
+  private async exitPresenter(): Promise<void> {
+    if (document.fullscreenElement && document.exitFullscreen) {
+      try {
+        await document.exitFullscreen()
+      } catch {
+        // Closing the dedicated presenter tab remains the final fallback.
+      }
+    }
+    this.closePresenter()
+  }
+
+  private closePresenter(): void {
+    if (this.presenterClosed) return
+    this.presenterClosed = true
+    window.close()
   }
 
   private readonly onTouchStart = (event: TouchEvent): void => {

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -252,9 +252,10 @@ export class DeckController {
     button.setAttribute('aria-label', 'Start slideshow in fullscreen')
     Object.assign(button.style, {
       position: 'fixed',
-      inset: '50% auto auto 50%',
+      top: '24px',
+      left: '50%',
       zIndex: '2147483647',
-      transform: 'translate(-50%, -50%)',
+      transform: 'translateX(-50%)',
       padding: '16px 24px',
       border: '2px solid currentColor',
       borderRadius: '12px',

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -12,6 +12,7 @@ export class DeckController {
   private presenter = new URLSearchParams(location.search).get('presenter') === '1'
   private enteredFullscreen = false
   private presenterClosed = false
+  private presenterStart?: HTMLButtonElement
 
   get currentIndex(): number {
     return this.index
@@ -30,7 +31,6 @@ export class DeckController {
     window.addEventListener('hashchange', this.onHashChange)
     if (this.presenter) {
       document.addEventListener('fullscreenchange', this.onFullscreenChange)
-      window.addEventListener('pointerdown', this.onPresenterInteraction, { once: true })
       window.addEventListener('keydown', this.onPresenterKeyDown)
     }
     this.applyState(false)
@@ -44,8 +44,8 @@ export class DeckController {
     this.deck.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('hashchange', this.onHashChange)
     document.removeEventListener('fullscreenchange', this.onFullscreenChange)
-    window.removeEventListener('pointerdown', this.onPresenterInteraction)
     window.removeEventListener('keydown', this.onPresenterKeyDown)
+    this.hidePresenterStart()
   }
 
   next(): void {
@@ -202,7 +202,9 @@ export class DeckController {
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
   }
 
-  private readonly onPresenterInteraction = (): void => {
+  private readonly onPresenterStart = (event: MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
     void this.enterFullscreen()
   }
 
@@ -212,25 +214,67 @@ export class DeckController {
       void this.exitPresenter()
       return
     }
-    void this.enterFullscreen()
+    if (event.target !== this.presenterStart) void this.enterFullscreen()
   }
 
   private readonly onFullscreenChange = (): void => {
     if (document.fullscreenElement) {
       this.enteredFullscreen = true
+      this.hidePresenterStart()
       return
     }
     if (this.enteredFullscreen) this.closePresenter()
   }
 
   private async enterFullscreen(): Promise<void> {
-    if (document.fullscreenElement || !document.documentElement.requestFullscreen) return
+    if (document.fullscreenElement) {
+      this.hidePresenterStart()
+      return
+    }
+    if (!document.documentElement.requestFullscreen) {
+      this.showPresenterStart()
+      return
+    }
     try {
       await document.documentElement.requestFullscreen()
       this.enteredFullscreen = true
+      this.hidePresenterStart()
     } catch {
-      // Browsers may require the first interaction in the presentation tab.
+      this.showPresenterStart()
     }
+  }
+
+  private showPresenterStart(): void {
+    if (this.presenterStart || this.presenterClosed) return
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.textContent = 'Start slideshow'
+    button.setAttribute('aria-label', 'Start slideshow in fullscreen')
+    Object.assign(button.style, {
+      position: 'fixed',
+      inset: '50% auto auto 50%',
+      zIndex: '2147483647',
+      transform: 'translate(-50%, -50%)',
+      padding: '16px 24px',
+      border: '2px solid currentColor',
+      borderRadius: '12px',
+      background: '#ffffff',
+      color: '#172033',
+      font: '600 20px/1.2 system-ui, sans-serif',
+      cursor: 'pointer',
+      boxShadow: '0 8px 30px rgb(0 0 0 / 25%)',
+    })
+    button.addEventListener('click', this.onPresenterStart)
+    document.body.append(button)
+    button.focus()
+    this.presenterStart = button
+  }
+
+  private hidePresenterStart(): void {
+    if (!this.presenterStart) return
+    this.presenterStart.removeEventListener('click', this.onPresenterStart)
+    this.presenterStart.remove()
+    this.presenterStart = undefined
   }
 
   private async exitPresenter(): Promise<void> {

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -1,5 +1,6 @@
 import type { AstFragment } from './AstFragment'
 import type { AstSlide } from './AstSlide'
+import { hitTest } from './EditController'
 import type { DeckChangeDetail, FragmentPolicy } from './types'
 
 const NAVIGATION_KEYS = new Set(['ArrowRight', 'ArrowDown', 'PageDown', ' ', 'ArrowLeft', 'ArrowUp', 'PageUp', 'Home', 'End'])
@@ -184,8 +185,8 @@ export class DeckController {
   }
 
   private readonly onClick = (event: MouseEvent): void => {
-    if (this.deck.hasAttribute('edit')) return
     if (event.defaultPrevented || (event.target as Element).closest('a,button,input,textarea,select')) return
+    if (this.deck.hasAttribute('edit') && hitTest(this.deck, event.clientX, event.clientY)) return
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
   }
 

--- a/web/src/components/docs/slides/runtime/styles.test.ts
+++ b/web/src/components/docs/slides/runtime/styles.test.ts
@@ -10,7 +10,12 @@ import { runtimeStyles } from './styles'
 // each slide with white margins — and spills the page-sized slide onto a
 // trailing blank page. This test locks the print contract so that regression
 // is caught in CI instead of only in an exported PDF.
-describe('slides runtime print styles', () => {
+describe('slides runtime styles', () => {
+  it('centers the positioned slide canvas against a black viewport', () => {
+    expect(runtimeStyles).toContain('html:has(> body > ast-deck), body:has(> ast-deck) { margin:0; width:100%; height:100%; overflow:hidden; background:#000; }')
+    expect(runtimeStyles).toContain('ast-deck { display:block; position:absolute;')
+  })
+
   it('sizes the page and slides to the exact PDF paper (no scale-to-fit)', () => {
     expect(runtimeStyles).toContain('@page { size:20in 11.25in; margin:0; }')
     expect(runtimeStyles).toContain('width:20in!important')

--- a/web/src/components/docs/slides/runtime/styles.ts
+++ b/web/src/components/docs/slides/runtime/styles.ts
@@ -1,5 +1,6 @@
 export const runtimeStyles = `
-  ast-deck { display:block; position:relative; width:1920px; height:1080px; overflow:hidden; transform-origin:top left; background:var(--ast-surface,#fff); color:var(--ast-ink,#172033); }
+  html:has(> body > ast-deck), body:has(> ast-deck) { margin:0; width:100%; height:100%; overflow:hidden; background:#000; }
+  ast-deck { display:block; position:absolute; width:1920px; height:1080px; overflow:hidden; transform-origin:top left; background:var(--ast-surface,#fff); color:var(--ast-ink,#172033); }
   /* Off-screen slides are display:none so their (potentially hundreds of)
      elements are never laid out; content-visibility:auto + contain-intrinsic-size
      lets the browser also skip rendering work for any slide that becomes
@@ -39,6 +40,7 @@ export const runtimeStyles = `
        page-sized slide onto a trailing blank page. */
     @page { size:20in 11.25in; margin:0; }
     html, body { margin:0; padding:0; width:20in; overflow:visible; }
+    body { background:var(--ast-surface,#fff); }
     ast-deck { transform:none!important; position:static!important; width:20in; height:auto; overflow:visible; background:transparent!important; }
     ast-slide { display:block!important; position:relative!important; inset:auto!important; width:20in!important; height:11.25in!important; overflow:hidden; break-inside:avoid; break-after:page; page-break-after:always; }
     ast-slide:last-of-type { break-after:auto; page-break-after:auto; }


### PR DESCRIPTION
## Summary
- package PPTX import/export workers and production Node dependencies in the runtime image
- resolve worker paths from a stable runtime root instead of build-time source paths
- provision PDF sandbox sessions with the configured template layer chain/image
- restart and wait for existing Kubernetes sessions before browser launch
- surface browser stderr and exit status on launch failures

## Verification
- `go test ./pkg/api ./pkg/launcher ./pkg/sandbox`
- `make lint`
- `docker build --check -f docker/astonish/Dockerfile .`
- clean runtime dependency install smoke test for PPTX workers
- `go test ./...` passed all affected packages; unrelated existing `pkg/tui` theme/footer assertions failed