### PR TITLE
feat(slides): fully functional slide editor — toolbar, properties, text formatting, z-order & bug fixes

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1085,6 +1085,7 @@ func RegisterRoutes(router *mux.Router, svc *store.Services, backend store.Platf
 	router.HandleFunc("/api/docs/slides/{deckSlug}", DeleteSlidesDeckHandler).Methods("DELETE")
 	router.HandleFunc("/api/docs/slides/{deckSlug}/slides/{idx:[0-9]+}", GetSlideHandler).Methods("GET")
 	router.HandleFunc("/api/docs/slides/{deckSlug}/slides/{idx:[0-9]+}", PatchSlideHandler).Methods("PATCH")
+	router.HandleFunc("/api/docs/slides/{deckSlug}/assets", UploadSlideAssetHandler).Methods("POST")
 	router.HandleFunc("/api/docs/slides/{deckSlug}/thumbnails/{idx:[0-9]+}", GetSlidesDeckSlideThumbnailHandler).Methods("GET")
 	router.HandleFunc("/api/docs/slides/{deckSlug}/present", PresentSlidesHandler).Methods("GET")
 	router.HandleFunc("/api/docs/slides/{deckSlug}/export/html", ExportSlidesHTMLHandler).Methods("POST")

--- a/pkg/api/slides_handlers.go
+++ b/pkg/api/slides_handlers.go
@@ -240,12 +240,13 @@ func GetSlideHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type slideMovesRequest struct {
-	Moves   []slideMove       `json:"moves"`
-	Resizes []slideResize     `json:"resizes"`
-	Texts   []slideText       `json:"texts"`
-	Deletes []string          `json:"deletes"`
-	Attrs   []slideAttrChange `json:"attrs"`
-	Creates []slideCreate     `json:"creates"`
+	Moves    []slideMove       `json:"moves"`
+	Resizes  []slideResize     `json:"resizes"`
+	Texts    []slideText       `json:"texts"`
+	Deletes  []string          `json:"deletes"`
+	Attrs    []slideAttrChange `json:"attrs"`
+	Creates  []slideCreate     `json:"creates"`
+	Reorders []string          `json:"reorders"`
 }
 
 type slideMove struct {
@@ -291,7 +292,7 @@ func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid edit payload", http.StatusBadRequest)
 		return
 	}
-	if len(body.Moves) == 0 && len(body.Resizes) == 0 && len(body.Texts) == 0 && len(body.Deletes) == 0 && len(body.Attrs) == 0 && len(body.Creates) == 0 {
+	if len(body.Moves) == 0 && len(body.Resizes) == 0 && len(body.Texts) == 0 && len(body.Deletes) == 0 && len(body.Attrs) == 0 && len(body.Creates) == 0 && len(body.Reorders) == 0 {
 		http.Error(w, "moves, resizes, texts, deletes, attrs, or creates are required", http.StatusBadRequest)
 		return
 	}
@@ -315,6 +316,7 @@ func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 	for _, c := range body.Creates {
 		edits.Creates = append(edits.Creates, slides.ElementCreate{ID: c.ID, Tag: c.Tag, Attrs: c.Attrs, Text: c.Text})
 	}
+	edits.Reorders = append(edits.Reorders, body.Reorders...)
 	item, diags, err := svc.ApplySlideEdits(r.Context(), mux.Vars(r)["deckSlug"], position, edits)
 	if err != nil {
 		if errors.Is(err, store.ErrDocsNotFound) {

--- a/pkg/api/slides_handlers.go
+++ b/pkg/api/slides_handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -239,10 +240,12 @@ func GetSlideHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type slideMovesRequest struct {
-	Moves   []slideMove   `json:"moves"`
-	Resizes []slideResize `json:"resizes"`
-	Texts   []slideText   `json:"texts"`
-	Deletes []string      `json:"deletes"`
+	Moves   []slideMove       `json:"moves"`
+	Resizes []slideResize     `json:"resizes"`
+	Texts   []slideText       `json:"texts"`
+	Deletes []string          `json:"deletes"`
+	Attrs   []slideAttrChange `json:"attrs"`
+	Creates []slideCreate     `json:"creates"`
 }
 
 type slideMove struct {
@@ -264,6 +267,18 @@ type slideText struct {
 	Text string `json:"text"`
 }
 
+type slideAttrChange struct {
+	ID    string            `json:"id"`
+	Attrs map[string]string `json:"attrs"`
+}
+
+type slideCreate struct {
+	ID    string            `json:"id"`
+	Tag   string            `json:"tag"`
+	Attrs map[string]string `json:"attrs"`
+	Text  string            `json:"text,omitempty"`
+}
+
 // PatchSlideHandler applies canvas object moves, resizes, text edits, and deletes.
 func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 	position, err := strconv.Atoi(mux.Vars(r)["idx"])
@@ -276,8 +291,8 @@ func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid edit payload", http.StatusBadRequest)
 		return
 	}
-	if len(body.Moves) == 0 && len(body.Resizes) == 0 && len(body.Texts) == 0 && len(body.Deletes) == 0 {
-		http.Error(w, "moves, resizes, texts, or deletes are required", http.StatusBadRequest)
+	if len(body.Moves) == 0 && len(body.Resizes) == 0 && len(body.Texts) == 0 && len(body.Deletes) == 0 && len(body.Attrs) == 0 && len(body.Creates) == 0 {
+		http.Error(w, "moves, resizes, texts, deletes, attrs, or creates are required", http.StatusBadRequest)
 		return
 	}
 	svc, ok := requireDocsService(w, r)
@@ -294,6 +309,12 @@ func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 	for _, t := range body.Texts {
 		edits.Texts = append(edits.Texts, slides.ElementText{ID: t.ID, Text: t.Text})
 	}
+	for _, a := range body.Attrs {
+		edits.Attrs = append(edits.Attrs, slides.ElementAttrChange{ID: a.ID, Attrs: a.Attrs})
+	}
+	for _, c := range body.Creates {
+		edits.Creates = append(edits.Creates, slides.ElementCreate{ID: c.ID, Tag: c.Tag, Attrs: c.Attrs, Text: c.Text})
+	}
 	item, diags, err := svc.ApplySlideEdits(r.Context(), mux.Vars(r)["deckSlug"], position, edits)
 	if err != nil {
 		if errors.Is(err, store.ErrDocsNotFound) {
@@ -308,6 +329,60 @@ func PatchSlideHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeSlidesJSON(w, http.StatusOK, item)
+}
+
+// UploadSlideAssetHandler handles POST /api/docs/slides/{deckSlug}/assets.
+// It accepts a multipart file upload (field "file"), validates the image
+// through AssetIngestor.Accept, stores it via AddDeckAsset, and returns the
+// content-addressed asset-ref that ast-image elements use.
+func UploadSlideAssetHandler(w http.ResponseWriter, r *http.Request) {
+	svc, ok := requireDocsService(w, r)
+	if !ok {
+		return
+	}
+	deckSlug := mux.Vars(r)["deckSlug"]
+	if deckSlug == "" {
+		http.Error(w, "deckSlug is required", http.StatusBadRequest)
+		return
+	}
+	// Limit upload body to the asset max (20MB) plus some multipart overhead.
+	r.Body = http.MaxBytesReader(w, r.Body, slides.MaxAssetBytes+1<<20)
+	if err := r.ParseMultipartForm(slides.MaxAssetBytes); err != nil { //nolint:gosec // body already bounded by MaxBytesReader above
+		http.Error(w, "invalid multipart upload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "file field is required: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	body, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, "failed to read uploaded file", http.StatusBadRequest)
+		return
+	}
+	// Use the file's declared content type from the multipart header, not the
+	// request-level Content-Type (which is multipart/form-data).
+	declaredMIME := ""
+	if header != nil {
+		declaredMIME = header.Header.Get("Content-Type")
+	}
+	asset, err := slides.AssetIngestor{}.Accept(body, declaredMIME)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ref := "sha256-" + asset.ID
+	dataURI := "data:" + asset.MIME + ";base64," + base64.StdEncoding.EncodeToString(asset.Bytes)
+	if _, err := svc.AddDeckAsset(r.Context(), deckSlug, ref, dataURI); err != nil {
+		http.Error(w, "failed to store asset: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeSlidesJSON(w, http.StatusOK, map[string]string{
+		"assetRef": ref,
+		"mime":     asset.MIME,
+	})
 }
 
 // deckSlideThumbnailPNGPrefix is the data-URI prefix stripped before

--- a/pkg/docs/slides/export_html.go
+++ b/pkg/docs/slides/export_html.go
@@ -198,6 +198,9 @@ func renderNode(out *bytes.Buffer, node Node, assets map[string]string, slideID 
 	if node.FlipV {
 		writeAttr(out, "flip-v", "true")
 	}
+	if node.Rot != 0 {
+		writeAttr(out, "rot", strconv.Itoa(node.Rot))
+	}
 	keys := make([]string, 0, len(node.Props))
 	for key := range node.Props {
 		keys = append(keys, key)

--- a/pkg/docs/slides/export_html.go
+++ b/pkg/docs/slides/export_html.go
@@ -91,6 +91,18 @@ func (e HTMLExporter) Export(scene SceneGraph) (ExportResult, error) {
 	return ExportResult{Bytes: body.Bytes(), Diagnostics: diagnostics}, nil
 }
 
+// fontTokenAliases maps camelCase template token keys to the kebab-case CSS
+// variable names the runtime expects. When a template (or imported deck) stores
+// "displayFont" → "Manrope", the runtime's AstText reads var(--ast-display),
+// NOT var(--ast-displayFont). This map bridges the gap: both --ast-displayFont
+// and --ast-display are emitted so every consumer finds the value it expects.
+// The PPTX exporter (worker.mjs) already checks both variants.
+var fontTokenAliases = map[string]string{
+	"displayFont": "display",
+	"bodyFont":    "body-font",
+	"monoFont":    "mono-font",
+}
+
 func writeThemeCSS(out *bytes.Buffer, theme map[string]string) {
 	if len(theme) == 0 {
 		return
@@ -116,6 +128,18 @@ func writeThemeCSS(out *bytes.Buffer, theme map[string]string) {
 		out.WriteByte(':')
 		out.WriteString(theme[key])
 		out.WriteByte(';')
+		// Emit a CSS-compatible alias when the canonical name differs from
+		// the template token key (e.g. displayFont → display).  Skip if
+		// the theme already contains the alias key to avoid double-emission.
+		if alias, ok := fontTokenAliases[key]; ok {
+			if _, exists := theme[alias]; !exists {
+				out.WriteString("--ast-")
+				out.WriteString(alias)
+				out.WriteByte(':')
+				out.WriteString(theme[key])
+				out.WriteByte(';')
+			}
+		}
 	}
 	out.WriteByte('}')
 }

--- a/pkg/docs/slides/export_html.go
+++ b/pkg/docs/slides/export_html.go
@@ -223,6 +223,11 @@ func renderNode(out *bytes.Buffer, node Node, assets map[string]string, slideID 
 			}
 			continue
 		}
+		// Skip stale/transient src on ast-image — it is always derived from
+		// asset-ref above and emitting it would duplicate the attribute.
+		if tag == "ast-image" && key == "src" {
+			continue
+		}
 		writeAttr(out, key, value)
 	}
 	if node.Table != nil {

--- a/pkg/docs/slides/export_html_test.go
+++ b/pkg/docs/slides/export_html_test.go
@@ -368,6 +368,53 @@ func TestWriteThemeCSSSkipsTemplateName(t *testing.T) {
 	}
 }
 
+func TestWriteThemeCSSEmitsFontAliases(t *testing.T) {
+	var buf bytes.Buffer
+	writeThemeCSS(&buf, map[string]string{
+		"displayFont": "Manrope, sans-serif",
+		"bodyFont":    "Manrope, sans-serif",
+		"monoFont":    "JetBrains Mono, monospace",
+		"surface":     "#0B0D0F",
+	})
+	css := buf.String()
+	// The camelCase originals must appear.
+	if !strings.Contains(css, "--ast-displayFont:Manrope, sans-serif") {
+		t.Errorf("expected --ast-displayFont; got: %s", css)
+	}
+	// The CSS-compatible aliases the runtime reads must also appear.
+	if !strings.Contains(css, "--ast-display:Manrope, sans-serif") {
+		t.Errorf("expected --ast-display alias; got: %s", css)
+	}
+	if !strings.Contains(css, "--ast-body-font:Manrope, sans-serif") {
+		t.Errorf("expected --ast-body-font alias; got: %s", css)
+	}
+	if !strings.Contains(css, "--ast-mono-font:JetBrains Mono, monospace") {
+		t.Errorf("expected --ast-mono-font alias; got: %s", css)
+	}
+}
+
+func TestWriteThemeCSSNoDoubleEmissionWhenAliasPresent(t *testing.T) {
+	// When the theme already contains the CSS-compatible key, don't emit it twice.
+	var buf bytes.Buffer
+	writeThemeCSS(&buf, map[string]string{
+		"displayFont": "Manrope, sans-serif",
+		"display":     "Inter, sans-serif", // explicit override takes precedence
+	})
+	css := buf.String()
+	// Both should appear with their own values.
+	if !strings.Contains(css, "--ast-display:Inter, sans-serif") {
+		t.Errorf("expected --ast-display with explicit value; got: %s", css)
+	}
+	if !strings.Contains(css, "--ast-displayFont:Manrope, sans-serif") {
+		t.Errorf("expected --ast-displayFont; got: %s", css)
+	}
+	// The alias should NOT be emitted a second time from the displayFont key.
+	count := strings.Count(css, "--ast-display:")
+	if count != 1 {
+		t.Errorf("expected --ast-display exactly once (from explicit key), got %d occurrences in: %s", count, css)
+	}
+}
+
 func TestHTMLGradientIDsAreSlideScoped(t *testing.T) {
 	grad := func(cx, cy int) *Gradient {
 		return &Gradient{Kind: "radial", Cx: cx, Cy: cy, Stops: []GradientStop{

--- a/pkg/docs/slides/export_html_test.go
+++ b/pkg/docs/slides/export_html_test.go
@@ -542,3 +542,24 @@ func TestExportNoFontFaceWhenAbsent(t *testing.T) {
 		t.Errorf("no deck without embedded fonts should emit @font-face; got:\n%s", doc)
 	}
 }
+
+func TestHTMLExporterRoundtripsRotAttribute(t *testing.T) {
+	// Parse a slide with rot="45", export it, and verify the rot attribute
+	// survives the roundtrip so the Lit runtime can read it on reload.
+	markup := `<ast-slide id="s1"><ast-text id="t1" x="10" y="20" w="300" h="80" rot="45">Hello</ast-text></ast-slide>`
+	slide, diags, err := ParseSlide(markup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if HasErrors(diags) {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+	if slide.Nodes[0].Rot != 45 {
+		t.Fatalf("expected Rot=45, got %d", slide.Nodes[0].Rot)
+	}
+	scene := SceneGraph{SchemaVersion: SchemaV2, Title: "Rot Test", Slides: []Slide{slide}}
+	doc := mustExport(t, HTMLExporter{RuntimeJS: []byte(`window.runtimeReady=true`)}, scene)
+	if !strings.Contains(doc, `rot="45"`) {
+		t.Errorf("exported HTML missing rot attribute; got:\n%s", doc)
+	}
+}

--- a/pkg/docs/slides/fill.go
+++ b/pkg/docs/slides/fill.go
@@ -1078,3 +1078,69 @@ func insertElement(markup, tag string, attrs map[string]string, text string) (st
 	}
 	return markup[:idx] + element + markup[idx:], nil
 }
+
+// reorderElements rearranges the direct element children of <ast-slide> so that
+// the elements whose IDs appear in `order` are placed in that order.  Elements
+// not mentioned in `order` (e.g. decorative backgrounds) keep their relative
+// position and stay before the reordered elements.
+func reorderElements(markup string, order []string) (string, error) {
+	if len(order) == 0 {
+		return markup, nil
+	}
+	// Collect the position of every element we need to reorder.
+	type fragment struct {
+		id    string
+		start int
+		end   int
+		text  string
+	}
+	var frags []fragment
+	for _, id := range order {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		start, _, _, _, _, closeEnd, ok := findElement(markup, id)
+		if !ok {
+			// Element might have been deleted — skip silently.
+			continue
+		}
+		frags = append(frags, fragment{id: id, start: start, end: closeEnd, text: markup[start:closeEnd]})
+	}
+	if len(frags) < 2 {
+		return markup, nil // nothing to reorder
+	}
+	// Sort fragments by their start position (original document order) so we
+	// can remove them back-to-front without invalidating offsets.
+	sort.Slice(frags, func(i, j int) bool { return frags[i].start < frags[j].start })
+	// Remove all reordered elements from markup, back-to-front.
+	result := markup
+	for i := len(frags) - 1; i >= 0; i-- {
+		f := frags[i]
+		// Recalculate position in the (possibly shortened) result.
+		s, _, _, _, _, e, ok := findElement(result, f.id)
+		if !ok {
+			continue
+		}
+		result = result[:s] + result[e:]
+	}
+	// Build the insertion string in the requested order.
+	orderMap := make(map[string]string, len(frags))
+	for _, f := range frags {
+		orderMap[f.id] = f.text
+	}
+	var insertion strings.Builder
+	for _, id := range order {
+		id = strings.TrimSpace(id)
+		if text, ok := orderMap[id]; ok {
+			insertion.WriteString(text)
+		}
+	}
+	// Insert before closing </ast-slide>.
+	closing := "</ast-slide>"
+	idx := strings.LastIndex(result, closing)
+	if idx < 0 {
+		return "", fmt.Errorf("no closing </ast-slide> found")
+	}
+	return result[:idx] + insertion.String() + result[idx:], nil
+}

--- a/pkg/docs/slides/fill.go
+++ b/pkg/docs/slides/fill.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"html"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/SAP/astonish/pkg/docs/slides/components"
 	"github.com/SAP/astonish/pkg/docs/slides/themes"
 )
 
@@ -978,4 +980,101 @@ func setIntAttr(attrs, key string, n int) string {
 		return fmt.Sprintf(`%s="%d"`, key, n)
 	}
 	return attrs + " " + fmt.Sprintf(`%s="%d"`, key, n)
+}
+
+func setStringAttr(attrs, key, value string) string {
+	if start, end, ok := attrValueRange(attrs, key); ok {
+		return attrs[:start] + html.EscapeString(value) + attrs[end:]
+	}
+	attrs = strings.TrimSpace(attrs)
+	if attrs == "" {
+		return fmt.Sprintf(`%s="%s"`, key, html.EscapeString(value))
+	}
+	return attrs + " " + fmt.Sprintf(`%s="%s"`, key, html.EscapeString(value))
+}
+
+func rewriteElementAttrs(markup, id string, attrs map[string]string) (string, error) {
+	start, tag, elAttrs, innerStart, innerEnd, closeEnd, ok := findElement(markup, id)
+	if !ok {
+		return "", fmt.Errorf("element %q not found", id)
+	}
+	// Validate all keys against the component schema
+	schema, schemaOK := components.SchemaV1(tag)
+	if !schemaOK {
+		return "", fmt.Errorf("unknown element type %q", tag)
+	}
+	allowed := make(map[string]bool)
+	for _, k := range schema.Required {
+		allowed[k] = true
+	}
+	for _, k := range schema.Optional {
+		allowed[k] = true
+	}
+	for k := range attrs {
+		if !allowed[k] {
+			return "", fmt.Errorf("attribute %q is not allowed on <%s>", k, tag)
+		}
+	}
+	// Apply changes
+	elAttrs = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(elAttrs), "/"))
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		elAttrs = setStringAttr(elAttrs, k, attrs[k])
+	}
+	selfClose := closeEnd == innerStart
+	open := "<" + tag
+	if strings.TrimSpace(elAttrs) != "" {
+		open += " " + strings.TrimSpace(elAttrs)
+	}
+	if selfClose {
+		open += "/>"
+		return markup[:start] + open + markup[closeEnd:], nil
+	}
+	open += ">"
+	return markup[:start] + open + markup[innerStart:innerEnd] + "</" + tag + ">" + markup[closeEnd:], nil
+}
+
+// insertElement appends a new element before the closing </ast-slide>.
+func insertElement(markup, tag string, attrs map[string]string, text string) (string, error) {
+	switch tag {
+	case "ast-shape", "ast-text", "ast-image":
+		// allowed
+	default:
+		return "", fmt.Errorf("cannot insert element of type %q", tag)
+	}
+	if attrs["id"] == "" {
+		return "", fmt.Errorf("inserted element must have an id")
+	}
+	// Build attribute string in sorted order for deterministic output
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, html.EscapeString(attrs[k])))
+	}
+	attrStr := strings.Join(parts, " ")
+
+	var element string
+	if tag == "ast-text" {
+		escapedText := html.EscapeString(text)
+		element = fmt.Sprintf("<%s %s>%s</%s>", tag, attrStr, escapedText, tag)
+	} else {
+		element = fmt.Sprintf("<%s %s></%s>", tag, attrStr, tag)
+	}
+
+	// Insert before closing </ast-slide>
+	closing := "</ast-slide>"
+	idx := strings.LastIndex(markup, closing)
+	if idx < 0 {
+		return "", fmt.Errorf("no closing </ast-slide> found")
+	}
+	return markup[:idx] + element + markup[idx:], nil
 }

--- a/pkg/docs/slides/fill_test.go
+++ b/pkg/docs/slides/fill_test.go
@@ -444,3 +444,100 @@ func TestRemoveElementDropsMarkup(t *testing.T) {
 		t.Fatalf("headline removed: %s", got)
 	}
 }
+
+func TestSetStringAttr(t *testing.T) {
+	// Replace existing
+	got := setStringAttr(`id="foo" fill="blue"`, "fill", "red")
+	if !strings.Contains(got, `fill="red"`) {
+		t.Fatalf("expected fill=red, got %s", got)
+	}
+	// Add new attr
+	got = setStringAttr(`id="foo"`, "fill", "green")
+	if !strings.Contains(got, `fill="green"`) {
+		t.Fatalf("expected fill=green, got %s", got)
+	}
+	// Empty attrs
+	got = setStringAttr("", "fill", "#ff0000")
+	if got != `fill="#ff0000"` {
+		t.Fatalf("expected fill=#ff0000, got %s", got)
+	}
+	// HTML escaping
+	got = setStringAttr("", "fill", `a"b<c`)
+	if !strings.Contains(got, "a&#34;b&lt;c") {
+		t.Fatalf("expected escaped value, got %s", got)
+	}
+}
+
+func TestRewriteElementAttrs(t *testing.T) {
+	markup := `<ast-slide><ast-shape id="s1" kind="rect" x="10" y="20" w="100" h="50" fill="blue"></ast-shape></ast-slide>`
+	got, err := rewriteElementAttrs(markup, "s1", map[string]string{"fill": "red", "opacity": "0.5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `fill="red"`) {
+		t.Fatalf("expected fill=red in %s", got)
+	}
+	if !strings.Contains(got, `opacity="0.5"`) {
+		t.Fatalf("expected opacity=0.5 in %s", got)
+	}
+}
+
+func TestRewriteElementAttrsRejectsDisallowed(t *testing.T) {
+	markup := `<ast-slide><ast-shape id="s1" kind="rect" x="10" y="20" w="100" h="50"></ast-shape></ast-slide>`
+	_, err := rewriteElementAttrs(markup, "s1", map[string]string{"onclick": "alert(1)"})
+	if err == nil {
+		t.Fatal("expected error for disallowed attribute")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected 'not allowed' in error, got: %s", err)
+	}
+	_, err = rewriteElementAttrs(markup, "s1", map[string]string{"style": "color:red"})
+	if err == nil {
+		t.Fatal("expected error for style attribute")
+	}
+}
+
+func TestInsertElement(t *testing.T) {
+	markup := `<ast-slide id="s"><ast-text id="t1" x="0" y="0" w="100" h="50">Hello</ast-text></ast-slide>`
+	got, err := insertElement(markup, "ast-shape", map[string]string{
+		"id": "user-rect-1", "kind": "rect", "x": "100", "y": "100", "w": "200", "h": "150", "fill": "#4F46E5", "geom": "rect",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `id="user-rect-1"`) {
+		t.Fatalf("expected user-rect-1 in %s", got)
+	}
+	if !strings.Contains(got, "</ast-slide>") {
+		t.Fatalf("expected closing tag preserved in %s", got)
+	}
+	// Verify element is before </ast-slide>
+	shapeIdx := strings.Index(got, `id="user-rect-1"`)
+	closeIdx := strings.Index(got, "</ast-slide>")
+	if shapeIdx > closeIdx {
+		t.Fatal("inserted element should be before </ast-slide>")
+	}
+
+	// ast-text with content
+	got, err = insertElement(markup, "ast-text", map[string]string{
+		"id": "user-text-1", "x": "50", "y": "50", "w": "400", "h": "60", "size": "32",
+	}, "Text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, ">Text</ast-text>") {
+		t.Fatalf("expected text content in %s", got)
+	}
+}
+
+func TestInsertElementValidatesTag(t *testing.T) {
+	markup := `<ast-slide id="s"></ast-slide>`
+	_, err := insertElement(markup, "div", map[string]string{"id": "x"}, "")
+	if err == nil {
+		t.Fatal("expected error for div tag")
+	}
+	_, err = insertElement(markup, "script", map[string]string{"id": "x"}, "")
+	if err == nil {
+		t.Fatal("expected error for script tag")
+	}
+}

--- a/pkg/docs/slides/fill_test.go
+++ b/pkg/docs/slides/fill_test.go
@@ -541,3 +541,42 @@ func TestInsertElementValidatesTag(t *testing.T) {
 		t.Fatal("expected error for script tag")
 	}
 }
+
+func TestReorderElements(t *testing.T) {
+	markup := `<ast-slide id="s"><ast-shape id="a" x="0" y="0" w="10" h="10"></ast-shape><ast-shape id="b" x="1" y="1" w="10" h="10"></ast-shape><ast-shape id="c" x="2" y="2" w="10" h="10"></ast-shape></ast-slide>`
+
+	// Reverse the order: c, b, a
+	got, err := reorderElements(markup, []string{"c", "b", "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify the new order: c before b before a
+	idxC := strings.Index(got, `id="c"`)
+	idxB := strings.Index(got, `id="b"`)
+	idxA := strings.Index(got, `id="a"`)
+	if idxC >= idxB || idxB >= idxA {
+		t.Fatalf("expected c < b < a positions, got c=%d b=%d a=%d in:\n%s", idxC, idxB, idxA, got)
+	}
+	// Verify the slide wrapper is intact
+	if !strings.HasPrefix(got, "<ast-slide") || !strings.HasSuffix(got, "</ast-slide>") {
+		t.Fatalf("slide wrapper broken: %s", got)
+	}
+}
+
+func TestReorderElementsPreservesNonEditable(t *testing.T) {
+	// Decorative element (no matching ID in reorder list) should stay in place
+	markup := `<ast-slide id="s"><ast-shape id="bg" decorative x="0" y="0" w="1920" h="1080"></ast-shape><ast-shape id="a" x="10" y="10" w="50" h="50"></ast-shape><ast-shape id="b" x="20" y="20" w="50" h="50"></ast-shape></ast-slide>`
+
+	// Reorder only a and b (swap them), bg not mentioned
+	got, err := reorderElements(markup, []string{"b", "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// bg should remain first
+	idxBg := strings.Index(got, `id="bg"`)
+	idxB := strings.Index(got, `id="b"`)
+	idxA := strings.Index(got, `id="a"`)
+	if idxBg >= idxB || idxB >= idxA {
+		t.Fatalf("expected bg < b < a positions, got bg=%d b=%d a=%d in:\n%s", idxBg, idxB, idxA, got)
+	}
+}

--- a/pkg/docs/slides/service.go
+++ b/pkg/docs/slides/service.go
@@ -249,6 +249,22 @@ type SlideEdits struct {
 	Resizes []ElementResize
 	Texts   []ElementText
 	Deletes []string
+	Attrs   []ElementAttrChange
+	Creates []ElementCreate
+}
+
+// ElementAttrChange represents attribute changes on an existing element.
+type ElementAttrChange struct {
+	ID    string
+	Attrs map[string]string
+}
+
+// ElementCreate represents a new element to insert into a slide.
+type ElementCreate struct {
+	ID    string
+	Tag   string
+	Attrs map[string]string
+	Text  string // only for ast-text
 }
 
 // MoveSlideElements patches x/y on named elements in a stored slide.
@@ -319,6 +335,38 @@ func (s Service) ApplySlideEdits(ctx context.Context, deckSlug string, position 
 			continue
 		}
 		next, err := setElementGeometry(markup, id, resize.X, resize.Y, resize.W, resize.H)
+		if err != nil {
+			return nil, nil, err
+		}
+		markup = next
+	}
+	// Apply attribute changes
+	for _, ac := range edits.Attrs {
+		id := strings.TrimSpace(ac.ID)
+		if id == "" {
+			return nil, nil, fmt.Errorf("attr change missing element id")
+		}
+		if deleted[id] {
+			continue
+		}
+		next, err := rewriteElementAttrs(markup, id, ac.Attrs)
+		if err != nil {
+			return nil, nil, err
+		}
+		markup = next
+	}
+	// Apply element creations
+	for _, c := range edits.Creates {
+		id := strings.TrimSpace(c.ID)
+		if id == "" {
+			return nil, nil, fmt.Errorf("create missing element id")
+		}
+		attrs := c.Attrs
+		if attrs == nil {
+			attrs = map[string]string{}
+		}
+		attrs["id"] = id
+		next, err := insertElement(markup, c.Tag, attrs, c.Text)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/docs/slides/service.go
+++ b/pkg/docs/slides/service.go
@@ -245,12 +245,13 @@ type ElementResize struct {
 
 // SlideEdits is a canvas edit batch: moves, resizes, text rewrites, and deletes.
 type SlideEdits struct {
-	Moves   []ElementMove
-	Resizes []ElementResize
-	Texts   []ElementText
-	Deletes []string
-	Attrs   []ElementAttrChange
-	Creates []ElementCreate
+	Moves    []ElementMove
+	Resizes  []ElementResize
+	Texts    []ElementText
+	Deletes  []string
+	Attrs    []ElementAttrChange
+	Creates  []ElementCreate
+	Reorders []string // ordered element IDs for z-order persistence
 }
 
 // ElementAttrChange represents attribute changes on an existing element.
@@ -367,6 +368,14 @@ func (s Service) ApplySlideEdits(ctx context.Context, deckSlug string, position 
 		}
 		attrs["id"] = id
 		next, err := insertElement(markup, c.Tag, attrs, c.Text)
+		if err != nil {
+			return nil, nil, err
+		}
+		markup = next
+	}
+	// Apply z-order reordering (must be last — runs on the final markup).
+	if len(edits.Reorders) > 0 {
+		next, err := reorderElements(markup, edits.Reorders)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/web/src/api/__tests__/slides.test.ts
+++ b/web/src/api/__tests__/slides.test.ts
@@ -18,6 +18,7 @@ import {
   publishDeckToTeam,
   forkDeckToPersonal,
   deleteSlidesDeck,
+  slideEditIsDirty,
 } from '../slides'
 import { teamFetch } from '../teamContext'
 
@@ -259,5 +260,21 @@ describe('slides API (templates)', () => {
   it('recolorSlidesTemplate throws on non-ok response', async () => {
     mockedTeamFetch.mockResolvedValue(new Response('bad hex', { status: 400 }))
     await expect(recolorSlidesTemplate('corp', { accent: 'red' })).rejects.toThrow()
+  })
+})
+
+describe('slideEditIsDirty', () => {
+  it('returns false for empty draft', () => {
+    expect(slideEditIsDirty(null)).toBe(false)
+    expect(slideEditIsDirty(undefined)).toBe(false)
+    expect(slideEditIsDirty({})).toBe(false)
+  })
+
+  it('returns true when attrs are present', () => {
+    expect(slideEditIsDirty({ attrs: [{ id: 's1', attrs: { fill: '#ff0000' } }] })).toBe(true)
+  })
+
+  it('returns true when creates are present', () => {
+    expect(slideEditIsDirty({ creates: [{ id: 'new-1', tag: 'ast-shape', attrs: { kind: 'rect' } }] })).toBe(true)
   })
 })

--- a/web/src/api/slides.ts
+++ b/web/src/api/slides.ts
@@ -149,11 +149,13 @@ export interface SlideEditDraft {
   resizes?: SlideElementResize[]
   texts?: SlideElementText[]
   deletes?: string[]
+  attrs?: { id: string; attrs: Record<string, string> }[]
+  creates?: { id: string; tag: string; attrs: Record<string, string>; text?: string }[]
 }
 
 export function slideEditIsDirty(draft?: SlideEditDraft | null): boolean {
   if (!draft) return false
-  return (draft.moves?.length ?? 0) > 0 || (draft.resizes?.length ?? 0) > 0 || (draft.texts?.length ?? 0) > 0 || (draft.deletes?.length ?? 0) > 0
+  return (draft.moves?.length ?? 0) > 0 || (draft.resizes?.length ?? 0) > 0 || (draft.texts?.length ?? 0) > 0 || (draft.deletes?.length ?? 0) > 0 || (draft.attrs?.length ?? 0) > 0 || (draft.creates?.length ?? 0) > 0
 }
 
 /** Apply canvas object moves, text edits, and deletes to a stored slide. */
@@ -168,6 +170,8 @@ export async function patchSlideMoves(
     resizes: draft.resizes?.length ? draft.resizes : undefined,
     texts: draft.texts?.length ? draft.texts : undefined,
     deletes: draft.deletes?.length ? draft.deletes : undefined,
+    attrs: draft.attrs?.length ? draft.attrs : undefined,
+    creates: draft.creates?.length ? draft.creates : undefined,
   }
   const response = await teamFetch(withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/slides/${index}`, scope), {
     method: 'PATCH',

--- a/web/src/api/slides.ts
+++ b/web/src/api/slides.ts
@@ -182,6 +182,27 @@ export async function patchSlideMoves(
   return response.json() as Promise<SlidesSlide>
 }
 
+export interface UploadSlideAssetResult {
+  assetRef: string
+  mime: string
+}
+
+/** Upload a local image file to the deck's asset library. Returns the content-addressed asset-ref for ast-image elements. */
+export async function uploadSlideAsset(
+  deckSlug: string,
+  file: File,
+  scope: DocsScope = 'personal',
+): Promise<UploadSlideAssetResult> {
+  const form = new FormData()
+  form.append('file', file)
+  const response = await teamFetch(withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/assets`, scope), {
+    method: 'POST',
+    body: form,
+  })
+  if (!response.ok) throw await responseError(response, 'Failed to upload image')
+  return response.json() as Promise<UploadSlideAssetResult>
+}
+
 export async function fetchSlidesDeck(deckSlug: string, scope: DocsScope = 'personal'): Promise<SlidesDeckResponse> {
   const response = await teamFetch(withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}`, scope))
   if (!response.ok) throw await responseError(response, 'Failed to load slide deck')

--- a/web/src/api/slides.ts
+++ b/web/src/api/slides.ts
@@ -151,11 +151,12 @@ export interface SlideEditDraft {
   deletes?: string[]
   attrs?: { id: string; attrs: Record<string, string> }[]
   creates?: { id: string; tag: string; attrs: Record<string, string>; text?: string }[]
+  reorders?: string[]
 }
 
 export function slideEditIsDirty(draft?: SlideEditDraft | null): boolean {
   if (!draft) return false
-  return (draft.moves?.length ?? 0) > 0 || (draft.resizes?.length ?? 0) > 0 || (draft.texts?.length ?? 0) > 0 || (draft.deletes?.length ?? 0) > 0 || (draft.attrs?.length ?? 0) > 0 || (draft.creates?.length ?? 0) > 0
+  return (draft.moves?.length ?? 0) > 0 || (draft.resizes?.length ?? 0) > 0 || (draft.texts?.length ?? 0) > 0 || (draft.deletes?.length ?? 0) > 0 || (draft.attrs?.length ?? 0) > 0 || (draft.creates?.length ?? 0) > 0 || (draft.reorders?.length ?? 0) > 0
 }
 
 /** Apply canvas object moves, text edits, and deletes to a stored slide. */
@@ -172,6 +173,7 @@ export async function patchSlideMoves(
     deletes: draft.deletes?.length ? draft.deletes : undefined,
     attrs: draft.attrs?.length ? draft.attrs : undefined,
     creates: draft.creates?.length ? draft.creates : undefined,
+    reorders: draft.reorders?.length ? draft.reorders : undefined,
   }
   const response = await teamFetch(withScope(`${DOCS_BASE}/slides/${encodeURIComponent(deckSlug)}/slides/${index}`, scope), {
     method: 'PATCH',

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -114,6 +114,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
       setCanvasInset(prev => (prev.left === inset && prev.right === inset ? prev : { left: inset, right: inset }))
     }
     update()
+    if (typeof ResizeObserver === 'undefined') return
     const ro = new ResizeObserver(update)
     ro.observe(el)
     return () => ro.disconnect()

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -62,6 +62,8 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   const fsIframeRef = useRef<HTMLIFrameElement | null>(null)
   const stripRef = useRef<HTMLDivElement | null>(null)
   const activeToolRef = useRef(activeTool)
+  const canvasRef = useRef<HTMLDivElement | null>(null)
+  const [canvasInset, setCanvasInset] = useState({ left: 0, right: 0 })
   // Tracks the deck/scope this component last loaded, so a pure refreshSignal
   // bump (same deck gaining slides) re-fetches WITHOUT yanking the user off
   // whatever slide they're viewing — we only reset slideIndex when the deck or
@@ -95,6 +97,26 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   }, [deckSlug, scope, refreshSignal])
 
   useEffect(() => { activeToolRef.current = activeTool }, [activeTool])
+
+  // Compute horizontal inset so the nav overlay buttons align with the 16:9
+  // slide content inside the iframe (which letterboxes when the container is
+  // wider than 16:9). The iframe's AstDeck.scaleToParent uses the same math.
+  useEffect(() => {
+    const el = canvasRef.current
+    if (!el) return
+    const update = () => {
+      const w = el.clientWidth
+      const h = el.clientHeight
+      if (!w || !h) return
+      const scale = Math.min(w / 1920, h / 1080)
+      const inset = Math.max(0, Math.round((w - 1920 * scale) / 2))
+      setCanvasInset(prev => (prev.left === inset && prev.right === inset ? prev : { left: inset, right: inset }))
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
 
   const slides = deck?.slides ?? []
   const total = slides.length
@@ -613,14 +635,14 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
               />
             </div>
           )}
-          <div className="relative h-full w-full overflow-hidden rounded-lg">
+          <div ref={canvasRef} className="relative h-full w-full overflow-hidden rounded-lg">
             {deckFrame}
             {total === 0 && (
               <div className="absolute inset-0">
                 {generatingPlaceholder}
               </div>
             )}
-            {/* Edge navigation buttons — inside the canvas frame, visible on hover */}
+            {/* Edge navigation buttons — aligned with the scaled slide content */}
             {!fullscreen && total > 1 && (
               <>
                 <button
@@ -629,10 +651,10 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
                   data-testid="slides-nav-prev"
                   onClick={() => setSlideIndex(prev => Math.max(0, prev - 1))}
                   disabled={boundedIndex === 0}
-                  className="absolute left-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-l-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
-                  style={{ background: 'linear-gradient(to right, rgba(0,0,0,0.25), transparent)' }}
+                  className="absolute top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                  style={{ left: canvasInset.left, background: 'linear-gradient(to right, rgba(0,0,0,0.3), transparent)' }}
                 >
-                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.5)' }}>
                     <ChevronLeft size={18} className="text-white" />
                   </span>
                 </button>
@@ -642,10 +664,10 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
                   data-testid="slides-nav-next"
                   onClick={() => setSlideIndex(prev => Math.min(total - 1, prev + 1))}
                   disabled={boundedIndex >= total - 1}
-                  className="absolute right-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
-                  style={{ background: 'linear-gradient(to left, rgba(0,0,0,0.25), transparent)' }}
+                  className="absolute top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                  style={{ right: canvasInset.right, background: 'linear-gradient(to left, rgba(0,0,0,0.3), transparent)' }}
                 >
-                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.5)' }}>
                     <ChevronRight size={18} className="text-white" />
                   </span>
                 </button>

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { Download, ExternalLink, Loader2, Maximize2, Save, Trash2, TriangleAlert, X } from 'lucide-react'
+import { Download, ExternalLink, Loader2, Maximize2, Save, Trash2, TriangleAlert, X, ChevronLeft, ChevronRight } from 'lucide-react'
 
 import {
   exportSlidesDeck,
@@ -621,6 +621,37 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
               </div>
             )}
           </div>
+          {/* Edge navigation buttons — visible on hover, occupy full height */}
+          {!fullscreen && total > 1 && (
+            <>
+              <button
+                type="button"
+                aria-label="Previous slide"
+                data-testid="slides-nav-prev"
+                onClick={() => setSlideIndex(prev => Math.max(0, prev - 1))}
+                disabled={boundedIndex === 0}
+                className="group absolute left-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-l-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                style={{ background: 'linear-gradient(to right, rgba(0,0,0,0.25), transparent)' }}
+              >
+                <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                  <ChevronLeft size={18} className="text-white" />
+                </span>
+              </button>
+              <button
+                type="button"
+                aria-label="Next slide"
+                data-testid="slides-nav-next"
+                onClick={() => setSlideIndex(prev => Math.min(total - 1, prev + 1))}
+                disabled={boundedIndex >= total - 1}
+                className="group absolute right-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                style={{ background: 'linear-gradient(to left, rgba(0,0,0,0.25), transparent)' }}
+              >
+                <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                  <ChevronRight size={18} className="text-white" />
+                </span>
+              </button>
+            </>
+          )}
         </div>
 
         {/* Right properties panel — shown when element is selected, hidden in fullscreen */}

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -171,6 +171,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
         index?: number
         id?: string | null
         tag?: string | null
+        clickX?: number; clickY?: number
         x?: number; y?: number; w?: number; h?: number
         rotation?: number
         fill?: string; stroke?: string; strokeWidth?: number; opacity?: number
@@ -199,11 +200,13 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
           if (tool !== 'select' && tool !== 'image') {
             const spec = SHAPE_DEFAULTS[tool]
             if (spec) {
+              const cx = typeof data.clickX === 'number' ? data.clickX : 400
+              const cy = typeof data.clickY === 'number' ? data.clickY : 300
               iframeRef.current?.contentWindow?.postMessage({
                 type: 'ast-edit-create',
                 tag: spec.tag,
-                x: 400,
-                y: 300,
+                x: cx - spec.w / 2,
+                y: cy - spec.h / 2,
                 w: spec.w,
                 h: spec.h,
                 defaults: spec.defaults,

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { Download, ExternalLink, Loader2, Maximize2, Save, Trash2, TriangleAlert, X } from 'lucide-react'
 
 import {
@@ -13,6 +13,10 @@ import {
   type SlidesDeckResponse,
   type SlidesExportFormat,
 } from '@/api/slides'
+import type { SelectionMetadata } from '@/components/docs/slides/runtime/EditController'
+import ShapeToolbar, { SHAPE_DEFAULTS } from '@/components/slides/ShapeToolbar'
+import ElementPropertiesPanel from '@/components/slides/ElementPropertiesPanel'
+import TextFormatBar from '@/components/slides/TextFormatBar'
 import { cn } from '@/lib/utils'
 import SlidesArchetypeThumb from './questions/SlidesArchetypeThumb'
 
@@ -50,12 +54,14 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   const [saveName, setSaveName] = useState('')
   const [fullscreen, setFullscreen] = useState(false)
   const [pendingBySlide, setPendingBySlide] = useState<Record<number, SlideEditDraft>>({})
-  const [selectedObject, setSelectedObject] = useState<{ id: string; tag: string } | null>(null)
+  const [selectedObject, setSelectedObject] = useState<SelectionMetadata | null>(null)
   const [applying, setApplying] = useState(false)
+  const [activeTool, setActiveTool] = useState('select')
   const mountedRef = useRef(true)
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const fsIframeRef = useRef<HTMLIFrameElement | null>(null)
   const stripRef = useRef<HTMLDivElement | null>(null)
+  const activeToolRef = useRef(activeTool)
   // Tracks the deck/scope this component last loaded, so a pure refreshSignal
   // bump (same deck gaining slides) re-fetches WITHOUT yanking the user off
   // whatever slide they're viewing — we only reset slideIndex when the deck or
@@ -85,7 +91,10 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   useEffect(() => {
     setPendingBySlide({})
     setSelectedObject(null)
+    setActiveTool('select')
   }, [deckSlug, scope, refreshSignal])
+
+  useEffect(() => { activeToolRef.current = activeTool }, [activeTool])
 
   const slides = deck?.slides ?? []
   const total = slides.length
@@ -98,6 +107,20 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   const iframeSrc = presentUrl.includes('?')
     ? `${presentUrl}&t=${refreshSignal}`
     : `${presentUrl}?t=${refreshSignal}`
+
+  // Extract custom font families from the deck theme's embedded-fonts declaration
+  // so the TextFormatBar dropdown shows them alongside system fonts.
+  const customFonts = useMemo(() => {
+    const raw = deck?.deck.theme?.['embedded-fonts']
+    if (!raw) return []
+    try {
+      const refs: { family?: string }[] = JSON.parse(raw)
+      const seen = new Set<string>()
+      return refs
+        .map(r => r.family?.trim() ?? '')
+        .filter(f => { if (!f || seen.has(f)) return false; seen.add(f); return true })
+    } catch { return [] }
+  }, [deck?.deck.theme])
 
   // Navigate the embedded deck to boundedIndex WITHOUT reloading it. The runtime
   // (AstDeck) listens for { type: 'ast-nav', index } on the opaque-origin iframe
@@ -125,11 +148,17 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
         index?: number
         id?: string | null
         tag?: string | null
+        x?: number; y?: number; w?: number; h?: number
+        rotation?: number
+        fill?: string; stroke?: string; strokeWidth?: number; opacity?: number
+        font?: string; fontSize?: number; fontWeight?: string; align?: string; color?: string
         changes?: SlideEditDraft['moves']
         moves?: SlideEditDraft['moves']
         resizes?: SlideEditDraft['resizes']
         texts?: SlideEditDraft['texts']
         deletes?: string[]
+        attrs?: { id: string; attrs: Record<string, string> }[]
+        creates?: { id: string; tag: string; attrs: Record<string, string>; text?: string }[]
       } | null
       if (!data?.type) return
       if (data.type === 'ast-deck-change') {
@@ -141,7 +170,46 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
       if (data.type === 'ast-edit-selected') {
         const id = typeof data.id === 'string' && data.id ? data.id : null
         const tag = typeof data.tag === 'string' && data.tag ? data.tag : ''
-        setSelectedObject(id ? { id, tag } : null)
+        if (!id) {
+          // Canvas click with a shape tool active → create element
+          const tool = activeToolRef.current
+          if (tool !== 'select' && tool !== 'image') {
+            const spec = SHAPE_DEFAULTS[tool]
+            if (spec) {
+              iframeRef.current?.contentWindow?.postMessage({
+                type: 'ast-edit-create',
+                tag: spec.tag,
+                x: 400,
+                y: 300,
+                w: spec.w,
+                h: spec.h,
+                defaults: spec.defaults,
+              }, '*')
+              setActiveTool('select')
+              return
+            }
+          }
+          setSelectedObject(null)
+        } else {
+          setSelectedObject({
+            id,
+            tag,
+            x: Number(data.x) || 0,
+            y: Number(data.y) || 0,
+            w: Number(data.w) || 0,
+            h: Number(data.h) || 0,
+            rotation: Number(data.rotation) || 0,
+            fill: String(data.fill ?? ''),
+            stroke: String(data.stroke ?? ''),
+            strokeWidth: Number(data.strokeWidth) || 0,
+            opacity: Number(data.opacity ?? 1),
+            font: String(data.font ?? ''),
+            fontSize: Number(data.fontSize) || 0,
+            fontWeight: String(data.fontWeight ?? ''),
+            align: String(data.align ?? ''),
+            color: String(data.color ?? ''),
+          })
+        }
         return
       }
       if (data.type === 'ast-edit-changed' || data.type === 'ast-edit-moved') {
@@ -152,6 +220,8 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
           ...(data.resizes?.length ? { resizes: data.resizes } : {}),
           texts: data.texts ?? [],
           deletes: data.deletes ?? [],
+          ...(data.attrs?.length ? { attrs: data.attrs } : {}),
+          ...(data.creates?.length ? { creates: data.creates } : {}),
         }
         setPendingBySlide(prev => {
           if (!slideEditIsDirty(draft)) {
@@ -171,6 +241,14 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   const postToCanvas = useCallback((payload: Record<string, unknown>) => {
     iframeRef.current?.contentWindow?.postMessage(payload, '*')
   }, [])
+
+  const handlePropertyChange = useCallback((key: string, value: string) => {
+    postToCanvas({ type: 'ast-edit-set-attr', key, value })
+  }, [postToCanvas])
+
+  const handleZOrder = useCallback((direction: string) => {
+    postToCanvas({ type: 'ast-edit-z-order', direction })
+  }, [postToCanvas])
 
   // After the present document reloads (new slides or an in-place rewrite),
   // restore the strip's current index inside the iframe and enable canvas edit.
@@ -513,15 +591,45 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
         </div>
       )}
 
-      {/* Embedded deck — the iframe stays mounted; while the deck has no slides
-          yet the "generating" placeholder covers it so the user never sees an
-          empty document. */}
-      <div className={cn('relative min-h-0 overflow-hidden rounded-lg', fillHeight ? 'flex-1' : 'aspect-video')}>
-        {deckFrame}
-        {total === 0 && (
-          <div className="absolute inset-0">
-            {generatingPlaceholder}
+      {/* Editor layout — left toolbar + canvas + right properties panel */}
+      <div className={cn('flex min-h-0 gap-0', fillHeight ? 'flex-1' : '')}>
+        {/* Left shape toolbar — always visible, hidden in fullscreen */}
+        {!fullscreen && (
+          <ShapeToolbar activeTool={activeTool} onToolChange={setActiveTool} />
+        )}
+
+        {/* Center: canvas + optional floating text bar */}
+        <div className={cn('relative flex-1 min-h-0 min-w-0', !fillHeight && 'aspect-video')}>
+          {/* Floating text format bar — above the canvas when a text element is selected */}
+          {!fullscreen && selectedObject?.tag === 'AST-TEXT' && (
+            <div className="absolute left-1/2 top-2 z-20 -translate-x-1/2">
+              <TextFormatBar
+                font={selectedObject.font}
+                fontSize={selectedObject.fontSize}
+                fontWeight={selectedObject.fontWeight}
+                color={selectedObject.color}
+                customFonts={customFonts}
+                onPropertyChange={handlePropertyChange}
+              />
+            </div>
+          )}
+          <div className="h-full w-full overflow-hidden rounded-lg">
+            {deckFrame}
+            {total === 0 && (
+              <div className="absolute inset-0">
+                {generatingPlaceholder}
+              </div>
+            )}
           </div>
+        </div>
+
+        {/* Right properties panel — shown when element is selected, hidden in fullscreen */}
+        {!fullscreen && selectedObject && (
+          <ElementPropertiesPanel
+            selection={selectedObject}
+            onPropertyChange={handlePropertyChange}
+            onZOrder={handleZOrder}
+          />
         )}
       </div>
 

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -613,45 +613,45 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
               />
             </div>
           )}
-          <div className="h-full w-full overflow-hidden rounded-lg">
+          <div className="relative h-full w-full overflow-hidden rounded-lg">
             {deckFrame}
             {total === 0 && (
               <div className="absolute inset-0">
                 {generatingPlaceholder}
               </div>
             )}
+            {/* Edge navigation buttons — inside the canvas frame, visible on hover */}
+            {!fullscreen && total > 1 && (
+              <>
+                <button
+                  type="button"
+                  aria-label="Previous slide"
+                  data-testid="slides-nav-prev"
+                  onClick={() => setSlideIndex(prev => Math.max(0, prev - 1))}
+                  disabled={boundedIndex === 0}
+                  className="absolute left-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-l-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                  style={{ background: 'linear-gradient(to right, rgba(0,0,0,0.25), transparent)' }}
+                >
+                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                    <ChevronLeft size={18} className="text-white" />
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next slide"
+                  data-testid="slides-nav-next"
+                  onClick={() => setSlideIndex(prev => Math.min(total - 1, prev + 1))}
+                  disabled={boundedIndex >= total - 1}
+                  className="absolute right-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
+                  style={{ background: 'linear-gradient(to left, rgba(0,0,0,0.25), transparent)' }}
+                >
+                  <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
+                    <ChevronRight size={18} className="text-white" />
+                  </span>
+                </button>
+              </>
+            )}
           </div>
-          {/* Edge navigation buttons — visible on hover, occupy full height */}
-          {!fullscreen && total > 1 && (
-            <>
-              <button
-                type="button"
-                aria-label="Previous slide"
-                data-testid="slides-nav-prev"
-                onClick={() => setSlideIndex(prev => Math.max(0, prev - 1))}
-                disabled={boundedIndex === 0}
-                className="group absolute left-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-l-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
-                style={{ background: 'linear-gradient(to right, rgba(0,0,0,0.25), transparent)' }}
-              >
-                <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
-                  <ChevronLeft size={18} className="text-white" />
-                </span>
-              </button>
-              <button
-                type="button"
-                aria-label="Next slide"
-                data-testid="slides-nav-next"
-                onClick={() => setSlideIndex(prev => Math.min(total - 1, prev + 1))}
-                disabled={boundedIndex >= total - 1}
-                className="group absolute right-0 top-0 z-10 flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg opacity-0 transition-opacity hover:opacity-100 disabled:cursor-default disabled:opacity-0"
-                style={{ background: 'linear-gradient(to left, rgba(0,0,0,0.25), transparent)' }}
-              >
-                <span className="flex items-center justify-center rounded-full p-1" style={{ background: 'rgba(0,0,0,0.45)' }}>
-                  <ChevronRight size={18} className="text-white" />
-                </span>
-              </button>
-            </>
-          )}
         </div>
 
         {/* Right properties panel — shown when element is selected, hidden in fullscreen */}

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -8,6 +8,7 @@ import {
   saveDeck,
   slideEditIsDirty,
   slidesPresentationURL,
+  uploadSlideAsset,
   type DocsScope,
   type SlideEditDraft,
   type SlidesDeckResponse,
@@ -271,6 +272,34 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
   const handleZOrder = useCallback((direction: string) => {
     postToCanvas({ type: 'ast-edit-z-order', direction })
   }, [postToCanvas])
+
+  const handleImagePick = useCallback(async (file: File) => {
+    try {
+      const result = await uploadSlideAsset(deckSlug, file, scope)
+      // Convert the file to a data URL so the ast-image web component can
+      // render the image immediately inside the cross-origin iframe. Blob URLs
+      // are origin-scoped and cannot be loaded by the iframe; data URLs work
+      // everywhere. The asset-ref is persisted for the present renderer to
+      // resolve on reload.
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result as string)
+        reader.onerror = () => reject(new Error('Failed to read file'))
+        reader.readAsDataURL(file)
+      })
+      postToCanvas({
+        type: 'ast-edit-create',
+        tag: 'ast-image',
+        x: 400,
+        y: 200,
+        w: 600,
+        h: 400,
+        defaults: { 'asset-ref': result.assetRef, src: dataUrl, fit: 'contain' },
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Image upload failed')
+    }
+  }, [deckSlug, scope, postToCanvas])
 
   // After the present document reloads (new slides or an in-place rewrite),
   // restore the strip's current index inside the iframe and enable canvas edit.
@@ -617,7 +646,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
       <div className={cn('flex min-h-0 gap-0', fillHeight ? 'flex-1' : '')}>
         {/* Left shape toolbar — always visible, hidden in fullscreen */}
         {!fullscreen && (
-          <ShapeToolbar activeTool={activeTool} onToolChange={setActiveTool} />
+          <ShapeToolbar activeTool={activeTool} onToolChange={setActiveTool} onImagePick={handleImagePick} />
         )}
 
         {/* Center: canvas + optional floating text bar */}

--- a/web/src/components/chat/SlidesDeckView.tsx
+++ b/web/src/components/chat/SlidesDeckView.tsx
@@ -183,6 +183,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
         deletes?: string[]
         attrs?: { id: string; attrs: Record<string, string> }[]
         creates?: { id: string; tag: string; attrs: Record<string, string>; text?: string }[]
+        reorders?: string[]
       } | null
       if (!data?.type) return
       if (data.type === 'ast-deck-change') {
@@ -248,6 +249,7 @@ export default function SlidesDeckView({ deckSlug, scope = 'personal', fillHeigh
           deletes: data.deletes ?? [],
           ...(data.attrs?.length ? { attrs: data.attrs } : {}),
           ...(data.creates?.length ? { creates: data.creates } : {}),
+          ...(data.reorders?.length ? { reorders: data.reorders } : {}),
         }
         setPendingBySlide(prev => {
           if (!slideEditIsDirty(draft)) {

--- a/web/src/components/docs/slides/runtime/AstDeck.ts
+++ b/web/src/components/docs/slides/runtime/AstDeck.ts
@@ -54,7 +54,7 @@ export class AstDeck extends LitElement implements AstDeckElement {
 
   private readonly onMessage = (event: MessageEvent): void => {
     if (event.source !== window.parent) return
-    const data = event.data as { type?: string; index?: number; slideId?: string; enabled?: boolean } | null
+    const data = event.data as { type?: string; index?: number; slideId?: string; enabled?: boolean; key?: string; value?: string; tag?: string; x?: number; y?: number; w?: number; h?: number; defaults?: Record<string, string>; direction?: string } | null
     if (!data?.type) return
     switch (data.type) {
       case 'ast-nav':
@@ -78,6 +78,26 @@ export class AstDeck extends LitElement implements AstDeckElement {
         break
       case 'ast-edit-delete':
         this.editor?.deleteSelection()
+        break
+      case 'ast-edit-set-attr':
+        if (typeof data.key === 'string' && typeof data.value === 'string') {
+          this.editor?.setAttr(data.key, data.value)
+        }
+        break
+      case 'ast-edit-create':
+        if (typeof data.tag === 'string') {
+          this.editor?.createElement(
+            data.tag,
+            Number(data.x) || 400, Number(data.y) || 200,
+            Number(data.w) || 300, Number(data.h) || 200,
+            (data.defaults as Record<string, string>) ?? {}
+          )
+        }
+        break
+      case 'ast-edit-z-order':
+        if (typeof data.direction === 'string') {
+          this.editor?.setZOrder(data.direction as 'front' | 'forward' | 'backward' | 'back')
+        }
         break
       default:
         break

--- a/web/src/components/docs/slides/runtime/DeckController.test.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.test.ts
@@ -107,17 +107,21 @@ describe('DeckController', () => {
     expect(deck.currentIndex).toBe(0)
   })
 
-  it('navigates from background clicks while canvas edit mode is on', async () => {
+  it('suppresses click navigation while canvas edit mode is on', async () => {
     const deck = await mountDeck()
     deck.setAttribute('edit', '')
-    deck.next()
-    deck.next()
+    // Navigate to slide 1 (past fragments on slide 0)
+    deck.goTo(1)
+    expect(deck.currentIndex).toBe(1)
 
+    // In edit mode, background clicks should NOT navigate — the React overlay
+    // buttons handle navigation instead. A right-side click must not advance
+    // and a left-side click must not go back.
     deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 800 }))
     expect(deck.currentIndex).toBe(1)
 
     deck.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 100 }))
-    expect(deck.currentIndex).toBe(0)
+    expect(deck.currentIndex).toBe(1)
   })
 
   it('does not navigate when an editable canvas object is clicked', async () => {

--- a/web/src/components/docs/slides/runtime/DeckController.ts
+++ b/web/src/components/docs/slides/runtime/DeckController.ts
@@ -1,6 +1,5 @@
 import type { AstFragment } from './AstFragment'
 import type { AstSlide } from './AstSlide'
-import { hitTest } from './EditController'
 import type { DeckChangeDetail, FragmentPolicy } from './types'
 
 const NAVIGATION_KEYS = new Set(['ArrowRight', 'ArrowDown', 'PageDown', ' ', 'ArrowLeft', 'ArrowUp', 'PageUp', 'Home', 'End'])
@@ -198,7 +197,10 @@ export class DeckController {
 
   private readonly onClick = (event: MouseEvent): void => {
     if (event.defaultPrevented || (event.target as Element).closest('a,button,input,textarea,select')) return
-    if (this.deck.hasAttribute('edit') && hitTest(this.deck, event.clientX, event.clientY)) return
+    // In edit mode, suppress ALL click-to-navigate. Navigation is handled by
+    // the React overlay buttons (SlidesDeckView) so accidental canvas clicks
+    // (or the tail-end of a drag/resize) never jump slides.
+    if (this.deck.hasAttribute('edit')) return
     event.clientX < window.innerWidth / 3 ? this.previous() : this.next()
   }
 

--- a/web/src/components/docs/slides/runtime/EditController.test.ts
+++ b/web/src/components/docs/slides/runtime/EditController.test.ts
@@ -701,4 +701,85 @@ describe('EditController', () => {
     expect(w).toBeGreaterThan(200)
     editor.disconnect()
   })
+
+  it('clicking empty canvas sends ast-edit-selected with clickX/clickY coordinates', async () => {
+    const { deck } = await mount()
+    const parentPost = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage: parentPost }, configurable: true })
+    // stubHit returns null for any click (miss)
+    stubHit([])
+
+    const editor = new EditController(deck)
+    editor.enable()
+
+    // Click empty canvas at (500, 500)
+    deck.dispatchEvent(pointer('pointerdown', 500, 500))
+
+    // Find the ast-edit-selected message
+    const selectedMsg = parentPost.mock.calls.find(
+      (c: unknown[]) => (c[0] as { type?: string }).type === 'ast-edit-selected'
+    )
+    expect(selectedMsg).toBeTruthy()
+    const msg = selectedMsg![0] as { id: unknown; clickX?: number; clickY?: number }
+    expect(msg.id).toBeNull()
+    expect(typeof msg.clickX).toBe('number')
+    expect(typeof msg.clickY).toBe('number')
+    editor.disconnect()
+  })
+
+  it('creating then moving an element produces creates (updated position) and NO moves for that element', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-deck')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const parentPost = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage: parentPost }, configurable: true })
+
+    const editor = new EditController(deck)
+    editor.enable()
+
+    // Create element at position (100, 200)
+    editor.createElement('ast-shape', 100, 200, 300, 150, { fill: 'red', kind: 'rect' })
+    const slide = deck.querySelector('ast-slide') as HTMLElement
+    const created = slide.querySelector('ast-shape') as HTMLElement
+    expect(created).not.toBeNull()
+    expect(created.id).toBe('user-shape-1')
+
+    // Now drag it — simulate selecting and moving
+    stubHit([created, deck])
+    deck.dispatchEvent(pointer('pointerdown', 200, 250))
+    // Move far enough to exceed DRAG_THRESHOLD
+    deck.dispatchEvent(pointer('pointermove', 300, 350))
+    deck.dispatchEvent(pointer('pointerup', 300, 350))
+
+    // Find the last ast-edit-changed message
+    const changedCalls = parentPost.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { type?: string }).type === 'ast-edit-changed'
+    )
+    expect(changedCalls.length).toBeGreaterThan(0)
+    const lastChanged = changedCalls[changedCalls.length - 1][0] as {
+      moves: { id: string }[]
+      creates?: { id: string; attrs: Record<string, string> }[]
+    }
+
+    // Should NOT have the created element in moves
+    const movedIds = lastChanged.moves.map((m: { id: string }) => m.id)
+    expect(movedIds).not.toContain('user-shape-1')
+
+    // Should have the created element in creates with updated position
+    expect(lastChanged.creates).toBeDefined()
+    const createEntry = lastChanged.creates!.find((c: { id: string }) => c.id === 'user-shape-1')
+    expect(createEntry).toBeDefined()
+    // The element was dragged, so position should differ from original (100, 200)
+    const cx = Number(createEntry!.attrs.x)
+    const cy = Number(createEntry!.attrs.y)
+    expect(cx).not.toBe(100)
+    expect(cy).not.toBe(200)
+    editor.disconnect()
+  })
 })

--- a/web/src/components/docs/slides/runtime/EditController.test.ts
+++ b/web/src/components/docs/slides/runtime/EditController.test.ts
@@ -266,4 +266,162 @@ describe('EditController', () => {
     expect(text.getAttribute('contenteditable')).toBe('true')
     editor.disconnect()
   })
+
+  it('setAttr changes fill on selected shape', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="s1" x="10" y="20" w="100" h="50" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-deck')
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#s1') as HTMLElement
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select the shape
+    deck.dispatchEvent(pointer('pointerdown', 50, 40))
+    deck.dispatchEvent(pointer('pointerup', 50, 40))
+    expect(shape.hasAttribute('data-edit-selected')).toBe(true)
+
+    editor.setAttr('fill', '#ff0000')
+    expect(shape.getAttribute('fill')).toBe('#ff0000')
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ast-edit-changed',
+        attrs: [{ id: 's1', attrs: { fill: '#ff0000' } }],
+      }),
+      '*',
+    )
+    editor.disconnect()
+  })
+
+  it('setAttr rejects disallowed attribute', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="s1" x="10" y="20" w="100" h="50" kind="rect"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#s1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    deck.dispatchEvent(pointer('pointerdown', 50, 40))
+    deck.dispatchEvent(pointer('pointerup', 50, 40))
+
+    editor.setAttr('onclick', 'alert(1)')
+    expect(shape.hasAttribute('onclick')).toBe(false)
+    editor.disconnect()
+  })
+
+  it('createElement adds a new ast-shape to the active slide', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-deck')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage }, configurable: true })
+
+    const editor = new EditController(deck)
+    editor.enable()
+    editor.createElement('ast-shape', 100, 200, 300, 150, { fill: 'red', kind: 'rect' })
+
+    const slide = deck.querySelector('ast-slide') as HTMLElement
+    const created = slide.querySelector('ast-shape') as HTMLElement
+    expect(created).not.toBeNull()
+    expect(created.id).toBe('user-shape-1')
+    expect(created.getAttribute('x')).toBe('100')
+    expect(created.getAttribute('y')).toBe('200')
+    expect(created.getAttribute('w')).toBe('300')
+    expect(created.getAttribute('h')).toBe('150')
+    expect(created.getAttribute('fill')).toBe('red')
+    expect(created.getAttribute('kind')).toBe('rect')
+    expect(created.hasAttribute('data-edit-selected')).toBe(true)
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ast-edit-changed',
+        creates: [{ id: 'user-shape-1', tag: 'ast-shape', attrs: { x: '100', y: '200', w: '300', h: '150', fill: 'red', kind: 'rect' } }],
+      }),
+      '*',
+    )
+    editor.disconnect()
+  })
+
+  it('setZOrder brings element to front', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="a" x="10" y="10" w="100" h="100"></ast-shape>
+          <ast-shape id="b" x="50" y="50" w="100" h="100"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const a = deck.querySelector('#a') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([a, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select element 'a' (which is first child)
+    deck.dispatchEvent(pointer('pointerdown', 50, 50))
+    deck.dispatchEvent(pointer('pointerup', 50, 50))
+    expect(a.hasAttribute('data-edit-selected')).toBe(true)
+
+    editor.setZOrder('front')
+    const slide = deck.querySelector('ast-slide') as HTMLElement
+    expect(slide.lastElementChild).toBe(a)
+    editor.disconnect()
+  })
+
+  it('reset clears attribute changes', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="s1" x="10" y="20" w="100" h="50" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#s1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    deck.dispatchEvent(pointer('pointerdown', 50, 40))
+    deck.dispatchEvent(pointer('pointerup', 50, 40))
+
+    editor.setAttr('fill', '#ff0000')
+    expect(shape.getAttribute('fill')).toBe('#ff0000')
+
+    editor.reset()
+    // After reset, the slide innerHTML is restored from snapshot
+    const restored = deck.querySelector('#s1') as HTMLElement
+    expect(restored.getAttribute('fill')).toBe('blue')
+    editor.disconnect()
+  })
 })

--- a/web/src/components/docs/slides/runtime/EditController.test.ts
+++ b/web/src/components/docs/slides/runtime/EditController.test.ts
@@ -821,4 +821,84 @@ describe('EditController', () => {
 
     editor.disconnect()
   })
+
+  test('setZOrder includes reorders in pendingDraft', async () => {
+    // Two shapes — select the first and bring to front, verify reorders in message
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="shape-a" x="10" y="10" w="100" h="100" kind="rect" fill="red"></ast-shape>
+          <ast-shape id="shape-b" x="50" y="50" w="100" h="100" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shapeA = deck.querySelector('#shape-a') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shapeA, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+
+    // Select shape-a
+    deck.dispatchEvent(pointer('pointerdown', 60, 60))
+    deck.dispatchEvent(pointer('pointerup', 60, 60))
+
+    // Bring to front
+    editor.setZOrder('front')
+
+    const spy = vi.spyOn(window.parent, 'postMessage')
+    // Trigger one more notify to capture the current state
+    editor.setZOrder('front')
+
+    const messages = spy.mock.calls
+      .map(c => c[0] as Record<string, unknown>)
+      .filter(m => m.type === 'ast-edit-changed')
+    const last = messages[messages.length - 1]
+
+    // reorders should contain both IDs with shape-a last (front)
+    expect(last.reorders).toBeDefined()
+    const reorders = last.reorders as string[]
+    expect(reorders).toContain('shape-a')
+    expect(reorders).toContain('shape-b')
+    expect(reorders.indexOf('shape-b')).toBeLessThan(reorders.indexOf('shape-a'))
+
+    editor.disconnect()
+  })
+
+  test('opacity defaults to 1 when attribute is absent', async () => {
+    // Shape without an explicit opacity attribute should report 1 (100%) not 0
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="shape1" x="10" y="10" w="100" h="100" kind="rect" fill="red"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#shape1') as HTMLElement
+    const spy = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage: spy }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+
+    // Select the shape
+    deck.dispatchEvent(pointer('pointerdown', 60, 60))
+    deck.dispatchEvent(pointer('pointerup', 60, 60))
+
+    // Find the ast-edit-selected message
+    const selMsg = spy.mock.calls
+      .map(c => c[0] as Record<string, unknown>)
+      .find(m => m.type === 'ast-edit-selected' && m.id === 'shape1')
+    expect(selMsg).toBeDefined()
+    expect(selMsg!.opacity).toBe(1)
+
+    editor.disconnect()
+  })
 })

--- a/web/src/components/docs/slides/runtime/EditController.test.ts
+++ b/web/src/components/docs/slides/runtime/EditController.test.ts
@@ -782,4 +782,43 @@ describe('EditController', () => {
     expect(cy).not.toBe(200)
     editor.disconnect()
   })
+
+  test('deleting existing element and creating new one includes both in draft', async () => {
+    const { deck, text } = await mount()
+    const editor = new EditController(deck)
+    editor.enable()
+    const spy = vi.spyOn(window.parent, 'postMessage')
+
+    // Select the existing text element
+    stubHit([text, deck])
+    text.dispatchEvent(pointer('pointerdown', 170, 390))
+    text.dispatchEvent(pointer('pointerup', 170, 390))
+
+    // Delete it
+    editor.deleteSelection()
+
+    // Create a new element
+    editor.createElement('ast-shape', 500, 300, 200, 150, { kind: 'rect', fill: '#ff0000', geom: 'rect' })
+
+    // Get the last ast-edit-changed message
+    const messages = spy.mock.calls
+      .map(c => c[0] as Record<string, unknown>)
+      .filter(m => m.type === 'ast-edit-changed')
+    const last = messages[messages.length - 1]
+
+    // Should have the original element in deletes
+    expect(last.deletes).toContain('headline')
+
+    // Should have the new element in creates
+    expect(last.creates).toBeDefined()
+    const creates = last.creates as { id: string; tag: string; attrs: Record<string, string> }[]
+    expect(creates.length).toBe(1)
+    expect(creates[0].tag).toBe('ast-shape')
+
+    // The deleted element should NOT be in creates (it was never created in this session)
+    const createIds = creates.map(c => c.id)
+    expect(createIds).not.toContain('headline')
+
+    editor.disconnect()
+  })
 })

--- a/web/src/components/docs/slides/runtime/EditController.test.ts
+++ b/web/src/components/docs/slides/runtime/EditController.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, test, vi } from 'vitest'
 
 import './index'
-import { EditController, proportionalResize, snapToAlign } from './EditController'
+import { EditController, freeResize, proportionalResize, snapToAlign } from './EditController'
 
 async function mount(): Promise<{ deck: HTMLElement; text: HTMLElement; bg: HTMLElement }> {
   document.body.innerHTML = `
@@ -29,6 +29,18 @@ function pointer(type: string, x: number, y: number): PointerEvent {
     clientY: y,
     button: 0,
     pointerId: 1,
+  })
+}
+
+function shiftPointer(type: string, x: number, y: number): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+    button: 0,
+    pointerId: 1,
+    shiftKey: true,
   })
 }
 
@@ -422,6 +434,271 @@ describe('EditController', () => {
     // After reset, the slide innerHTML is restored from snapshot
     const restored = deck.querySelector('#s1') as HTMLElement
     expect(restored.getAttribute('fill')).toBe('blue')
+    editor.disconnect()
+  })
+
+  test('clicking empty canvas with nothing selected still sends ast-edit-selected id:null', async () => {
+    const { deck } = await mount()
+    const parentPost = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage: parentPost }, configurable: true })
+    // stubHit returns null for any click (miss)
+    stubHit([])
+
+    const editor = new EditController(deck)
+    editor.enable()
+
+    // Click empty canvas — nothing is selected beforehand
+    deck.dispatchEvent(pointer('pointerdown', 500, 500))
+    deck.dispatchEvent(pointer('pointerup', 500, 500))
+
+    // Should have sent ast-edit-selected with id: null
+    const selectedMsg = parentPost.mock.calls.find(
+      (c: unknown[]) => (c[0] as { type?: string }).type === 'ast-edit-selected'
+    )
+    expect(selectedMsg).toBeTruthy()
+    expect((selectedMsg![0] as { id: unknown }).id).toBeNull()
+    editor.disconnect()
+  })
+
+  it('freeResize resizes independently in each direction', () => {
+    const start = { x: 100, y: 100, w: 200, h: 100 }
+    // Drag SE handle right and down
+    const se = freeResize(start, 'se', 50, 30)
+    expect(se).toEqual({ x: 100, y: 100, w: 250, h: 130 })
+
+    // Drag NW handle left and up (negative dx, negative dy)
+    const nw = freeResize(start, 'nw', -50, -30)
+    expect(nw).toEqual({ x: 50, y: 70, w: 250, h: 130 })
+
+    // Drag NE handle right and up
+    const ne = freeResize(start, 'ne', 50, -30)
+    expect(ne).toEqual({ x: 100, y: 70, w: 250, h: 130 })
+
+    // Drag SW handle left and down
+    const sw = freeResize(start, 'sw', -50, 30)
+    expect(sw).toEqual({ x: 50, y: 100, w: 250, h: 130 })
+  })
+
+  it('freeResize enforces minimum size', () => {
+    const start = { x: 100, y: 100, w: 200, h: 100 }
+    // Drag SE handle far inward — should not go below min size (16)
+    const shrunk = freeResize(start, 'se', -300, -300)
+    expect(shrunk.w).toBe(16)
+    expect(shrunk.h).toBe(16)
+  })
+
+  it('shows resize handles on all element types (not just images)', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="150" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select the shape
+    deck.dispatchEvent(pointer('pointerdown', 200, 175))
+    deck.dispatchEvent(pointer('pointerup', 200, 175))
+    expect(shape.hasAttribute('data-edit-selected')).toBe(true)
+
+    // All four corner handles should be present
+    for (const corner of ['nw', 'ne', 'se', 'sw']) {
+      expect(deck.querySelector(`[data-resize-corner="${corner}"]`)).not.toBeNull()
+    }
+    editor.disconnect()
+  })
+
+  it('renders rotation handle on selected element', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="150" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    deck.dispatchEvent(pointer('pointerdown', 200, 175))
+    deck.dispatchEvent(pointer('pointerup', 200, 175))
+
+    // Rotation handle and connecting line should be present
+    expect(deck.querySelector('[data-rotation-handle]')).not.toBeNull()
+    expect(deck.querySelector('.ast-edit-rotation-line')).not.toBeNull()
+    expect(deck.querySelector('.ast-edit-rotation-handle')).not.toBeNull()
+    editor.disconnect()
+  })
+
+  it('free-resizes non-image elements (ast-shape) without keeping aspect ratio', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="200" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select
+    deck.dispatchEvent(pointer('pointerdown', 200, 200))
+    deck.dispatchEvent(pointer('pointerup', 200, 200))
+
+    const handle = deck.querySelector<HTMLElement>('[data-resize-corner="se"]')!
+    expect(handle).not.toBeNull()
+
+    // Resize: drag SE handle right only (dx=100, dy=0) — should NOT enforce aspect ratio
+    handle.dispatchEvent(pointer('pointerdown', 300, 300))
+    deck.dispatchEvent(pointer('pointermove', 400, 300))
+    deck.dispatchEvent(pointer('pointerup', 400, 300))
+
+    // Width changed but height should stay the same (free resize, not proportional)
+    expect(Number(shape.getAttribute('w'))).toBe(300)
+    expect(Number(shape.getAttribute('h'))).toBe(200)
+    editor.disconnect()
+  })
+
+  it('rotation drag updates rot attribute and records attr change', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="200" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'parent', { value: { postMessage }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select
+    deck.dispatchEvent(pointer('pointerdown', 200, 200))
+    deck.dispatchEvent(pointer('pointerup', 200, 200))
+
+    const rotHandle = deck.querySelector<HTMLElement>('[data-rotation-handle]')!
+    expect(rotHandle).not.toBeNull()
+
+    // Start rotation drag from the handle
+    rotHandle.dispatchEvent(pointer('pointerdown', 200, 60))
+    // Move to a different angle — enough to pass the threshold
+    deck.dispatchEvent(pointer('pointermove', 350, 200))
+    // Verify data-edit-rotating attribute is set during drag
+    expect(deck.hasAttribute('data-edit-rotating')).toBe(true)
+
+    deck.dispatchEvent(pointer('pointerup', 350, 200))
+    // After release, data-edit-rotating should be cleared
+    expect(deck.hasAttribute('data-edit-rotating')).toBe(false)
+
+    // The rot attribute should have been set to a non-zero value
+    const rot = Number(shape.getAttribute('rot'))
+    expect(rot).not.toBe(0)
+
+    // Should have notified parent with attr changes including rot
+    const changedMsg = postMessage.mock.calls.find(
+      (c: unknown[]) => {
+        const msg = c[0] as { type?: string; attrs?: { id: string; attrs: Record<string, string> }[] }
+        return msg.type === 'ast-edit-changed' && msg.attrs?.some(a => a.id === 'rect1' && 'rot' in a.attrs)
+      }
+    )
+    expect(changedMsg).toBeTruthy()
+    editor.disconnect()
+  })
+
+  it('clears rotation state on slide change', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="200" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+        <ast-slide id="s1">
+          <ast-text id="t1" x="50" y="50" w="300" h="80">Slide 2</ast-text>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select
+    deck.dispatchEvent(pointer('pointerdown', 200, 200))
+    deck.dispatchEvent(pointer('pointerup', 200, 200))
+    expect(shape.hasAttribute('data-edit-selected')).toBe(true)
+
+    // Simulate slide change
+    deck.dispatchEvent(new Event('ast-deck-change', { bubbles: true }))
+    // Selection and handles should be cleared
+    expect(shape.hasAttribute('data-edit-selected')).toBe(false)
+    expect(deck.querySelector('[data-resize-corner]')).toBeNull()
+    expect(deck.querySelector('[data-rotation-handle]')).toBeNull()
+    editor.disconnect()
+  })
+
+  it('Shift+resize forces proportional resize on non-image elements', async () => {
+    document.body.innerHTML = `
+      <ast-deck>
+        <ast-slide id="s0" active>
+          <ast-shape id="rect1" x="100" y="100" w="200" h="200" kind="rect" fill="blue"></ast-shape>
+        </ast-slide>
+      </ast-deck>`
+    const deck = document.querySelector('ast-deck') as HTMLElement
+    await customElements.whenDefined('ast-shape')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    deck.querySelector('ast-slide')?.setAttribute('active', '')
+    const shape = deck.querySelector('#rect1') as HTMLElement
+    Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, configurable: true })
+    stubHit([shape, deck])
+
+    const editor = new EditController(deck)
+    editor.enable()
+    // Select
+    deck.dispatchEvent(pointer('pointerdown', 200, 200))
+    deck.dispatchEvent(pointer('pointerup', 200, 200))
+
+    const handle = deck.querySelector<HTMLElement>('[data-resize-corner="se"]')!
+    expect(handle).not.toBeNull()
+
+    // Shift+resize: drag SE handle right only (dx=100, dy=0) — should enforce proportional
+    handle.dispatchEvent(pointer('pointerdown', 300, 300))
+    deck.dispatchEvent(shiftPointer('pointermove', 400, 300))
+    deck.dispatchEvent(pointer('pointerup', 400, 300))
+
+    // With proportional resize on a 1:1 element, both w and h should change equally
+    const w = Number(shape.getAttribute('w'))
+    const h = Number(shape.getAttribute('h'))
+    expect(w).toBe(h)
+    // The element grew (was 200×200, dragged 100px right)
+    expect(w).toBeGreaterThan(200)
     editor.disconnect()
   })
 })

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -315,7 +315,11 @@ export class EditController {
   }
 
   private pendingDraft(slide: HTMLElement | null = this.activeSlide(), index: number = this.slideIndex()): EditDraft {
-    const deletes = [...this.deleted].filter(key => key.startsWith(`${index}:`)).map(key => key.slice(`${index}:`.length))
+    // Only include deletes for elements that existed before this session (not newly created ones)
+    const deletes = [...this.deleted]
+      .filter(key => key.startsWith(`${index}:`))
+      .map(key => key.slice(`${index}:`.length))
+      .filter(id => !this.created.has(id))
     const moves: EditMove[] = []
     const resizes: EditResize[] = []
     const texts: EditText[] = []
@@ -349,6 +353,8 @@ export class EditController {
     // Created elements — use current DOM geometry so drags after creation are captured
     const creates: EditCreate[] = []
     for (const [elId, info] of this.created) {
+      // Skip elements that were created and then deleted in the same session
+      if (this.deleted.has(`${index}:${elId}`)) continue
       const el = slide?.querySelector(`#${CSS.escape(elId)}`) as HTMLElement | null
       const updatedAttrs = { ...info.attrs }
       if (el) {

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -37,6 +37,7 @@ export type EditDraft = {
   deletes: string[]
   attrs?: EditAttr[]
   creates?: EditCreate[]
+  reorders?: string[]
 }
 
 export type SelectionMetadata = {
@@ -97,6 +98,7 @@ export class EditController {
   private slideHTML = new Map<number, string>()
   private attrChanges = new Map<string, Record<string, string>>()
   private created = new Map<string, { tag: string; attrs: Record<string, string>; text?: string }>()
+  private zOrderChanged = false
   private guides: SVGSVGElement | null = null
 
   constructor(private readonly deck: HTMLElement) {}
@@ -146,6 +148,7 @@ export class EditController {
     this.slideHTML.clear()
     this.attrChanges.clear()
     this.created.clear()
+    this.zOrderChanged = false
   }
 
   /** Restore last committed markup on the active slide. */
@@ -158,6 +161,7 @@ export class EditController {
     this.clearDeleted(index)
     this.attrChanges.clear()
     this.created.clear()
+    this.zOrderChanged = false
     this.clearHover()
     this.clearSelected()
     this.clearGuides()
@@ -175,6 +179,7 @@ export class EditController {
     this.snapshotSlide(this.slideIndex())
     this.attrChanges.clear()
     this.created.clear()
+    this.zOrderChanged = false
     this.drag = null
     this.resize = null
     this.clearGuides()
@@ -243,26 +248,43 @@ export class EditController {
     if (!el) return
     const parent = el.parentElement
     if (!parent) return
+    // Helper: find the next/previous editable sibling (skip non-editable elements
+    // like decorative backgrounds so forward/backward move through visible layers).
+    const nextEditable = (from: Element): Element | null => {
+      let sib = from.nextElementSibling
+      while (sib && !isEditable(sib)) sib = sib.nextElementSibling
+      return sib
+    }
+    const prevEditable = (from: Element): Element | null => {
+      let sib = from.previousElementSibling
+      while (sib && !isEditable(sib)) sib = sib.previousElementSibling
+      return sib
+    }
     switch (direction) {
       case 'front':
         parent.appendChild(el)
         break
       case 'back': {
-        const first = parent.firstElementChild
-        if (first && first !== el) parent.insertBefore(el, first)
+        // Insert after the last non-editable leading child (decorative bg).
+        let target: Element | null = parent.firstElementChild
+        while (target && target !== el && !isEditable(target)) {
+          target = target.nextElementSibling
+        }
+        if (target && target !== el) parent.insertBefore(el, target)
         break
       }
       case 'forward': {
-        const next = el.nextElementSibling
+        const next = nextEditable(el)
         if (next) next.after(el)
         break
       }
       case 'backward': {
-        const prev = el.previousElementSibling
+        const prev = prevEditable(el)
         if (prev) parent.insertBefore(el, prev)
         break
       }
     }
+    this.zOrderChanged = true
     this.positionResizeHandles()
     this.notifyParent()
   }
@@ -287,6 +309,7 @@ export class EditController {
     this.slideHTML.clear()
     this.attrChanges.clear()
     this.created.clear()
+    this.zOrderChanged = false
     this.slides().forEach((_, index) => this.snapshotSlide(index))
   }
 
@@ -379,7 +402,13 @@ export class EditController {
       creates.push({ id: elId, tag: info.tag, attrs: updatedAttrs, text })
     }
 
-    return { moves, resizes, texts, deletes, ...(attrs.length ? { attrs } : {}), ...(creates.length ? { creates } : {}) }
+    // Z-order: when any reorder happened, send the full ordered list of element IDs
+    // so the backend can persist the new stacking order.
+    const reorders = this.zOrderChanged && slide
+      ? editableChildren(slide).map(el => el.id).filter(Boolean)
+      : undefined
+
+    return { moves, resizes, texts, deletes, ...(attrs.length ? { attrs } : {}), ...(creates.length ? { creates } : {}), ...(reorders?.length ? { reorders } : {}) }
   }
 
   private notifyParent(slide?: HTMLElement | null, index?: number): void {
@@ -409,7 +438,8 @@ export class EditController {
     const fill = el.getAttribute('fill') || el.getAttribute('fill-token') || ''
     const stroke = el.getAttribute('line') || el.getAttribute('line-token') || ''
     const strokeWidth = Number(el.getAttribute('line-width')) || 0
-    const opacity = Number(el.getAttribute('opacity'))
+    const opacityRaw = el.getAttribute('opacity')
+    const opacity = opacityRaw != null && opacityRaw !== '' ? Number(opacityRaw) : 1
     // Text properties (AstText)
     const font = el.getAttribute('font') || el.getAttribute('font-token') || ''
     const fontSize = Number(el.getAttribute('size')) || 0

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -320,8 +320,10 @@ export class EditController {
     const resizes: EditResize[] = []
     const texts: EditText[] = []
     if (!slide) return { moves, resizes, texts, deletes }
+    const createdIds = new Set(this.created.keys())
     for (const el of editableChildren(slide)) {
       if (!el.id) continue
+      if (createdIds.has(el.id)) continue  // skip — position captured in creates
       const orig = this.baseline.get(baselineKey(index, el.id))
       const g = geom(el)
       const resized = Boolean(orig && (orig.w !== g.w || orig.h !== g.h))
@@ -344,10 +346,22 @@ export class EditController {
       }
     }
 
-    // Created elements
+    // Created elements — use current DOM geometry so drags after creation are captured
     const creates: EditCreate[] = []
     for (const [elId, info] of this.created) {
-      creates.push({ id: elId, tag: info.tag, attrs: info.attrs, text: info.text })
+      const el = slide?.querySelector(`#${CSS.escape(elId)}`) as HTMLElement | null
+      const updatedAttrs = { ...info.attrs }
+      if (el) {
+        const g = geom(el)
+        updatedAttrs.x = String(g.x)
+        updatedAttrs.y = String(g.y)
+        updatedAttrs.w = String(g.w)
+        updatedAttrs.h = String(g.h)
+        const rot = el.getAttribute('rot')
+        if (rot && rot !== '0') updatedAttrs.rot = rot
+      }
+      const text = info.tag === 'ast-text' && el ? (el.textContent ?? '') : info.text
+      creates.push({ id: elId, tag: info.tag, attrs: updatedAttrs, text })
     }
 
     return { moves, resizes, texts, deletes, ...(attrs.length ? { attrs } : {}), ...(creates.length ? { creates } : {}) }
@@ -360,7 +374,7 @@ export class EditController {
     window.parent.postMessage({ type: 'ast-edit-changed', index: i, ...this.pendingDraft(target, i) }, '*')
   }
 
-  private notifySelection(): void {
+  private notifySelection(clickX?: number, clickY?: number): void {
     if (window.parent === window) return
     const el = this.selected
     if (!el) {
@@ -369,6 +383,8 @@ export class EditController {
         index: this.slideIndex(),
         id: null,
         tag: null,
+        clickX,
+        clickY,
       }, '*')
       return
     }
@@ -425,12 +441,12 @@ export class EditController {
     this.notifySelection()
   }
 
-  private clearSelected(): void {
+  private clearSelected(notify = true): void {
     if (!this.selected) return
     this.selected.removeAttribute('data-edit-selected')
     this.selected = null
     this.clearResizeHandles()
-    this.notifySelection()
+    if (notify) this.notifySelection()
   }
 
   private startTextEdit(el: HTMLElement): void {
@@ -553,10 +569,14 @@ export class EditController {
     if (!hit) {
       // Always notify parent of the deselect — even when nothing was selected.
       // The parent uses this "id: null" message to trigger shape creation when a
-      // drawing tool is active.
-      const wasSelected = !!this.selected
-      this.clearSelected()
-      if (!wasSelected) this.notifySelection()
+      // drawing tool is active. Include canvas-space click coordinates so the
+      // parent can place a newly created element at the pointer position.
+      const scale = canvasScale(this.deck)
+      const rect = this.deck.getBoundingClientRect()
+      const canvasX = (event.clientX - rect.left) / scale
+      const canvasY = (event.clientY - rect.top) / scale
+      this.clearSelected(false)
+      this.notifySelection(canvasX, canvasY)
       return
     }
     event.preventDefault()

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -11,6 +11,12 @@ const EDITABLE_TAGS = new Set([
   'AST-ICON',
 ])
 
+const EDITABLE_ATTRS = new Set([
+  'fill', 'fill-token', 'line', 'line-token', 'line-width', 'opacity',
+  'rot', 'font', 'font-token', 'size', 'weight', 'align', 'color',
+  'color-token', 'geom', 'kind', 'anchor', 'x', 'y', 'w', 'h',
+])
+
 const DRAG_THRESHOLD = 4
 const MIN_VISIBLE = 8
 export const ALIGN_SNAP = 6
@@ -22,11 +28,24 @@ export type AlignGuide = { axis: 'x' | 'y'; pos: number }
 export type EditMove = { id: string; x: number; y: number }
 export type EditResize = { id: string; x: number; y: number; w: number; h: number }
 export type EditText = { id: string; text: string }
+export type EditAttr = { id: string; attrs: Record<string, string> }
+export type EditCreate = { id: string; tag: string; attrs: Record<string, string>; text?: string }
 export type EditDraft = {
   moves: EditMove[]
   resizes: EditResize[]
   texts: EditText[]
   deletes: string[]
+  attrs?: EditAttr[]
+  creates?: EditCreate[]
+}
+
+export type SelectionMetadata = {
+  id: string
+  tag: string
+  x: number; y: number; w: number; h: number
+  rotation: number
+  fill: string; stroke: string; strokeWidth: number; opacity: number
+  font: string; fontSize: number; fontWeight: string; align: string; color: string
 }
 
 type DragState = {
@@ -68,6 +87,8 @@ export class EditController {
   private baseline = new Map<string, Baseline>()
   private deleted = new Set<string>()
   private slideHTML = new Map<number, string>()
+  private attrChanges = new Map<string, Record<string, string>>()
+  private created = new Map<string, { tag: string; attrs: Record<string, string>; text?: string }>()
   private guides: SVGSVGElement | null = null
 
   constructor(private readonly deck: HTMLElement) {}
@@ -114,6 +135,8 @@ export class EditController {
     this.baseline.clear()
     this.deleted.clear()
     this.slideHTML.clear()
+    this.attrChanges.clear()
+    this.created.clear()
   }
 
   /** Restore last committed markup on the active slide. */
@@ -124,6 +147,8 @@ export class EditController {
     const html = this.slideHTML.get(index)
     if (slide && html != null) slide.innerHTML = html
     this.clearDeleted(index)
+    this.attrChanges.clear()
+    this.created.clear()
     this.clearHover()
     this.clearSelected()
     this.clearGuides()
@@ -137,6 +162,8 @@ export class EditController {
   commit(): void {
     this.endTextEdit(true, false)
     this.snapshotSlide(this.slideIndex())
+    this.attrChanges.clear()
+    this.created.clear()
     this.drag = null
     this.resize = null
     this.clearGuides()
@@ -150,10 +177,98 @@ export class EditController {
     this.deleteSelected()
   }
 
+  /** Set an allowed attribute on the selected element. */
+  setAttr(key: string, value: string): void {
+    if (!this.selected || !EDITABLE_ATTRS.has(key)) return
+    this.selected.setAttribute(key, value)
+    const id = this.selected.id
+    if (id) {
+      const existing = this.attrChanges.get(id) ?? {}
+      existing[key] = value
+      this.attrChanges.set(id, existing)
+    }
+    this.notifyParent()
+    this.notifySelection()
+  }
+
+  /** Create a new element on the active slide. */
+  createElement(tag: string, x: number, y: number, w: number, h: number, defaults: Record<string, string>): void {
+    const slide = this.activeSlide()
+    if (!slide) return
+    const allowed = new Set(['ast-shape', 'ast-text', 'ast-image'])
+    if (!allowed.has(tag)) return
+    const prefix = tag.replace('ast-', '')
+    const id = this.generateId(prefix)
+    const el = document.createElement(tag)
+    el.id = id
+    el.setAttribute('x', String(Math.round(x)))
+    el.setAttribute('y', String(Math.round(y)))
+    el.setAttribute('w', String(Math.round(w)))
+    el.setAttribute('h', String(Math.round(h)))
+    for (const [k, v] of Object.entries(defaults)) {
+      el.setAttribute(k, v)
+    }
+    if (tag === 'ast-text' && !el.textContent) {
+      el.textContent = 'Text'
+    }
+    slide.appendChild(el)
+    const attrs: Record<string, string> = { x: String(Math.round(x)), y: String(Math.round(y)), w: String(Math.round(w)), h: String(Math.round(h)), ...defaults }
+    this.created.set(id, { tag, attrs, text: tag === 'ast-text' ? (el.textContent ?? '') : undefined })
+    this.snapshotSlide(this.slideIndex())
+    this.setSelected(el)
+    this.notifyParent()
+  }
+
+  /** Reorder the selected element within its parent. */
+  setZOrder(direction: 'front' | 'forward' | 'backward' | 'back'): void {
+    const el = this.selected
+    if (!el) return
+    const parent = el.parentElement
+    if (!parent) return
+    switch (direction) {
+      case 'front':
+        parent.appendChild(el)
+        break
+      case 'back': {
+        const first = parent.firstElementChild
+        if (first && first !== el) parent.insertBefore(el, first)
+        break
+      }
+      case 'forward': {
+        const next = el.nextElementSibling
+        if (next) next.after(el)
+        break
+      }
+      case 'backward': {
+        const prev = el.previousElementSibling
+        if (prev) parent.insertBefore(el, prev)
+        break
+      }
+    }
+    this.positionResizeHandles()
+    this.notifyParent()
+  }
+
+  private generateId(prefix: string): string {
+    const slide = this.activeSlide()
+    const existing = new Set<string>()
+    if (slide) {
+      for (const el of editableChildren(slide)) {
+        if (el.id) existing.add(el.id)
+      }
+    }
+    for (const id of this.created.keys()) existing.add(id)
+    let n = 1
+    while (existing.has(`user-${prefix}-${n}`)) n++
+    return `user-${prefix}-${n}`
+  }
+
   private snapshotAll(): void {
     this.baseline.clear()
     this.deleted.clear()
     this.slideHTML.clear()
+    this.attrChanges.clear()
+    this.created.clear()
     this.slides().forEach((_, index) => this.snapshotSlide(index))
   }
 
@@ -206,7 +321,22 @@ export class EditController {
         texts.push({ id: el.id, text })
       }
     }
-    return { moves, resizes, texts, deletes }
+
+    // Attribute changes
+    const attrs: EditAttr[] = []
+    for (const [elId, changes] of this.attrChanges) {
+      if (!this.deleted.has(`${index}:${elId}`)) {
+        attrs.push({ id: elId, attrs: changes })
+      }
+    }
+
+    // Created elements
+    const creates: EditCreate[] = []
+    for (const [elId, info] of this.created) {
+      creates.push({ id: elId, tag: info.tag, attrs: info.attrs, text: info.text })
+    }
+
+    return { moves, resizes, texts, deletes, ...(attrs.length ? { attrs } : {}), ...(creates.length ? { creates } : {}) }
   }
 
   private notifyParent(slide?: HTMLElement | null, index?: number): void {
@@ -218,11 +348,39 @@ export class EditController {
 
   private notifySelection(): void {
     if (window.parent === window) return
+    const el = this.selected
+    if (!el) {
+      window.parent.postMessage({
+        type: 'ast-edit-selected',
+        index: this.slideIndex(),
+        id: null,
+        tag: null,
+      }, '*')
+      return
+    }
+    const g = geom(el)
+    const rotation = Number(el.getAttribute('rot')) || 0
+    // Shape properties (AstShape)
+    const fill = el.getAttribute('fill') || el.getAttribute('fill-token') || ''
+    const stroke = el.getAttribute('line') || el.getAttribute('line-token') || ''
+    const strokeWidth = Number(el.getAttribute('line-width')) || 0
+    const opacity = Number(el.getAttribute('opacity'))
+    // Text properties (AstText)
+    const font = el.getAttribute('font') || el.getAttribute('font-token') || ''
+    const fontSize = Number(el.getAttribute('size')) || 0
+    const fontWeight = el.getAttribute('weight') || ''
+    const align = el.getAttribute('align') || ''
+    const color = el.getAttribute('color') || el.getAttribute('color-token') || ''
+
     window.parent.postMessage({
       type: 'ast-edit-selected',
       index: this.slideIndex(),
-      id: this.selected?.id ?? null,
-      tag: this.selected?.tagName ?? null,
+      id: el.id ?? null,
+      tag: el.tagName ?? null,
+      x: g.x, y: g.y, w: g.w, h: g.h,
+      rotation,
+      fill, stroke, strokeWidth, opacity: Number.isNaN(opacity) ? 1 : opacity,
+      font, fontSize, fontWeight, align, color,
     }, '*')
   }
 

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -228,7 +228,11 @@ export class EditController {
     const persistAttrs: Record<string, string> = { x: String(Math.round(x)), y: String(Math.round(y)), w: String(Math.round(w)), h: String(Math.round(h)), ...defaults }
     delete persistAttrs.src
     this.created.set(id, { tag, attrs: persistAttrs, text: tag === 'ast-text' ? (el.textContent ?? '') : undefined })
-    this.snapshotSlide(this.slideIndex())
+    // Add baseline entry for the new element so subsequent moves/resizes are
+    // detected correctly.  Do NOT call snapshotSlide() here — that would clear
+    // the deleted set and lose any pending deletes made before this creation.
+    const index = this.slideIndex()
+    this.baseline.set(baselineKey(index, id), { x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h), text: el.textContent ?? '' })
     this.setSelected(el)
     this.notifyParent()
   }

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -69,6 +69,13 @@ type ResizeState = {
   moved: boolean
 }
 
+type RotationState = {
+  el: HTMLElement
+  startAngle: number      // angle (deg) from element center to initial pointer
+  startRot: number        // element's rot attribute at drag start
+  moved: boolean
+}
+
 type Baseline = { x: number; y: number; w: number; h: number; text: string }
 
 const MIN_IMAGE_SIZE = 32
@@ -80,6 +87,7 @@ export class EditController {
   private selected: HTMLElement | null = null
   private drag: DragState | null = null
   private resize: ResizeState | null = null
+  private rotation: RotationState | null = null
   private resizeHandles: HTMLElement | null = null
   private editing: HTMLElement | null = null
   private editingOriginal = ''
@@ -117,6 +125,7 @@ export class EditController {
     this.clearResizeHandles()
     this.drag = null
     this.resize = null
+    this.rotation = null
     this.deck.removeAttribute('edit')
     this.deck.removeAttribute('data-edit-dragging')
     this.deck.removeEventListener('pointerdown', this.onPointerDown)
@@ -154,8 +163,10 @@ export class EditController {
     this.clearGuides()
     this.deck.removeAttribute('data-edit-dragging')
     this.deck.removeAttribute('data-edit-resizing')
+    this.deck.removeAttribute('data-edit-rotating')
     this.drag = null
     this.resize = null
+    this.rotation = null
   }
 
   /** Treat current slide as the saved baseline (after Apply). */
@@ -212,8 +223,11 @@ export class EditController {
       el.textContent = 'Text'
     }
     slide.appendChild(el)
-    const attrs: Record<string, string> = { x: String(Math.round(x)), y: String(Math.round(y)), w: String(Math.round(w)), h: String(Math.round(h)), ...defaults }
-    this.created.set(id, { tag, attrs, text: tag === 'ast-text' ? (el.textContent ?? '') : undefined })
+    // Strip transient attributes (e.g. blob: src URLs for images) from the
+    // persisted create record — the server derives `src` from `asset-ref`.
+    const persistAttrs: Record<string, string> = { x: String(Math.round(x)), y: String(Math.round(y)), w: String(Math.round(w)), h: String(Math.round(h)), ...defaults }
+    delete persistAttrs.src
+    this.created.set(id, { tag, attrs: persistAttrs, text: tag === 'ast-text' ? (el.textContent ?? '') : undefined })
     this.snapshotSlide(this.slideIndex())
     this.setSelected(el)
     this.notifyParent()
@@ -482,16 +496,37 @@ export class EditController {
     if (this.editing) this.endTextEdit(true)
     this.drag = null
     this.resize = null
+    this.rotation = null
     this.clearHover()
     this.clearSelected()
     this.clearGuides()
     this.deck.removeAttribute('data-edit-dragging')
+    this.deck.removeAttribute('data-edit-rotating')
   }
 
   private readonly onPointerDown = (event: PointerEvent): void => {
     if (!this.enabled || event.button !== 0) return
+    // Rotation handle
+    const rotHandle = (event.target as Element | null)?.closest<HTMLElement>('[data-rotation-handle]')
+    if (rotHandle && this.selected) {
+      event.preventDefault()
+      event.stopPropagation()
+      const g = geom(this.selected)
+      const scale = canvasScale(this.deck)
+      const rect = this.deck.getBoundingClientRect()
+      const cx = rect.left + (g.x + g.w / 2) * scale
+      const cy = rect.top + (g.y + g.h / 2) * scale
+      const startAngle = Math.atan2(event.clientY - cy, event.clientX - cx) * 180 / Math.PI
+      const startRot = Number(this.selected.getAttribute('rot')) || 0
+      this.rotation = { el: this.selected, startAngle, startRot, moved: false }
+      try {
+        this.deck.setPointerCapture(event.pointerId)
+      } catch { /* jsdom */ }
+      return
+    }
+    // Resize corner handle — works for ALL element types
     const handle = (event.target as Element | null)?.closest<HTMLElement>('[data-resize-corner]')
-    if (handle && this.selected?.tagName === 'AST-IMAGE') {
+    if (handle && this.selected) {
       event.preventDefault()
       event.stopPropagation()
       this.resize = {
@@ -516,7 +551,12 @@ export class EditController {
     }
     const hit = hitTest(this.deck, event.clientX, event.clientY)
     if (!hit) {
+      // Always notify parent of the deselect — even when nothing was selected.
+      // The parent uses this "id: null" message to trigger shape creation when a
+      // drawing tool is active.
+      const wasSelected = !!this.selected
       this.clearSelected()
+      if (!wasSelected) this.notifySelection()
       return
     }
     event.preventDefault()
@@ -543,6 +583,27 @@ export class EditController {
 
   private readonly onPointerMove = (event: PointerEvent): void => {
     if (!this.enabled || this.editing) return
+    // Rotation drag
+    if (this.rotation) {
+      const g = geom(this.rotation.el)
+      const scale = canvasScale(this.deck)
+      const rect = this.deck.getBoundingClientRect()
+      const cx = rect.left + (g.x + g.w / 2) * scale
+      const cy = rect.top + (g.y + g.h / 2) * scale
+      const currentAngle = Math.atan2(event.clientY - cy, event.clientX - cx) * 180 / Math.PI
+      const delta = currentAngle - this.rotation.startAngle
+      let rot = Math.round(this.rotation.startRot + delta)
+      // Normalize to 0..359
+      rot = ((rot % 360) + 360) % 360
+      // Snap to 15° increments when close
+      const snapped = Math.round(rot / 15) * 15
+      if (Math.abs(rot - snapped) <= 3) rot = snapped % 360
+      if (!this.rotation.moved && Math.abs(delta) < 2) return
+      this.rotation.moved = true
+      this.deck.setAttribute('data-edit-rotating', '')
+      this.rotation.el.setAttribute('rot', String(rot))
+      return
+    }
     if (this.resize) {
       const scale = canvasScale(this.deck)
       const dx = (event.clientX - this.resize.pointerX) / scale
@@ -550,7 +611,12 @@ export class EditController {
       if (!this.resize.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD) return
       this.resize.moved = true
       this.deck.setAttribute('data-edit-resizing', '')
-      const next = proportionalResize(this.resize.start, this.resize.corner, dx, dy)
+      // Images always resize proportionally; other elements use free resize
+      // unless Shift is held, which forces proportional for any element type.
+      const useProportional = this.resize.el.tagName === 'AST-IMAGE' || event.shiftKey
+      const next = useProportional
+        ? proportionalResize(this.resize.start, this.resize.corner, dx, dy)
+        : freeResize(this.resize.start, this.resize.corner, dx, dy)
       setFullGeom(this.resize.el, next)
       this.positionResizeHandles()
       return
@@ -577,6 +643,27 @@ export class EditController {
   }
 
   private readonly onPointerUp = (event: PointerEvent): void => {
+    if (this.rotation) {
+      const moved = this.rotation.moved
+      const el = this.rotation.el
+      this.rotation = null
+      this.deck.removeAttribute('data-edit-rotating')
+      try {
+        this.deck.releasePointerCapture(event.pointerId)
+      } catch { /* already released / jsdom */ }
+      if (moved) {
+        // Record rotation as an attr change
+        const rot = el.getAttribute('rot') || '0'
+        if (el.id) {
+          const existing = this.attrChanges.get(el.id) ?? {}
+          existing['rot'] = rot
+          this.attrChanges.set(el.id, existing)
+        }
+        this.notifyParent()
+        this.notifySelection()
+      }
+      return
+    }
     if (this.resize) {
       const moved = this.resize.moved
       this.resize = null
@@ -653,7 +740,7 @@ export class EditController {
 
   private renderResizeHandles(): void {
     this.clearResizeHandles()
-    if (this.selected?.tagName !== 'AST-IMAGE') return
+    if (!this.selected) return
     const overlay = document.createElement('div')
     overlay.className = 'ast-edit-resize-handles'
     overlay.setAttribute('aria-hidden', 'true')
@@ -663,6 +750,14 @@ export class EditController {
       handle.dataset.resizeCorner = corner
       overlay.append(handle)
     }
+    // Rotation handle: a circle above top-center connected by a thin line
+    const rotLine = document.createElement('span')
+    rotLine.className = 'ast-edit-rotation-line'
+    overlay.append(rotLine)
+    const rotHandle = document.createElement('span')
+    rotHandle.className = 'ast-edit-rotation-handle'
+    rotHandle.dataset.rotationHandle = ''
+    overlay.append(rotHandle)
     this.deck.append(overlay)
     this.resizeHandles = overlay
     this.positionResizeHandles()
@@ -673,10 +768,12 @@ export class EditController {
     const g = geom(this.selected)
     const scale = canvasScale(this.deck)
     const handleSize = Math.round(24 / scale)
+    const rotOffset = Math.round(40 / scale)
     Object.assign(this.resizeHandles.style, {
       left: `${g.x}px`, top: `${g.y}px`, width: `${g.w}px`, height: `${g.h}px`,
       '--ast-edit-handle-size': `${handleSize}px`,
       '--ast-edit-handle-offset': `${Math.round(handleSize / -2)}px`,
+      '--ast-edit-rot-offset': `${rotOffset}px`,
     })
   }
 
@@ -788,6 +885,32 @@ export function proportionalResize(start: Geom, corner: ResizeCorner, dx: number
     w,
     h,
   }
+}
+
+const MIN_ELEMENT_SIZE = 16
+
+/** Free (non-proportional) resize for shapes and text. */
+export function freeResize(start: Geom, corner: ResizeCorner, dx: number, dy: number): Geom {
+  let x = start.x
+  let y = start.y
+  let w = start.w
+  let h = start.h
+
+  if (corner.endsWith('e')) {
+    w = Math.max(MIN_ELEMENT_SIZE, Math.round(start.w + dx))
+  } else {
+    w = Math.max(MIN_ELEMENT_SIZE, Math.round(start.w - dx))
+    x = start.x + start.w - w
+  }
+
+  if (corner.startsWith('s')) {
+    h = Math.max(MIN_ELEMENT_SIZE, Math.round(start.h + dy))
+  } else {
+    h = Math.max(MIN_ELEMENT_SIZE, Math.round(start.h - dy))
+    y = start.y + start.h - h
+  }
+
+  return { x, y, w, h }
 }
 
 function canvasScale(deck: HTMLElement): number {

--- a/web/src/components/docs/slides/runtime/EditController.ts
+++ b/web/src/components/docs/slides/runtime/EditController.ts
@@ -342,12 +342,14 @@ export class EditController {
       }
     }
 
-    // Attribute changes
+    // Attribute changes — skip elements that only exist client-side (in created)
+    // because their attrs are captured in the creates array and the backend
+    // cannot look them up by id yet.
     const attrs: EditAttr[] = []
     for (const [elId, changes] of this.attrChanges) {
-      if (!this.deleted.has(`${index}:${elId}`)) {
-        attrs.push({ id: elId, attrs: changes })
-      }
+      if (this.deleted.has(`${index}:${elId}`)) continue
+      if (this.created.has(elId)) continue  // merged into creates below
+      attrs.push({ id: elId, attrs: changes })
     }
 
     // Created elements — use current DOM geometry so drags after creation are captured
@@ -366,6 +368,9 @@ export class EditController {
         const rot = el.getAttribute('rot')
         if (rot && rot !== '0') updatedAttrs.rot = rot
       }
+      // Merge any attribute changes made after creation (e.g. fill, font, rot)
+      const extraAttrs = this.attrChanges.get(elId)
+      if (extraAttrs) Object.assign(updatedAttrs, extraAttrs)
       const text = info.tag === 'ast-text' && el ? (el.textContent ?? '') : info.text
       creates.push({ id: elId, tag: info.tag, attrs: updatedAttrs, text })
     }

--- a/web/src/components/docs/slides/runtime/styles.ts
+++ b/web/src/components/docs/slides/runtime/styles.ts
@@ -31,6 +31,10 @@ export const runtimeStyles = `
   ast-deck[edit] .ast-edit-resize-handle[data-resize-corner="ne"] { right:var(--ast-edit-handle-offset,-12px); top:var(--ast-edit-handle-offset,-12px); cursor:nesw-resize; }
   ast-deck[edit] .ast-edit-resize-handle[data-resize-corner="se"] { right:var(--ast-edit-handle-offset,-12px); bottom:var(--ast-edit-handle-offset,-12px); cursor:nwse-resize; }
   ast-deck[edit] .ast-edit-resize-handle[data-resize-corner="sw"] { left:var(--ast-edit-handle-offset,-12px); bottom:var(--ast-edit-handle-offset,-12px); cursor:nesw-resize; }
+  ast-deck[edit] .ast-edit-rotation-line { position:absolute; left:50%; top:calc(-1 * var(--ast-edit-rot-offset,40px)); width:2px; height:var(--ast-edit-rot-offset,40px); background:var(--ast-accent,#2563eb); transform:translateX(-50%); pointer-events:none; }
+  ast-deck[edit] .ast-edit-rotation-handle { position:absolute; left:50%; top:calc(-1 * var(--ast-edit-rot-offset,40px) - var(--ast-edit-handle-size,24px) / 2); width:var(--ast-edit-handle-size,24px); height:var(--ast-edit-handle-size,24px); transform:translateX(-50%); border:3px solid var(--ast-surface,#fff); border-radius:50%; background:var(--ast-accent,#2563eb); box-shadow:0 0 0 2px color-mix(in srgb,var(--ast-ink,#172033) 35%,transparent); pointer-events:auto; touch-action:none; cursor:grab; }
+  ast-deck[edit][data-edit-rotating] { user-select:none; }
+  ast-deck[edit][data-edit-rotating] .ast-edit-rotation-handle { cursor:grabbing; }
   ast-deck[edit] .ast-edit-guides { position:absolute; left:0; top:0; width:1920px; height:1080px; pointer-events:none; z-index:20; overflow:visible; }
   ast-deck[edit] .ast-edit-guides line { stroke:#f43f5e; stroke-width:2; stroke-dasharray:8 6; fill:none; vector-effect:non-scaling-stroke; }
   @media print {

--- a/web/src/components/slides/ElementPropertiesPanel.tsx
+++ b/web/src/components/slides/ElementPropertiesPanel.tsx
@@ -1,0 +1,189 @@
+import { useRef } from 'react'
+import { ChevronsUp, ChevronUp, ChevronDown, ChevronsDown } from 'lucide-react'
+import type { SelectionMetadata } from '@/components/docs/slides/runtime/EditController'
+
+interface ElementPropertiesPanelProps {
+  selection: SelectionMetadata
+  onPropertyChange?: (key: string, value: string) => void
+  onZOrder?: (direction: 'front' | 'forward' | 'backward' | 'back') => void
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function PropField({ label, value, unit, attrKey, onChange }: {
+  label: string; value: string | number; unit?: string;
+  attrKey?: string; onChange?: (key: string, value: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <label className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <div className="flex items-center">
+        <input
+          type="text"
+          value={String(value)}
+          onChange={(e) => {
+            if (attrKey && onChange) {
+              const v = e.target.value
+              if (/^-?\d+$/.test(v) || v === '' || v === '-') {
+                onChange(attrKey, v)
+              }
+            }
+          }}
+          className="w-full rounded border px-2 py-1 text-xs"
+          style={{
+            background: 'var(--bg-primary)',
+            borderColor: 'var(--border-color)',
+            color: 'var(--text-primary)',
+          }}
+          data-testid={`prop-${label.toLowerCase()}`}
+        />
+        {unit && (
+          <span className="ml-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+            {unit}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ColorSwatch({ color, label, attrKey, onChange }: {
+  color: string; label: string;
+  attrKey?: string; onChange?: (key: string, value: string) => void
+}) {
+  const colorRef = useRef<HTMLInputElement>(null)
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <div
+        className="rounded border cursor-pointer"
+        style={{
+          width: 24,
+          height: 24,
+          background: color || 'transparent',
+          borderColor: 'var(--border-color)',
+        }}
+        data-testid={`swatch-${label.toLowerCase()}`}
+        onClick={() => colorRef.current?.click()}
+      />
+      <input
+        ref={colorRef}
+        type="color"
+        value={color || '#000000'}
+        onChange={(e) => { if (attrKey && onChange) onChange(attrKey, e.target.value) }}
+        className="sr-only"
+        data-testid={`color-input-${label.toLowerCase()}`}
+        tabIndex={-1}
+      />
+      <span className="text-xs" style={{ color: 'var(--text-primary)' }}>
+        {color || 'none'}
+      </span>
+    </div>
+  )
+}
+
+export default function ElementPropertiesPanel({ selection, onPropertyChange, onZOrder }: ElementPropertiesPanelProps) {
+  return (
+    <div
+      className="flex shrink-0 flex-col gap-4 overflow-y-auto p-3"
+      style={{
+        width: 260,
+        background: 'var(--bg-secondary)',
+        borderLeft: '1px solid var(--border-color)',
+      }}
+      data-testid="element-properties-panel"
+    >
+      {/* POSITION & SIZE */}
+      <section>
+        <SectionHeader>Position &amp; Size</SectionHeader>
+        <div className="grid grid-cols-2 gap-2">
+          <PropField label="X" value={Math.round(selection.x)} attrKey="x" onChange={onPropertyChange} />
+          <PropField label="Y" value={Math.round(selection.y)} attrKey="y" onChange={onPropertyChange} />
+          <PropField label="W" value={Math.round(selection.w)} attrKey="w" onChange={onPropertyChange} />
+          <PropField label="H" value={Math.round(selection.h)} attrKey="h" onChange={onPropertyChange} />
+        </div>
+        <div className="mt-2">
+          <PropField label="Rotation" value={Math.round(selection.rotation)} unit="°" attrKey="rot" onChange={onPropertyChange} />
+        </div>
+      </section>
+
+      {/* FILL */}
+      <section>
+        <SectionHeader>Fill</SectionHeader>
+        <ColorSwatch color={selection.fill} label="Fill" attrKey="fill" onChange={onPropertyChange} />
+        <div className="mt-2 flex items-center gap-2">
+          <label className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+            Opacity
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={Math.round(selection.opacity * 100)}
+            onChange={(e) => { if (onPropertyChange) onPropertyChange('opacity', String(Number(e.target.value) / 100)) }}
+            className="flex-1"
+            data-testid="prop-opacity"
+          />
+          <span className="text-xs" style={{ color: 'var(--text-primary)' }}>
+            {Math.round(selection.opacity * 100)}%
+          </span>
+        </div>
+      </section>
+
+      {/* STROKE */}
+      <section>
+        <SectionHeader>Stroke</SectionHeader>
+        <ColorSwatch color={selection.stroke} label="Stroke" attrKey="line" onChange={onPropertyChange} />
+        <div className="mt-2">
+          <PropField label="Width" value={selection.strokeWidth} attrKey="line-width" onChange={onPropertyChange} />
+        </div>
+      </section>
+
+      {/* Z-ORDER */}
+      <section>
+        <SectionHeader>Z-Order</SectionHeader>
+        <div className="flex items-center gap-1">
+          {[
+            { icon: ChevronsUp, label: 'Bring to front', testId: 'z-front', dir: 'front' as const },
+            { icon: ChevronUp, label: 'Bring forward', testId: 'z-forward', dir: 'forward' as const },
+            { icon: ChevronDown, label: 'Send backward', testId: 'z-backward', dir: 'backward' as const },
+            { icon: ChevronsDown, label: 'Send to back', testId: 'z-back', dir: 'back' as const },
+          ].map(item => {
+            const Icon = item.icon
+            return (
+              <button
+                key={item.testId}
+                type="button"
+                title={item.label}
+                aria-label={item.label}
+                data-testid={item.testId}
+                onClick={() => onZOrder?.(item.dir)}
+                className="flex items-center justify-center rounded-md border p-1.5 transition-colors"
+                style={{
+                  borderColor: 'var(--border-color)',
+                  color: 'var(--text-secondary)',
+                  background: 'var(--bg-primary)',
+                }}
+              >
+                <Icon size={16} />
+              </button>
+            )
+          })}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/web/src/components/slides/ShapeToolbar.tsx
+++ b/web/src/components/slides/ShapeToolbar.tsx
@@ -1,0 +1,95 @@
+import { MousePointer2, Type, Square, Circle, Minus, ImageIcon, Undo2, Redo2 } from 'lucide-react'
+
+export const SHAPE_TOOLS = [
+  { id: 'select', icon: MousePointer2, label: 'Select' },
+  { id: 'text', icon: Type, label: 'Text' },
+  { id: 'rect', icon: Square, label: 'Rectangle' },
+  { id: 'circle', icon: Circle, label: 'Circle' },
+  { id: 'line', icon: Minus, label: 'Line' },
+  { id: 'image', icon: ImageIcon, label: 'Image' },
+] as const
+
+export type ShapeToolId = (typeof SHAPE_TOOLS)[number]['id']
+
+export const SHAPE_DEFAULTS: Record<string, { tag: string; w: number; h: number; defaults: Record<string, string> }> = {
+  rect: { tag: 'ast-shape', w: 300, h: 200, defaults: { kind: 'rect', fill: '#4F46E5', geom: 'rect' } },
+  circle: { tag: 'ast-shape', w: 200, h: 200, defaults: { kind: 'ellipse', fill: '#4F46E5', geom: 'ellipse' } },
+  line: { tag: 'ast-shape', w: 300, h: 2, defaults: { kind: 'line', line: '#000000', 'line-width': '2', geom: 'line' } },
+  text: { tag: 'ast-text', w: 400, h: 60, defaults: { size: '32', weight: '400', align: 'left' } },
+}
+
+interface ShapeToolbarProps {
+  activeTool: string
+  onToolChange: (tool: string) => void
+}
+
+export default function ShapeToolbar({ activeTool, onToolChange }: ShapeToolbarProps) {
+  return (
+    <div
+      className="flex shrink-0 flex-col items-center gap-1 py-2"
+      style={{
+        width: 48,
+        background: 'var(--bg-secondary)',
+        borderRight: '1px solid var(--border-color)',
+      }}
+      role="toolbar"
+      aria-label="Shape tools"
+    >
+      {SHAPE_TOOLS.map(tool => {
+        const Icon = tool.icon
+        const isActive = activeTool === tool.id
+        return (
+          <button
+            key={tool.id}
+            type="button"
+            title={tool.label}
+            aria-label={tool.label}
+            aria-pressed={isActive}
+            data-testid={`tool-${tool.id}`}
+            onClick={() => onToolChange(tool.id)}
+            className="flex items-center justify-center rounded-md transition-colors"
+            style={{
+              width: 36,
+              height: 36,
+              background: isActive ? 'var(--brand)' : 'transparent',
+              color: isActive ? 'var(--brand-foreground, #fff)' : 'var(--text-secondary)',
+            }}
+          >
+            <Icon size={18} />
+          </button>
+        )
+      })}
+
+      {/* Separator */}
+      <div
+        className="my-1"
+        style={{ width: 24, height: 1, background: 'var(--border-color)' }}
+        role="separator"
+      />
+
+      {/* Undo / Redo */}
+      <button
+        type="button"
+        title="Undo"
+        aria-label="Undo"
+        disabled
+        data-testid="tool-undo"
+        className="flex items-center justify-center rounded-md transition-colors disabled:opacity-30"
+        style={{ width: 36, height: 36, color: 'var(--text-secondary)' }}
+      >
+        <Undo2 size={18} />
+      </button>
+      <button
+        type="button"
+        title="Redo"
+        aria-label="Redo"
+        disabled
+        data-testid="tool-redo"
+        className="flex items-center justify-center rounded-md transition-colors disabled:opacity-30"
+        style={{ width: 36, height: 36, color: 'var(--text-secondary)' }}
+      >
+        <Redo2 size={18} />
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/slides/ShapeToolbar.tsx
+++ b/web/src/components/slides/ShapeToolbar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { MousePointer2, Type, Square, Circle, Minus, ImageIcon, Undo2, Redo2 } from 'lucide-react'
 
 export const SHAPE_TOOLS = [
@@ -21,9 +22,12 @@ export const SHAPE_DEFAULTS: Record<string, { tag: string; w: number; h: number;
 interface ShapeToolbarProps {
   activeTool: string
   onToolChange: (tool: string) => void
+  onImagePick?: (file: File) => void
 }
 
-export default function ShapeToolbar({ activeTool, onToolChange }: ShapeToolbarProps) {
+export default function ShapeToolbar({ activeTool, onToolChange, onImagePick }: ShapeToolbarProps) {
+  const fileRef = useRef<HTMLInputElement>(null)
+
   return (
     <div
       className="flex shrink-0 flex-col items-center gap-1 py-2"
@@ -46,7 +50,13 @@ export default function ShapeToolbar({ activeTool, onToolChange }: ShapeToolbarP
             aria-label={tool.label}
             aria-pressed={isActive}
             data-testid={`tool-${tool.id}`}
-            onClick={() => onToolChange(tool.id)}
+            onClick={() => {
+              if (tool.id === 'image') {
+                fileRef.current?.click()
+                return
+              }
+              onToolChange(tool.id)
+            }}
             className="flex items-center justify-center rounded-md transition-colors"
             style={{
               width: 36,
@@ -59,6 +69,21 @@ export default function ShapeToolbar({ activeTool, onToolChange }: ShapeToolbarP
           </button>
         )
       })}
+
+      {/* Hidden file input for image upload */}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        data-testid="image-file-input"
+        onChange={e => {
+          const file = e.target.files?.[0]
+          if (file) onImagePick?.(file)
+          // Reset so the same file can be re-selected
+          e.target.value = ''
+        }}
+      />
 
       {/* Separator */}
       <div

--- a/web/src/components/slides/TextFormatBar.tsx
+++ b/web/src/components/slides/TextFormatBar.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useRef } from 'react'
+
+const SYSTEM_FONTS = [
+  'Arial',
+  'Helvetica',
+  'Times New Roman',
+  'Georgia',
+  'Courier New',
+  'Verdana',
+]
+
+interface TextFormatBarProps {
+  font: string
+  fontSize: number
+  fontWeight: string
+  color?: string
+  /** Custom font families from the deck theme (e.g. Manrope, 72 Brand). */
+  customFonts?: string[]
+  onPropertyChange?: (key: string, value: string) => void
+}
+
+export default function TextFormatBar({
+  font,
+  fontSize,
+  fontWeight,
+  color,
+  customFonts,
+  onPropertyChange,
+}: TextFormatBarProps) {
+  const colorRef = useRef<HTMLInputElement>(null)
+  const isBold = fontWeight === '700' || fontWeight === 'bold'
+
+  // Build font list: custom deck fonts first, then system fonts.
+  // Always include the current font value so the dropdown never silently resets.
+  const fontFamilies = useMemo(() => {
+    const seen = new Set<string>()
+    const result: string[] = []
+    // Custom fonts from deck theme (e.g. Manrope) go first
+    for (const f of customFonts ?? []) {
+      const name = f.trim()
+      if (name && !seen.has(name)) {
+        seen.add(name)
+        result.push(name)
+      }
+    }
+    // System fonts
+    for (const f of SYSTEM_FONTS) {
+      if (!seen.has(f)) {
+        seen.add(f)
+        result.push(f)
+      }
+    }
+    // Ensure the currently-selected font is always present (defensive)
+    if (font && !seen.has(font)) {
+      result.unshift(font)
+    }
+    return result
+  }, [customFonts, font])
+
+  return (
+    <div
+      className="flex items-center gap-1 rounded-lg px-2 py-1 shadow-lg"
+      style={{
+        background: 'var(--bg-secondary)',
+        border: '1px solid var(--border-color)',
+      }}
+      role="toolbar"
+      aria-label="Text formatting"
+      data-testid="text-format-bar"
+    >
+      {/* Bold / Italic / Underline */}
+      <button
+        type="button"
+        title="Bold"
+        aria-label="Bold"
+        aria-pressed={isBold}
+        data-testid="fmt-bold"
+        onClick={() => onPropertyChange?.('weight', isBold ? '400' : '700')}
+        className="flex items-center justify-center rounded px-1.5 py-1 text-sm font-bold transition-colors"
+        style={{
+          color: isBold ? 'var(--brand)' : 'var(--text-primary)',
+          background: isBold ? 'var(--brand-soft, rgba(99,102,241,0.1))' : 'transparent',
+          minWidth: 28,
+        }}
+      >
+        B
+      </button>
+      <button
+        type="button"
+        title="Italic"
+        aria-label="Italic"
+        data-testid="fmt-italic"
+        className="flex items-center justify-center rounded px-1.5 py-1 text-sm italic transition-colors"
+        style={{ color: 'var(--text-primary)', minWidth: 28 }}
+      >
+        I
+      </button>
+      <button
+        type="button"
+        title="Underline"
+        aria-label="Underline"
+        data-testid="fmt-underline"
+        className="flex items-center justify-center rounded px-1.5 py-1 text-sm underline transition-colors"
+        style={{ color: 'var(--text-primary)', minWidth: 28 }}
+      >
+        U
+      </button>
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 20, background: 'var(--border-color)' }} role="separator" />
+
+      {/* Font family */}
+      <select
+        value={font || 'Arial'}
+        className="rounded border px-1.5 py-1 text-xs"
+        style={{
+          background: 'var(--bg-primary)',
+          borderColor: 'var(--border-color)',
+          color: 'var(--text-primary)',
+          maxWidth: 130,
+        }}
+        data-testid="fmt-font"
+        onChange={(e) => onPropertyChange?.('font', e.target.value)}
+      >
+        {fontFamilies.map(f => (
+          <option key={f} value={f}>{f}</option>
+        ))}
+      </select>
+
+      {/* Font size */}
+      <input
+        type="number"
+        value={fontSize || 24}
+        onChange={(e) => {
+          const v = Number(e.target.value)
+          if (v > 0) onPropertyChange?.('size', String(v))
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.currentTarget.blur()
+        }}
+        className="w-12 rounded border px-1.5 py-1 text-center text-xs"
+        style={{
+          background: 'var(--bg-primary)',
+          borderColor: 'var(--border-color)',
+          color: 'var(--text-primary)',
+        }}
+        data-testid="fmt-size"
+      />
+
+      {/* Separator */}
+      <div style={{ width: 1, height: 20, background: 'var(--border-color)' }} role="separator" />
+
+      {/* Color swatch */}
+      <div
+        className="rounded border"
+        style={{
+          width: 24,
+          height: 24,
+          background: color || '#000000',
+          borderColor: 'var(--border-color)',
+          cursor: 'pointer',
+        }}
+        title="Text color"
+        data-testid="fmt-color"
+        onClick={() => colorRef.current?.click()}
+      />
+      <input
+        ref={colorRef}
+        type="color"
+        value={color || '#000000'}
+        onChange={(e) => onPropertyChange?.('color', e.target.value)}
+        className="sr-only"
+        data-testid="fmt-color-input"
+        tabIndex={-1}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Makes the slide editor fully functional: toolbar shape creation, properties panel editing, text formatting, z-order persistence, and fixes several editing bugs discovered during integration testing.

## What Changed

### New Features (initial commit `6e044db`)
- **Shape Toolbar**: Click Rectangle/Circle/Line/Text tool → click canvas → element is created at the click position with sensible defaults
- **Properties Panel**: X, Y, W, H, Rotation, Fill color, Stroke color, Stroke width, and Opacity are all editable with live preview
- **Text Format Bar**: Bold toggle, font family dropdown, font size input, and text color picker — all wired to live-update the selected text element  
- **Z-Order buttons**: Bring to front/forward, Send backward/to back — now fully functional with persistence
- **Element creation**: New `ast-edit-create` postMessage protocol + Go `insertElement()` backend
- **Attribute editing**: New `ast-edit-set-attr` postMessage protocol + Go `rewriteElementAttrs()` backend
- **Image upload**: Toolbar image tool uploads files and creates `ast-image` elements with asset references

### Bug Fixes
- **CSS variable aliases** (`575a31e`): Emit aliases for camelCase font token keys so `var(--font-heading)` works
- **Slide navigation** (`1c70cc5`, `b1dc37e`, `f1cdb66`): Replaced unpredictable click-to-navigate with hover edge buttons, moved inside canvas frame, aligned with scaled 16:9 content
- **Element placement** (`877d98d`): Elements now appear at the actual click position instead of always in the same spot; move-after-create saves correctly; rotation persists after refresh
- **Delete + create in same session** (`9c36502`, `1c95599`): Fixed `createElement()` calling `snapshotSlide()` which cleared the delete tracking, causing deleted elements to reappear after save
- **Rotation on new elements** (`104e40c`): Skip `attrChanges` for elements in `this.created` to prevent backend errors on unsaved elements
- **Opacity display** (`219992a`): Fixed opacity showing 0% instead of 100% when the element has no explicit opacity attribute (`Number(null) === 0`, not NaN)
- **Z-order behavior** (`219992a`): Forward/backward now skip non-editable decorative elements; "Send to back" stays in front of decorative backgrounds; z-order changes persist via new `reorders` field

## Files Changed

### Go Backend
- `pkg/docs/slides/fill.go` — `setStringAttr()`, `rewriteElementAttrs()`, `insertElement()`, `reorderElements()`
- `pkg/docs/slides/service.go` — `SlideEdits` extended with `Attrs`, `Creates`, `Reorders`; `ApplySlideEdits` processes all three
- `pkg/api/slides_handlers.go` — `slideMovesRequest` extended; PATCH handler maps new fields

### Frontend Runtime (iframe)
- `EditController.ts` — `setAttr()`, `createElement()`, `setZOrder()`, `pendingDraft()` with attrs/creates/reorders tracking
- `AstDeck.ts` — Message handlers for `ast-edit-set-attr`, `ast-edit-create`, `ast-edit-z-order`

### React Components
- `SlidesDeckView.tsx` — Wires toolbar, properties panel, text bar; handles element creation on canvas click; passes reorders through
- `ElementPropertiesPanel.tsx` — All inputs editable with `onPropertyChange`/`onZOrder` callbacks
- `TextFormatBar.tsx` — `onPropertyChange` callback replaces individual no-op handlers
- `ShapeToolbar.tsx` — Exports `SHAPE_DEFAULTS` for element creation specs

### API Client
- `web/src/api/slides.ts` — `SlideEditDraft` extended with `attrs`, `creates`, `reorders`; `slideEditIsDirty` and `patchSlideMoves` updated

## Testing
- All existing Go tests pass (`go test ./pkg/docs/slides/... ./pkg/api/...`)
- All existing frontend tests pass (`cd web && npm test` — 145 slide-related tests)
- **New Go tests**: `TestSetStringAttr`, `TestRewriteElementAttrs`, `TestInsertElement`, `TestReorderElements`, `TestReorderElementsPreservesNonEditable`, `TestApplySlideEditsAttrs`, `TestApplySlideEditsCreate`, `TestPatchSlideAttrsAndCreates`
- **New TS tests**: setAttr, createElement, setZOrder, reset, z-order reorders in pendingDraft, opacity default, delete+create preservation, rotation attr changes, and more (30 EditController tests total)
- TypeScript: zero errors (`npx tsc --noEmit`)
