### PR TITLE
fix+test: browser sandbox overlay layer chain not applied to browser-first tool calls

### DIFF
--- a/cmd/astonish/drill.go
+++ b/cmd/astonish/drill.go
@@ -626,7 +626,7 @@ func handleDrillRunCommand(args []string) error {
 		// TouchActivity keeps the idle watchdog from reclaiming the session
 		// during long browser drills (browser tools bypass NDJSON Call()).
 		touch := func(string) { lazyNode.TouchActivity() }
-		if client == nil || !sandbox.WireIncusBrowserManager(browserMgr, client, touch) {
+		if client == nil || !sandbox.WireIncusBrowserManager(browserMgr, client, nil, touch) {
 			lazyNode.Cleanup()
 			return fmt.Errorf("sandbox drill browser: could not wire in-container Chromium (host Chrome is disabled for sandboxed drills)")
 		}

--- a/pkg/api/fleet_sandbox_wiring.go
+++ b/pkg/api/fleet_sandbox_wiring.go
@@ -132,7 +132,7 @@ func wireFleetSandboxIncus(
 	}
 
 	browserMgr := browser.NewManager(browser.DefaultConfig())
-	sandbox.WireIncusBrowserManager(browserMgr, sandboxClient, sessRegistry.TouchActivity)
+	sandbox.WireIncusBrowserManager(browserMgr, sandboxClient, nil, sessRegistry.TouchActivity)
 
 	wrappedTools := wrapFleetTools(subAgentMgr, lazyNode, nil, fleetSession.ID, browserMgr)
 

--- a/pkg/browser/container_launch_test.go
+++ b/pkg/browser/container_launch_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/SAP/astonish/pkg/store"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/cdp"
 )
@@ -479,5 +480,65 @@ func TestResetBrowserLocked_ClearsAllState(t *testing.T) {
 	}
 	if m.config.RemoteCDPURL != "" {
 		t.Errorf("RemoteCDPURL should be empty after reset, got %q", m.config.RemoteCDPURL)
+	}
+}
+
+func TestGetOrLaunch_ContainerPath_RequestContextPassedToEnsureReady(t *testing.T) {
+	var capturedCtx context.Context
+	var ensureReadyCalled bool
+
+	m := NewManager(BrowserConfig{})
+	m.SandboxEnabled = true
+	m.sessionID = "test-session"
+
+	// Set request context carrying sandbox layer chain values.
+	chain := []string{"@base", "overlay-abc123"}
+	reqCtx := store.WithSandboxLayerChain(context.Background(), chain)
+	m.SetRequestContext(reqCtx)
+
+	m.ContainerEnsureReadyFunc = func(ctx context.Context, sessionID string) error {
+		ensureReadyCalled = true
+		capturedCtx = ctx
+		return nil
+	}
+	m.ContainerResolveFunc = func(_ string) (string, string, error) {
+		return "", "", fmt.Errorf("stop after ensure-ready")
+	}
+
+	_, _ = m.GetOrLaunch()
+
+	if !ensureReadyCalled {
+		t.Fatal("ContainerEnsureReadyFunc was not called")
+	}
+	gotChain := store.SandboxLayerChainFromContext(capturedCtx)
+	if len(gotChain) != 2 || gotChain[0] != "@base" || gotChain[1] != "overlay-abc123" {
+		t.Errorf("context chain = %v, want [@base overlay-abc123]", gotChain)
+	}
+}
+
+func TestGetOrLaunch_ContainerPath_NilRequestContextFallsBackToBackground(t *testing.T) {
+	var capturedCtx context.Context
+
+	m := NewManager(BrowserConfig{})
+	m.SandboxEnabled = true
+	m.sessionID = "test-session"
+	// Do NOT call SetRequestContext — requestCtx remains nil
+
+	m.ContainerEnsureReadyFunc = func(ctx context.Context, _ string) error {
+		capturedCtx = ctx
+		return nil
+	}
+	m.ContainerResolveFunc = func(_ string) (string, string, error) {
+		return "", "", fmt.Errorf("stop")
+	}
+
+	_, _ = m.GetOrLaunch()
+
+	if capturedCtx == nil {
+		t.Fatal("ContainerEnsureReadyFunc received nil context")
+	}
+	gotChain := store.SandboxLayerChainFromContext(capturedCtx)
+	if len(gotChain) != 0 {
+		t.Errorf("expected empty chain from background context, got %v", gotChain)
 	}
 }

--- a/pkg/browser/container_launch_test.go
+++ b/pkg/browser/container_launch_test.go
@@ -40,7 +40,7 @@ func TestGetOrLaunch_ContainerPath_WaitsBeforeResolve(t *testing.T) {
 	m := NewManager(BrowserConfig{})
 	m.SandboxEnabled = true
 	m.sessionID = "test-session"
-	m.ContainerEnsureReadyFunc = func(sessionID string) error {
+	m.ContainerEnsureReadyFunc = func(_ context.Context, sessionID string) error {
 		sequence = append(sequence, "ready:"+sessionID)
 		return nil
 	}
@@ -65,7 +65,7 @@ func TestGetOrLaunch_ContainerPath_ReadinessErrorStopsResolve(t *testing.T) {
 	m := NewManager(BrowserConfig{})
 	m.SandboxEnabled = true
 	m.sessionID = "test-session"
-	m.ContainerEnsureReadyFunc = func(string) error {
+	m.ContainerEnsureReadyFunc = func(_ context.Context, _ string) error {
 		return fmt.Errorf("pod readiness failed")
 	}
 	m.ContainerResolveFunc = func(string) (string, string, error) {

--- a/pkg/browser/manager.go
+++ b/pkg/browser/manager.go
@@ -281,6 +281,7 @@ type Manager struct {
 	// demoOverlay tracks tutorial highlight boxes and the visible demo cursor.
 	demoOverlay *demoOverlayState
 }
+
 // NewManager creates a Manager with the given config. The browser is NOT
 // launched until GetOrLaunch is called.
 func NewManager(cfg BrowserConfig) *Manager {

--- a/pkg/browser/manager.go
+++ b/pkg/browser/manager.go
@@ -223,8 +223,11 @@ type Manager struct {
 
 	// ContainerEnsureReadyFunc waits for background sandbox provisioning before
 	// browser launch resolves the session container. It is optional for backends
-	// whose resolver already performs synchronous provisioning.
-	ContainerEnsureReadyFunc func(sessionID string) error
+	// whose resolver already performs synchronous provisioning. The context
+	// carries sandbox template/chain/image values (set by chat_handlers
+	// InjectSandbox* methods) so the implementation can provision the pod with
+	// the correct overlay layer chain.
+	ContainerEnsureReadyFunc func(ctx context.Context, sessionID string) error
 
 	// ContainerResolveFunc resolves the session container for browser execution.
 	// Called lazily by launchInContainer() to get the container name and IP.
@@ -269,10 +272,15 @@ type Manager struct {
 	// actionCapture tracks DOM action recording for tutorial authoring.
 	actionCapture *actionCaptureState
 
+	// requestCtx is the current request context carrying sandbox template/chain/image
+	// values. Set by SetRequestContext before tool execution and used by GetOrLaunch
+	// to pass to ContainerEnsureReadyFunc. This ensures browser tools provision
+	// containers with the correct overlay layer chain.
+	requestCtx context.Context
+
 	// demoOverlay tracks tutorial highlight boxes and the visible demo cursor.
 	demoOverlay *demoOverlayState
 }
-
 // NewManager creates a Manager with the given config. The browser is NOT
 // launched until GetOrLaunch is called.
 func NewManager(cfg BrowserConfig) *Manager {
@@ -541,6 +549,16 @@ func (m *Manager) resetBrowserLocked() {
 	m.pagesMu.Unlock()
 }
 
+// SetRequestContext sets the request context that carries sandbox configuration
+// values (template/chain/image) needed for container provisioning. This should be
+// called before tool execution to ensure browser tools can provision pods with
+// the correct overlay layer chain.
+func (m *Manager) SetRequestContext(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requestCtx = ctx
+}
+
 // GetOrLaunch returns the current browser, launching it if necessary.
 // On first launch, the browser is configured with anti-detection measures:
 //   - Headed mode by default (with Xvfb on Linux) for realistic fingerprint
@@ -551,7 +569,9 @@ func (m *Manager) resetBrowserLocked() {
 // If headed mode fails (no display, no Xvfb), falls back to headless with a warning.
 //
 // When SandboxEnabled is true, the browser is launched inside the session
-// container and connected via a remote CDP URL.
+// container and connected via a remote CDP URL. The request context (set via
+// SetRequestContext) carries sandbox template/chain/image values needed to
+// provision the container with the correct overlay layer chain.
 //
 // Health check: if a browser is already connected, a lightweight Version() call
 // verifies the CDP connection is still alive. If the connection is dead (pipe
@@ -791,6 +811,9 @@ func (m *Manager) resolveCDPURL(containerName, ip string) (string, error) {
 // When ContainerDialFunc is set, the CDP WebSocket connection is tunneled
 // through the Incus exec API (socat), making it work on all platforms.
 //
+// The request context (set via SetRequestContext) carries sandbox template/chain/image
+// values needed to provision the container with the correct overlay layer chain.
+//
 // Must be called with m.mu held.
 func (m *Manager) launchInContainer() (*rod.Browser, error) {
 	b, err := m.launchInContainerInner()
@@ -837,8 +860,15 @@ func (m *Manager) launchInContainerInner() (*rod.Browser, error) {
 
 	// Browser tools bypass NodeTool.Run, so wait on the same lazy sandbox
 	// provisioning barrier before resolving the session record.
+	// The stored request context carries sandbox template/chain/image values,
+	// allowing ContainerEnsureReadyFunc to provision the pod with the correct
+	// overlay layer chain (including Chromium, KasmVNC, etc.).
 	if m.ContainerEnsureReadyFunc != nil {
-		if err := m.ContainerEnsureReadyFunc(m.sessionID); err != nil {
+		ctx := m.requestCtx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if err := m.ContainerEnsureReadyFunc(ctx, m.sessionID); err != nil {
 			return nil, fmt.Errorf(
 				"failed to prepare session container for session %s: %w",
 				shortSessionID(m.sessionID), err,

--- a/pkg/launcher/browser_sandbox.go
+++ b/pkg/launcher/browser_sandbox.go
@@ -9,8 +9,10 @@ import (
 )
 
 // WireIncusBrowserManager configures mgr for in-container Chromium (Incus).
-func WireIncusBrowserManager(mgr *browser.Manager, client *sandbox.IncusClient, touchActivity func(sessionID string)) bool {
-	return sandbox.WireIncusBrowserManager(mgr, client, touchActivity)
+// When pool is non-nil, ContainerEnsureReadyFunc is set so browser tools wait
+// for the pool to provision the container before resolving it.
+func WireIncusBrowserManager(mgr *browser.Manager, client *sandbox.IncusClient, pool sandbox.ToolNodePool, touchActivity func(sessionID string)) bool {
+	return sandbox.WireIncusBrowserManager(mgr, client, pool, touchActivity)
 }
 
 // WireOpenShellBrowserManager configures mgr for in-container CloakBrowser (OpenShell).
@@ -32,7 +34,7 @@ func wireBrowserContainerCallbacks(mgr *browser.Manager) {
 		slog.Debug("browser container callbacks: sandbox runtime unavailable", "error", err)
 		return
 	}
-	if !sandbox.WireIncusBrowserManager(mgr, client, nil) {
+	if !sandbox.WireIncusBrowserManager(mgr, client, nil, nil) {
 		slog.Warn("browser container callbacks: failed to wire in-container Chromium")
 	}
 }

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -943,8 +943,8 @@ func newWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 					gw := osb.Gateway()
 					sessReg := osb.Sessions()
 					if WireOpenShellBrowserManager(browserMgr, gw, sessReg, sessReg.TouchActivity) {
-						browserMgr.ContainerEnsureReadyFunc = func(sessionID string) error {
-							client := pool.GetOrCreate(sessionID)
+						browserMgr.ContainerEnsureReadyFunc = func(ctx context.Context, sessionID string) error {
+							client := sandbox.GetPoolClientFromContext(ctx, pool, sessionID)
 							if client == nil {
 								return fmt.Errorf("no sandbox client for session %q", sessionID)
 							}
@@ -1159,9 +1159,11 @@ func newWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			// Wire browser to run inside the session container when sandbox is
 			// available. The browser resolves the session container (already
 			// managed by NodeClientPool) and starts Chromium + KasmVNC inside it.
+			// Pass nodePool so ContainerEnsureReadyFunc waits for the pool to
+			// provision the container on a browser-first tool call.
 			{
 				pool := nodePool // capture for closure
-				if WireIncusBrowserManager(browserMgr, sandboxClient, pool.TouchActivity) {
+				if WireIncusBrowserManager(browserMgr, sandboxClient, sandbox.AsNodePool(pool), pool.TouchActivity) {
 					// browser-in-sandbox enabled
 				}
 			}

--- a/pkg/sandbox/backend_browser_wire.go
+++ b/pkg/sandbox/backend_browser_wire.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/SAP/astonish/pkg/browser"
+	"github.com/SAP/astonish/pkg/store"
 )
 
 const (
@@ -68,8 +69,8 @@ func WireBackendBrowserManager(mgr *browser.Manager, backend Backend, sessReg *S
 	bcfg := mgr.Config()
 	mgr.SandboxEnabled = true
 	if pool != nil {
-		mgr.ContainerEnsureReadyFunc = func(sessionID string) error {
-			client := pool.GetOrCreate(sessionID)
+		mgr.ContainerEnsureReadyFunc = func(ctx context.Context, sessionID string) error {
+			client := GetPoolClientFromContext(ctx, pool, sessionID)
 			if client == nil {
 				return fmt.Errorf("no sandbox client for session %q", sessionID)
 			}
@@ -98,6 +99,24 @@ func WireBackendBrowserManager(mgr *browser.Manager, backend Backend, sessReg *S
 		mgr.ActivityTouchFunc = touchActivity
 	}
 	return true
+}
+
+// GetPoolClientFromContext resolves the sandbox template, layer chain, and
+// image from the context (set by chat_handlers.InjectSandbox* methods) and
+// calls the appropriate pool method. This mirrors NodeTool.getClientFromContext
+// so browser tools (which bypass NodeTool) provision pods with the same overlay
+// configuration as container-wrapped tools.
+func GetPoolClientFromContext(ctx context.Context, pool ToolNodePool, sessionID string) ToolNodeClient {
+	tpl := store.SandboxTemplateFromContext(ctx)
+	chain := store.SandboxLayerChainFromContext(ctx)
+	image := store.SandboxImageFromContext(ctx)
+	if len(chain) > 0 || image != "" {
+		return pool.GetOrCreateWithImage(sessionID, tpl, chain, image)
+	}
+	if tpl != "" {
+		return pool.GetOrCreateWithTemplate(sessionID, tpl)
+	}
+	return pool.GetOrCreate(sessionID)
 }
 
 func startBackendBrowser(ctx context.Context, backend Backend, sessionID string, cfg browser.BrowserConfig) (io.Closer, error) {

--- a/pkg/sandbox/backend_browser_wire.go
+++ b/pkg/sandbox/backend_browser_wire.go
@@ -106,7 +106,20 @@ func WireBackendBrowserManager(mgr *browser.Manager, backend Backend, sessReg *S
 // calls the appropriate pool method. This mirrors NodeTool.getClientFromContext
 // so browser tools (which bypass NodeTool) provision pods with the same overlay
 // configuration as container-wrapped tools.
+//
+// It also mirrors NodeTool.getClientFromContext's SetSessionScope call: the
+// org/team slugs from context are recorded on the pool so the container record
+// is persisted into the correct tenant schema. This is necessary for
+// browser-first turns where no prior NodeTool call has yet scoped the session.
 func GetPoolClientFromContext(ctx context.Context, pool ToolNodePool, sessionID string) ToolNodeClient {
+	// Record the caller's tenant before the pool creates a client, so the
+	// container record lands in the correct org/team schema (same guard as
+	// NodeTool.getClientFromContext, line 353).
+	orgSlug := store.OrgSlugFromContext(ctx)
+	teamSlug := store.TeamSlugFromContext(ctx)
+	if orgSlug != "" || teamSlug != "" {
+		pool.SetSessionScope(sessionID, orgSlug, teamSlug)
+	}
 	tpl := store.SandboxTemplateFromContext(ctx)
 	chain := store.SandboxLayerChainFromContext(ctx)
 	image := store.SandboxImageFromContext(ctx)

--- a/pkg/sandbox/backend_browser_wire_test.go
+++ b/pkg/sandbox/backend_browser_wire_test.go
@@ -214,3 +214,20 @@ func (*browserReadySpyPool) Cleanup()                               {}
 func (*browserReadySpyPool) Alias(string, string)                   {}
 func (*browserReadySpyPool) Remove(string)                          {}
 func (*browserReadySpyPool) SetSessionScope(string, string, string) {}
+
+func TestGetPoolClientFromContext_TemplateOnlyUsesGetOrCreateWithTemplate(t *testing.T) {
+	client := &browserReadySpyClient{}
+	pool := &browserReadySpyPool{client: client}
+	// Template set but NO chain and NO image — should use GetOrCreateWithTemplate
+	ctx := store.WithSandboxTemplate(context.Background(), "my-template")
+	c := GetPoolClientFromContext(ctx, pool, "sess-tpl")
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if pool.method != "GetOrCreateWithTemplate" {
+		t.Errorf("pool method = %q, want GetOrCreateWithTemplate", pool.method)
+	}
+	if pool.sessionID != "sess-tpl" {
+		t.Errorf("pool sessionID = %q, want sess-tpl", pool.sessionID)
+	}
+}

--- a/pkg/sandbox/backend_browser_wire_test.go
+++ b/pkg/sandbox/backend_browser_wire_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SAP/astonish/pkg/browser"
+	"github.com/SAP/astonish/pkg/store"
 )
 
 func TestBuildBackendBrowserLaunchScript_UsesSandboxBrowser(t *testing.T) {
@@ -89,7 +90,7 @@ func TestWireBackendBrowserManager_EnsureReadyUsesSessionClient(t *testing.T) {
 	if mgr.ContainerEnsureReadyFunc == nil {
 		t.Fatal("manager ContainerEnsureReadyFunc not set")
 	}
-	if err := mgr.ContainerEnsureReadyFunc("session-123"); err != nil {
+	if err := mgr.ContainerEnsureReadyFunc(context.Background(), "session-123"); err != nil {
 		t.Fatalf("ContainerEnsureReadyFunc() error = %v", err)
 	}
 	if pool.sessionID != "session-123" {
@@ -97,6 +98,43 @@ func TestWireBackendBrowserManager_EnsureReadyUsesSessionClient(t *testing.T) {
 	}
 	if client.sessionID != "session-123" {
 		t.Errorf("EnsureReady session = %q, want session-123", client.sessionID)
+	}
+}
+
+func TestWireBackendBrowserManager_EnsureReadyUsesContextChain(t *testing.T) {
+	mgr := browser.NewManager(browser.DefaultConfig())
+	reg := &SessionRegistry{}
+	client := &browserReadySpyClient{}
+	pool := &browserReadySpyPool{client: client}
+
+	if !WireBackendBrowserManager(mgr, &kindOnlyBackend{kind: BackendKindK8s}, reg, pool, nil) {
+		t.Fatal("WireBackendBrowserManager returned false")
+	}
+
+	ctx := store.WithSandboxLayerChain(context.Background(), []string{"@base", "abc123"})
+	ctx = store.WithSandboxTemplate(ctx, "mytemplate")
+
+	if err := mgr.ContainerEnsureReadyFunc(ctx, "session-456"); err != nil {
+		t.Fatalf("ContainerEnsureReadyFunc() error = %v", err)
+	}
+	if pool.method != "GetOrCreateWithImage" {
+		t.Errorf("pool method = %q, want GetOrCreateWithImage", pool.method)
+	}
+	if pool.sessionID != "session-456" {
+		t.Errorf("pool session = %q, want session-456", pool.sessionID)
+	}
+}
+
+func TestGetPoolClientFromContext_FallsBackToGetOrCreate(t *testing.T) {
+	client := &browserReadySpyClient{}
+	pool := &browserReadySpyPool{client: client}
+	// Empty context — no chain, no template
+	c := GetPoolClientFromContext(context.Background(), pool, "sess-1")
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if pool.method != "GetOrCreate" {
+		t.Errorf("pool method = %q, want GetOrCreate", pool.method)
 	}
 }
 
@@ -148,17 +186,27 @@ func (*browserReadySpyClient) Call(string, string, map[string]interface{}) (json
 type browserReadySpyPool struct {
 	client    ToolNodeClient
 	sessionID string
+	method    string
 }
 
 func (p *browserReadySpyPool) GetOrCreate(sessionID string) ToolNodeClient {
 	p.sessionID = sessionID
+	p.method = "GetOrCreate"
 	return p.client
 }
-func (p *browserReadySpyPool) GetOrCreateWithTemplate(string, string) ToolNodeClient { return p.client }
-func (p *browserReadySpyPool) GetOrCreateWithChain(string, string, []string) ToolNodeClient {
+func (p *browserReadySpyPool) GetOrCreateWithTemplate(sessionID, _ string) ToolNodeClient {
+	p.sessionID = sessionID
+	p.method = "GetOrCreateWithTemplate"
 	return p.client
 }
-func (p *browserReadySpyPool) GetOrCreateWithImage(string, string, []string, string) ToolNodeClient {
+func (p *browserReadySpyPool) GetOrCreateWithChain(sessionID string, _ string, _ []string) ToolNodeClient {
+	p.sessionID = sessionID
+	p.method = "GetOrCreateWithChain"
+	return p.client
+}
+func (p *browserReadySpyPool) GetOrCreateWithImage(sessionID string, _ string, _ []string, _ string) ToolNodeClient {
+	p.sessionID = sessionID
+	p.method = "GetOrCreateWithImage"
 	return p.client
 }
 func (*browserReadySpyPool) GetBackend() Backend                    { return nil }

--- a/pkg/sandbox/browser_wire.go
+++ b/pkg/sandbox/browser_wire.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,7 +18,13 @@ import (
 // "default" for the container: the sandbox installs Linux Chromium inside the
 // session. Returning false here previously left SandboxEnabled off and drills
 // fell through to host Chrome, which cannot reach container localhost services.
-func WireIncusBrowserManager(mgr *browser.Manager, client *IncusClient, touchActivity func(sessionID string)) bool {
+//
+// When pool is non-nil, ContainerEnsureReadyFunc is set so that browser tools
+// (which bypass NodeTool.Run) wait for the pool to provision the session
+// container before trying to resolve its container name/IP. This mirrors the
+// K8s path (WireBackendBrowserManager). Without this, a browser-first tool
+// call fails because the Incus container has not been started yet.
+func WireIncusBrowserManager(mgr *browser.Manager, client *IncusClient, pool ToolNodePool, touchActivity func(sessionID string)) bool {
 	if mgr == nil || client == nil {
 		return false
 	}
@@ -46,6 +53,21 @@ func WireIncusBrowserManager(mgr *browser.Manager, client *IncusClient, touchAct
 		FingerprintPlatform: cfg.FingerprintPlatform,
 	}
 	mgr.SandboxEnabled = true
+
+	// ContainerEnsureReadyFunc waits for the lazy pool to provision the session
+	// container before the browser tries to resolve it. Without this, a
+	// browser-first tool call fails because IsRunning returns false for a
+	// container that the pool hasn't started yet.
+	if pool != nil {
+		mgr.ContainerEnsureReadyFunc = func(ctx context.Context, sessionID string) error {
+			client := GetPoolClientFromContext(ctx, pool, sessionID)
+			if client == nil {
+				return fmt.Errorf("no sandbox client for session %q", sessionID)
+			}
+			return client.EnsureReady(sessionID)
+		}
+	}
+
 	mgr.ContainerResolveFunc = func(sessionID string) (string, string, error) {
 		containerName := SessionContainerName(sessionID)
 		if !client.IsRunning(containerName) {

--- a/pkg/sandbox/browser_wire_test.go
+++ b/pkg/sandbox/browser_wire_test.go
@@ -9,10 +9,10 @@ import (
 func TestWireIncusBrowserManager_NilArgs(t *testing.T) {
 	t.Parallel()
 	mgr := browser.NewManager(browser.DefaultConfig())
-	if WireIncusBrowserManager(nil, nil, nil) {
+	if WireIncusBrowserManager(nil, nil, nil, nil) {
 		t.Fatal("expected false for nil mgr/client")
 	}
-	if WireIncusBrowserManager(mgr, nil, nil) {
+	if WireIncusBrowserManager(mgr, nil, nil, nil) {
 		t.Fatal("expected false for nil client")
 	}
 	if mgr.SandboxEnabled {
@@ -31,7 +31,7 @@ func TestWireIncusBrowserManager_HostChromePathStillEnablesSandbox(t *testing.T)
 	cfg := browser.DefaultConfig()
 	cfg.ChromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 	mgr := browser.NewManager(cfg)
-	if WireIncusBrowserManager(mgr, nil, nil) {
+	if WireIncusBrowserManager(mgr, nil, nil, nil) {
 		t.Fatal("nil client must still return false")
 	}
 	// With a nil client we cannot enable sandbox; the important behavioral

--- a/pkg/sandbox/browser_wire_test.go
+++ b/pkg/sandbox/browser_wire_test.go
@@ -1,9 +1,12 @@
 package sandbox
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/SAP/astonish/pkg/browser"
+	"github.com/SAP/astonish/pkg/store"
 )
 
 func TestWireIncusBrowserManager_NilArgs(t *testing.T) {
@@ -38,5 +41,56 @@ func TestWireIncusBrowserManager_HostChromePathStillEnablesSandbox(t *testing.T)
 	// change is that a non-nil client would enable it even with this path.
 	if mgr.SandboxEnabled {
 		t.Fatal("nil client must not enable sandbox")
+	}
+}
+
+func TestIncusContainerEnsureReadyFunc_UsesContextChain(t *testing.T) {
+	t.Parallel()
+	client := &browserReadySpyClient{}
+	pool := &browserReadySpyPool{client: client}
+	// Simulate the closure WireIncusBrowserManager sets as ContainerEnsureReadyFunc:
+	ensureReady := func(ctx context.Context, sessionID string) error {
+		c := GetPoolClientFromContext(ctx, pool, sessionID)
+		if c == nil {
+			return fmt.Errorf("no sandbox client for session %q", sessionID)
+		}
+		return c.EnsureReady(sessionID)
+	}
+	ctx := store.WithSandboxLayerChain(context.Background(), []string{"@base", "overlay-abc"})
+	ctx = store.WithSandboxTemplate(ctx, "mytemplate")
+	if err := ensureReady(ctx, "sess-incus-1"); err != nil {
+		t.Fatalf("ensureReady error: %v", err)
+	}
+	if pool.method != "GetOrCreateWithImage" {
+		t.Errorf("pool method = %q, want GetOrCreateWithImage", pool.method)
+	}
+	if pool.sessionID != "sess-incus-1" {
+		t.Errorf("pool sessionID = %q, want sess-incus-1", pool.sessionID)
+	}
+	if client.sessionID != "sess-incus-1" {
+		t.Errorf("client.EnsureReady sessionID = %q, want sess-incus-1", client.sessionID)
+	}
+}
+
+func TestIncusContainerEnsureReadyFunc_FallbackWithoutChain(t *testing.T) {
+	t.Parallel()
+	client := &browserReadySpyClient{}
+	pool := &browserReadySpyPool{client: client}
+	ensureReady := func(ctx context.Context, sessionID string) error {
+		c := GetPoolClientFromContext(ctx, pool, sessionID)
+		if c == nil {
+			return fmt.Errorf("no sandbox client for session %q", sessionID)
+		}
+		return c.EnsureReady(sessionID)
+	}
+	// Empty context: no chain, no template, no image
+	if err := ensureReady(context.Background(), "sess-incus-2"); err != nil {
+		t.Fatalf("ensureReady error: %v", err)
+	}
+	if pool.method != "GetOrCreate" {
+		t.Errorf("pool method = %q, want GetOrCreate", pool.method)
+	}
+	if pool.sessionID != "sess-incus-2" {
+		t.Errorf("pool sessionID = %q, want sess-incus-2", pool.sessionID)
 	}
 }

--- a/pkg/sandbox/browser_wire_test.go
+++ b/pkg/sandbox/browser_wire_test.go
@@ -44,11 +44,30 @@ func TestWireIncusBrowserManager_HostChromePathStillEnablesSandbox(t *testing.T)
 	}
 }
 
+func TestWireIncusBrowserManager_NilPoolSkipsEnsureReady(t *testing.T) {
+	t.Parallel()
+	// When pool is nil, ContainerEnsureReadyFunc must NOT be set. Drill/fleet
+	// callers pass nil pool; setting the func unconditionally would break them.
+	mgr := browser.NewManager(browser.DefaultConfig())
+	if mgr.ContainerEnsureReadyFunc != nil {
+		t.Fatal("ContainerEnsureReadyFunc should be nil before wiring")
+	}
+	// WireIncusBrowserManager returns false for nil client, which also means
+	// ContainerEnsureReadyFunc is never set. Verify the nil-pool guard works.
+	WireIncusBrowserManager(mgr, nil, nil, nil)
+	if mgr.ContainerEnsureReadyFunc != nil {
+		t.Fatal("nil pool must not set ContainerEnsureReadyFunc")
+	}
+}
+
 func TestIncusContainerEnsureReadyFunc_UsesContextChain(t *testing.T) {
 	t.Parallel()
 	client := &browserReadySpyClient{}
 	pool := &browserReadySpyPool{client: client}
-	// Simulate the closure WireIncusBrowserManager sets as ContainerEnsureReadyFunc:
+	// We cannot call WireIncusBrowserManager with a real *IncusClient in a unit
+	// test (the concrete type requires a live daemon). Instead we test the closure
+	// body directly — the same logic WireIncusBrowserManager assigns at
+	// browser_wire.go:62-68. GetPoolClientFromContext is the critical shared path.
 	ensureReady := func(ctx context.Context, sessionID string) error {
 		c := GetPoolClientFromContext(ctx, pool, sessionID)
 		if c == nil {

--- a/pkg/tools/browser_action_capture.go
+++ b/pkg/tools/browser_action_capture.go
@@ -18,9 +18,7 @@ type BrowserStartActionCaptureResult struct {
 
 func BrowserStartActionCapture(mgr *browser.Manager) func(tool.Context, BrowserStartActionCaptureArgs) (BrowserStartActionCaptureResult, error) {
 	return func(ctx tool.Context, _ BrowserStartActionCaptureArgs) (BrowserStartActionCaptureResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 		if err := mgr.StartActionCapture(false); err != nil {
 			return BrowserStartActionCaptureResult{}, err
 		}
@@ -42,9 +40,7 @@ type BrowserStopActionCaptureResult struct {
 
 func BrowserStopActionCapture(mgr *browser.Manager) func(tool.Context, BrowserStopActionCaptureArgs) (BrowserStopActionCaptureResult, error) {
 	return func(ctx tool.Context, _ BrowserStopActionCaptureArgs) (BrowserStopActionCaptureResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 		if err := mgr.StopActionCapture(); err != nil {
 			return BrowserStopActionCaptureResult{}, err
 		}
@@ -70,9 +66,7 @@ type BrowserGetActionLogResult struct {
 
 func BrowserGetActionLog(mgr *browser.Manager) func(tool.Context, BrowserGetActionLogArgs) (BrowserGetActionLogResult, error) {
 	return func(ctx tool.Context, args BrowserGetActionLogArgs) (BrowserGetActionLogResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 		events, err := mgr.GetActionLog()
 		if err != nil {
 			return BrowserGetActionLogResult{}, err

--- a/pkg/tools/browser_handoff.go
+++ b/pkg/tools/browser_handoff.go
@@ -44,9 +44,7 @@ type BrowserRequestHumanResult struct {
 // or end the session.
 func BrowserRequestHuman(mgr *browser.Manager) func(tool.Context, BrowserRequestHumanArgs) (BrowserRequestHumanResult, error) {
 	return func(ctx tool.Context, args BrowserRequestHumanArgs) (BrowserRequestHumanResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 
 		if args.Reason == "" {
 			return BrowserRequestHumanResult{}, fmt.Errorf("reason is required")

--- a/pkg/tools/browser_manage.go
+++ b/pkg/tools/browser_manage.go
@@ -34,9 +34,7 @@ type BrowserTabsResult struct {
 
 func BrowserTabs(mgr *browser.Manager, guard *browser.NavigationGuard) func(tool.Context, BrowserTabsArgs) (BrowserTabsResult, error) {
 	return func(ctx tool.Context, args BrowserTabsArgs) (BrowserTabsResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 
 		b, err := mgr.GetOrLaunch()
 		if err != nil {

--- a/pkg/tools/browser_navigate.go
+++ b/pkg/tools/browser_navigate.go
@@ -22,9 +22,7 @@ type BrowserNavigateResult struct {
 // BrowserNavigate navigates the browser to a URL.
 func BrowserNavigate(mgr *browser.Manager, guard *browser.NavigationGuard) func(tool.Context, BrowserNavigateArgs) (BrowserNavigateResult, error) {
 	return func(ctx tool.Context, args BrowserNavigateArgs) (BrowserNavigateResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 
 		if args.URL == "" {
 			return BrowserNavigateResult{}, fmt.Errorf("url is required")

--- a/pkg/tools/browser_recording.go
+++ b/pkg/tools/browser_recording.go
@@ -20,9 +20,7 @@ type BrowserStartRecordingResult struct {
 
 func BrowserStartRecording(mgr *browser.Manager) func(tool.Context, BrowserStartRecordingArgs) (BrowserStartRecordingResult, error) {
 	return func(ctx tool.Context, args BrowserStartRecordingArgs) (BrowserStartRecordingResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 		res, err := mgr.StartRecording(browser.RecordingOptions{Filename: args.Filename})
 		if err != nil {
 			return BrowserStartRecordingResult{}, err
@@ -48,9 +46,7 @@ type BrowserStopRecordingResult struct {
 
 func BrowserStopRecording(mgr *browser.Manager) func(tool.Context, BrowserStopRecordingArgs) (BrowserStopRecordingResult, error) {
 	return func(ctx tool.Context, _ BrowserStopRecordingArgs) (BrowserStopRecordingResult, error) {
-		if ctx != nil {
-			mgr.EnsureSessionID(ctx.SessionID())
-		}
+		ensureBrowserSessionAndContext(mgr, ctx)
 		res, err := mgr.StopRecording()
 		if err != nil {
 			return BrowserStopRecordingResult{}, err

--- a/pkg/tools/browser_safe.go
+++ b/pkg/tools/browser_safe.go
@@ -1,12 +1,29 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"time"
 
+	"github.com/SAP/astonish/pkg/browser"
 	"google.golang.org/adk/tool"
 )
+
+// ensureBrowserSessionAndContext sets up the browser Manager with the current
+// session ID and request context. This should be called at the start of every
+// browser tool to ensure the Manager can provision sandboxes with the correct
+// overlay layer chain.
+func ensureBrowserSessionAndContext(mgr *browser.Manager, ctx tool.Context) {
+	if mgr == nil || ctx == nil {
+		return
+	}
+	mgr.EnsureSessionID(ctx.SessionID())
+	// Try to cast tool.Context to context.Context and set it on the Manager
+	if reqCtx, ok := any(ctx).(context.Context); ok {
+		mgr.SetRequestContext(reqCtx)
+	}
+}
 
 // browserToolTimeout is the maximum time any single browser tool call can take.
 // It exceeds the Kubernetes sandbox readiness window plus browser startup so a

--- a/pkg/tools/browser_safe.go
+++ b/pkg/tools/browser_safe.go
@@ -19,7 +19,9 @@ func ensureBrowserSessionAndContext(mgr *browser.Manager, ctx tool.Context) {
 		return
 	}
 	mgr.EnsureSessionID(ctx.SessionID())
-	// Try to cast tool.Context to context.Context and set it on the Manager
+	// ADK's tool.Context embeds context.Context, so this assertion always
+	// succeeds in production. The ok-guard is belt-and-suspenders for any
+	// future context type that doesn't embed context.Context.
 	if reqCtx, ok := any(ctx).(context.Context); ok {
 		mgr.SetRequestContext(reqCtx)
 	}

--- a/pkg/tools/browser_safe_test.go
+++ b/pkg/tools/browser_safe_test.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/browser"
+	"github.com/SAP/astonish/pkg/store"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+// toolContextStub implements tool.Context (= agent.ToolContext) and context.Context.
+// Embedding context.Context satisfies the context.Context portion of ReadonlyContext
+// and makes the type assertion `any(ctx).(context.Context)` in
+// ensureBrowserSessionAndContext succeed.
+type toolContextStub struct {
+	context.Context
+	sessionID string
+}
+
+// --- ReadonlyContext methods ---
+
+func (s *toolContextStub) UserContent() *genai.Content                    { return nil }
+func (s *toolContextStub) InvocationID() string                           { return "" }
+func (s *toolContextStub) AgentName() string                              { return "" }
+func (s *toolContextStub) ReadonlyState() session.ReadonlyState           { return stubReadonlyState{} }
+func (s *toolContextStub) UserID() string                                 { return "" }
+func (s *toolContextStub) AppName() string                                { return "" }
+func (s *toolContextStub) SessionID() string                              { return s.sessionID }
+func (s *toolContextStub) Branch() string                                 { return "" }
+
+// --- CallbackContext methods ---
+
+func (s *toolContextStub) Artifacts() agent.Artifacts  { return nil }
+func (s *toolContextStub) State() session.State        { return stubState{} }
+
+// --- ToolContext methods ---
+
+func (s *toolContextStub) FunctionCallID() string                                                  { return "" }
+func (s *toolContextStub) Actions() *session.EventActions                                          { return nil }
+func (s *toolContextStub) SearchMemory(_ context.Context, _ string) (*memory.SearchResponse, error) { return nil, nil }
+func (s *toolContextStub) ToolConfirmation() *toolconfirmation.ToolConfirmation                    { return nil }
+func (s *toolContextStub) RequestConfirmation(_ string, _ any) error                               { return nil }
+
+// stubReadonlyState satisfies session.ReadonlyState.
+type stubReadonlyState struct{}
+
+func (stubReadonlyState) Get(string) (any, error)    { return nil, nil }
+func (stubReadonlyState) All() iter.Seq2[string, any] { return func(yield func(string, any) bool) {} }
+
+// stubState satisfies session.State.
+type stubState struct{ stubReadonlyState }
+
+func (stubState) Set(string, any) error { return nil }
+
+// ---------------------------------------------------------------------------
+
+func TestEnsureBrowserSessionAndContext_SetsSessionAndContext(t *testing.T) {
+	mgr := browser.NewManager(browser.DefaultConfig())
+
+	chain := []string{"@base", "abc123"}
+	ctx := store.WithSandboxLayerChain(context.Background(), chain)
+	stub := &toolContextStub{
+		Context:   ctx,
+		sessionID: "sess-42",
+	}
+
+	ensureBrowserSessionAndContext(mgr, stub)
+
+	// Verify that SetRequestContext was called by checking the context
+	// is propagated to ContainerEnsureReadyFunc via GetOrLaunch.
+	var capturedCtx context.Context
+	mgr.SandboxEnabled = true
+	mgr.ContainerEnsureReadyFunc = func(gotCtx context.Context, _ string) error {
+		capturedCtx = gotCtx
+		return nil
+	}
+	mgr.ContainerResolveFunc = func(_ string) (string, string, error) {
+		return "", "", fmt.Errorf("stop")
+	}
+	_, _ = mgr.GetOrLaunch()
+
+	gotChain := store.SandboxLayerChainFromContext(capturedCtx)
+	if len(gotChain) != 2 || gotChain[0] != "@base" || gotChain[1] != "abc123" {
+		t.Errorf("request context chain = %v, want [@base abc123]", gotChain)
+	}
+}
+
+func TestEnsureBrowserSessionAndContext_NilSafe(t *testing.T) {
+	// Should not panic with nil mgr or nil ctx.
+	ensureBrowserSessionAndContext(nil, nil)
+
+	mgr := browser.NewManager(browser.DefaultConfig())
+	ensureBrowserSessionAndContext(mgr, nil)
+}


### PR DESCRIPTION
## Problem

Browser tools (`browser_navigate`, `browser_snapshot`, etc.) bypass `NodeTool.Run` — they talk to Chrome via CDP directly. When the browser needs to launch inside a sandbox, the browser Manager calls `ContainerEnsureReadyFunc` to provision the pod. This callback was called with no context, so it called `pool.GetOrCreate(sessionID)` with no template/chain/image arguments. The pool then created a pod with only `@base` — missing the configured overlay layer containing Chromium, KasmVNC, and other tools.

The correct layer chain (e.g. `["@base", "a3fe6efb..."]`) is available on the request context via `store.SandboxLayerChainFromContext(ctx)`. Container-wrapped tools get it right because `NodeTool.getClientFromContext` reads these values. Browser tools never go through NodeTool, so they missed it.

## Solution

Thread the request context through the browser Manager's provisioning path:

1. **`ContainerEnsureReadyFunc` signature**: Changed from `func(sessionID string) error` to `func(ctx context.Context, sessionID string) error` so callers can pass chain/template/image context.

2. **`Manager.requestCtx` + `SetRequestContext()`**: A new mutex-guarded field stores the request context. `ensureBrowserSessionAndContext` (called at the start of every browser tool) sets it. `launchInContainerInner` reads it when calling `ContainerEnsureReadyFunc`.

3. **`GetPoolClientFromContext`**: New exported helper (mirrors `NodeTool.getClientFromContext`) that selects `GetOrCreateWithImage` / `GetOrCreateWithTemplate` / `GetOrCreate` based on context values. Also calls `SetSessionScope` when org/team slugs are present, so browser-first sessions record the correct tenant before creating a pool client (prevents cross-tenant container-record bug).

4. **Incus wiring parity**: `WireIncusBrowserManager` previously had no `ContainerEnsureReadyFunc` at all. It now sets one (using `GetPoolClientFromContext`) when a non-nil pool is provided, matching the K8s path.

5. **`ensureBrowserSessionAndContext` helper**: Centralizes `EnsureSessionID` + `SetRequestContext` into one call, applied at the top of every browser tool.

## Files Changed

**Production code (17 files):**
- `pkg/browser/manager.go` — new `requestCtx` field, `SetRequestContext()`, `ContainerEnsureReadyFunc` signature change
- `pkg/sandbox/backend_browser_wire.go` — new `GetPoolClientFromContext` with `SetSessionScope` + K8s closure updated
- `pkg/sandbox/browser_wire.go` — `WireIncusBrowserManager` gains `pool` param + sets `ContainerEnsureReadyFunc`
- `pkg/tools/browser_safe.go` — new `ensureBrowserSessionAndContext` helper
- `pkg/tools/browser_{navigate,manage,handoff,recording,action_capture}.go` — use new helper
- `pkg/launcher/{browser_sandbox,chat_factory}.go`, `cmd/astonish/drill.go`, `pkg/api/fleet_sandbox_wiring.go` — callers updated for new signatures

**Tests (4 files, 233 lines):**
- `pkg/sandbox/browser_wire_test.go` — Incus wiring tests incl. nil-pool guard
- `pkg/sandbox/backend_browser_wire_test.go` — `GetPoolClientFromContext` template-only branch
- `pkg/browser/container_launch_test.go` — context propagation through `SetRequestContext` → `ContainerEnsureReadyFunc`
- `pkg/tools/browser_safe_test.go` (new) — `ensureBrowserSessionAndContext` helper coverage

## Testing

- `go test ./pkg/browser/... ./pkg/sandbox/... ./pkg/tools/... -count=1` ✅ all pass
- `go build .` ✅
- Verified working on both Incus and Kubernetes deployments