### PR TITLE
K8s sandbox recording fix + TUI render-cache with collision prevention

### DIFF
--- a/pkg/sandbox/backend_browser_wire.go
+++ b/pkg/sandbox/backend_browser_wire.go
@@ -416,6 +416,19 @@ func dialBackendSessionPort(ctx context.Context, backend Backend, sessionID stri
 	}, nil
 }
 
+// backendShellCommand wraps a raw shell command for execution in backend containers.
+// On Kubernetes backends (which chroot into /sandbox/rootfs), it wraps through
+// /usr/local/bin/astonish-shell to ensure tools like xdpyinfo, ffmpeg, etc.
+// are found inside the overlay. On Docker backends, the overlay IS the root
+// filesystem, so we use plain sh -c.
+// This mirrors the pattern established in backend_mcp_transport.go.
+func backendShellCommand(backend Backend, script string) []string {
+	if backend != nil && backend.Kind() == BackendKindK8s {
+		return []string{"/usr/local/bin/astonish-shell", "sh", "-c", script}
+	}
+	return []string{"sh", "-c", script}
+}
+
 type backendExecConn struct {
 	stream ExecStream
 	reader *bufio.Reader
@@ -467,7 +480,7 @@ func startBackendRecording(ctx context.Context, backend Backend, sessionID, disp
 
 	// Probe display size.
 	probeResult, err := backend.Exec(ctx, sessionID, ExecSpec{
-		Command: []string{"sh", "-c", browser.DisplayProbeShellCommand(display)},
+		Command: backendShellCommand(backend, browser.DisplayProbeShellCommand(display)),
 	})
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("probe display size: %w", err)
@@ -483,7 +496,7 @@ func startBackendRecording(ctx context.Context, backend Backend, sessionID, disp
 	// Create output directory.
 	dir := filepath.Dir(outPath)
 	if _, err := backend.Exec(ctx, sessionID, ExecSpec{
-		Command: []string{"sh", "-c", "mkdir -p " + shellQuoteBackend(dir)},
+		Command: backendShellCommand(backend, "mkdir -p "+shellQuoteBackend(dir)),
 	}); err != nil {
 		return nil, 0, 0, fmt.Errorf("mkdir recordings dir: %w", err)
 	}
@@ -516,7 +529,7 @@ fi
 	)
 
 	startResult, err := backend.Exec(ctx, sessionID, ExecSpec{
-		Command: []string{"sh", "-c", startScript},
+		Command: backendShellCommand(backend, startScript),
 	})
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("start ffmpeg: %w", err)
@@ -556,7 +569,7 @@ fi
 		)
 
 		stopResult, err := backend.Exec(context.Background(), sessionID, ExecSpec{
-			Command: []string{"sh", "-c", stopScript},
+			Command: backendShellCommand(backend, stopScript),
 		})
 		if err != nil {
 			return fmt.Errorf("stop ffmpeg: %w", err)

--- a/pkg/sandbox/backend_browser_wire_test.go
+++ b/pkg/sandbox/backend_browser_wire_test.go
@@ -314,6 +314,7 @@ func TestGetPoolClientFromContext_TemplateOnlyUsesGetOrCreateWithTemplate(t *tes
 // startBackendRecording.
 type recordingExecBackend struct {
 	interfaceTestStub
+	kind        BackendKind
 	// calls receives each script that was executed via Exec.
 	calls []string
 	// execResults maps call index → ExecResult. If no entry, returns a default
@@ -324,7 +325,7 @@ type recordingExecBackend struct {
 	callIdx     int
 }
 
-func (b *recordingExecBackend) Kind() BackendKind { return BackendKindDocker }
+func (b *recordingExecBackend) Kind() BackendKind { return b.kind }
 
 func (b *recordingExecBackend) Exec(_ context.Context, _ string, opts ExecSpec) (*ExecResult, error) {
 	idx := b.callIdx
@@ -343,6 +344,7 @@ func (b *recordingExecBackend) Exec(_ context.Context, _ string, opts ExecSpec) 
 
 func TestStartBackendRecording_ProbeFailure(t *testing.T) {
 	b := &recordingExecBackend{
+		kind: BackendKindDocker,
 		execErrors: map[int]error{
 			0: fmt.Errorf("xdpyinfo not found"),
 		},
@@ -358,6 +360,7 @@ func TestStartBackendRecording_ProbeFailure(t *testing.T) {
 
 func TestStartBackendRecording_ProbeBadDimensions(t *testing.T) {
 	b := &recordingExecBackend{
+		kind: BackendKindDocker,
 		execResults: map[int]*ExecResult{
 			0: {ExitCode: 0, Stdout: []byte("not-dimensions")},
 		},
@@ -379,5 +382,65 @@ func TestWireBackendBrowserManager_SetsRecordingFunc(t *testing.T) {
 	}
 	if mgr.ContainerStartRecordingFunc == nil {
 		t.Fatal("ContainerStartRecordingFunc was not wired by WireBackendBrowserManager")
+	}
+}
+
+func TestBackendShellCommand_Docker(t *testing.T) {
+	backend := &kindOnlyBackend{kind: BackendKindDocker}
+	script := "echo hello"
+	cmd := backendShellCommand(backend, script)
+	if len(cmd) != 3 {
+		t.Errorf("Docker backend command length = %d, want 3", len(cmd))
+	}
+	if cmd[0] != "sh" || cmd[1] != "-c" || cmd[2] != script {
+		t.Errorf("Docker backend command = %v, want [sh -c %q]", cmd, script)
+	}
+}
+
+func TestBackendShellCommand_K8s(t *testing.T) {
+	backend := &kindOnlyBackend{kind: BackendKindK8s}
+	script := "echo hello"
+	cmd := backendShellCommand(backend, script)
+	if len(cmd) != 4 {
+		t.Errorf("K8s backend command length = %d, want 4", len(cmd))
+	}
+	if cmd[0] != "/usr/local/bin/astonish-shell" || cmd[1] != "sh" || cmd[2] != "-c" || cmd[3] != script {
+		t.Errorf("K8s backend command = %v, want [/usr/local/bin/astonish-shell sh -c %q]", cmd, script)
+	}
+}
+
+func TestBackendShellCommand_NilBackend(t *testing.T) {
+	script := "echo hello"
+	cmd := backendShellCommand(nil, script)
+	if len(cmd) != 3 {
+		t.Errorf("nil backend command length = %d, want 3", len(cmd))
+	}
+	if cmd[0] != "sh" || cmd[1] != "-c" || cmd[2] != script {
+		t.Errorf("nil backend command = %v, want [sh -c %q]", cmd, script)
+	}
+}
+
+func TestStartBackendRecording_K8sUsesAstonishShell(t *testing.T) {
+	// recordingExecBackend captures all Exec calls; by default it returns
+	// success with a valid probe response "1920x1080".
+	b := &recordingExecBackend{
+		kind: BackendKindK8s,
+	}
+	_, _, _, err := startBackendRecording(context.Background(), b, "sess-1", ":0", "/tmp/astonish-recordings/test.mp4")
+	if err != nil {
+		t.Fatalf("startBackendRecording failed: %v", err)
+	}
+
+	// We expect 4 Exec calls (probe, mkdir, start ffmpeg, and the stopFn closure will call stop ffmpeg).
+	// We only verify the first 3 here since stopFn is lazy.
+	if len(b.calls) < 3 {
+		t.Fatalf("expected at least 3 Exec calls, got %d", len(b.calls))
+	}
+
+	// Each call should start with /usr/local/bin/astonish-shell for K8s backends.
+	for i, call := range b.calls[:3] {
+		if !strings.Contains(call, "/usr/local/bin/astonish-shell") {
+			t.Errorf("call %d = %q; expected to contain /usr/local/bin/astonish-shell", i, call)
+		}
 	}
 }

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -2195,6 +2195,39 @@ func itemCacheKey(width int, kind events.ItemKind, content string, expanded bool
 	return strconv.Itoa(width) + "\x00" + string(kind) + "\x00" + strconv.FormatBool(expanded) + "\x00" + routingTier + "\x00" + routingModel + "\x00" + content
 }
 
+// applyRoutingBadge appends a tier emoji badge to the right margin of md's last
+// line (inline) when it fits, or appends it on a new line below. Called from
+// both the streaming bypass path and the finalized/cacheable path so they stay
+// visually identical.
+func (m model) applyRoutingBadge(md string, cw int, it events.Item) string {
+	if it.RoutingModel == "" {
+		return md
+	}
+	th := m.theme
+	var badge string
+	switch it.RoutingTier {
+	case "strong":
+		badge = " 🧠"
+	case "medium":
+		badge = " ⚙️"
+	default:
+		badge = " ⚡"
+	}
+	badgeRendered := th.Muted.Render(badge)
+	badgeW := lipgloss.Width(badgeRendered)
+	lines := strings.Split(md, "\n")
+	lastLineW := lipgloss.Width(lines[len(lines)-1])
+	if lastLineW+badgeW+1 <= cw {
+		pad := cw - lastLineW - badgeW
+		if pad < 1 {
+			pad = 1
+		}
+		lines[len(lines)-1] = lines[len(lines)-1] + strings.Repeat(" ", pad) + badgeRendered
+		return strings.Join(lines, "\n")
+	}
+	return md + "\n" + badgeRendered
+}
+
 // stepsCacheDigest computes a compact, stable hash digest of steps for cache-key
 // inclusion. This prevents collisions between activities with identical summaries
 // but different underlying steps (e.g., "Read 1 file" reading different files).
@@ -2214,7 +2247,7 @@ func stepsCacheDigest(steps []events.ToolStep) string {
 			hash *= fnvPrime
 		}
 	}
-	return strconv.FormatInt(int64(hash), 16)
+	return strconv.FormatUint(hash, 16)
 }
 
 // argsCacheDigest computes a compact hash of tool args map for cache keys.
@@ -2235,8 +2268,8 @@ func argsCacheDigest(args map[string]any) string {
 	for _, k := range keys {
 		// Include key and a compact stringification of the value
 		valStr := fmt.Sprintf("%v", args[k])
-		if len(valStr) > 50 {
-			valStr = valStr[:50] // Truncate very large values
+		if len([]rune(valStr)) > 50 {
+			valStr = string([]rune(valStr)[:50]) // Truncate at rune boundary
 		}
 		entry := k + ":" + valStr
 		for _, b := range []byte(entry) {
@@ -2244,7 +2277,7 @@ func argsCacheDigest(args map[string]any) string {
 			hash *= fnvPrime
 		}
 	}
-	return strconv.FormatInt(int64(hash), 16)
+	return strconv.FormatUint(hash, 16)
 }
 
 // resultCacheDigest computes a compact hash of a tool result for cache keys.
@@ -2254,8 +2287,8 @@ func resultCacheDigest(result any) string {
 	}
 	// For most results use a short string representation; avoid hashing entire large outputs
 	resultStr := fmt.Sprintf("%v", result)
-	if len(resultStr) > 50 {
-		resultStr = resultStr[:50]
+	if len([]rune(resultStr)) > 50 {
+		resultStr = string([]rune(resultStr)[:50])
 	}
 	hash := uint64(14695981039346656037)
 	const fnvPrime uint64 = 1099511628211
@@ -2263,7 +2296,7 @@ func resultCacheDigest(result any) string {
 		hash ^= uint64(b)
 		hash *= fnvPrime
 	}
-	return strconv.FormatInt(int64(hash), 16)
+	return strconv.FormatUint(hash, 16)
 }
 
 func waitEvent(ch <-chan events.Event) tea.Cmd {
@@ -2990,6 +3023,10 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 	if m.itemRenderCache == nil {
 		m.itemRenderCache = make(map[string]renderedBlock)
 	}
+	// usedCacheKeys tracks every cache key referenced in this render pass.
+	// After the loop we evict any entry not touched this pass (e.g. orphaned
+	// entries from toggled expand/collapse states, or compacted-away items).
+	usedCacheKeys := make(map[string]struct{}, len(m.itemRenderCache))
 
 	// buildPlainSpanned computes the ANSI-stripped plain lines and content spans
 	// for a padded block. It is called when building a new cache entry.
@@ -3066,8 +3103,9 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 	// is active and intersects the block's line range, we re-apply the
 	// selection highlight to the cached raw block (cheap — only for the few
 	// blocks in the selected region). All other blocks use the cached output
-	// verbatim, skipping all string work.
-	useCached := func(itemIdx int, kind events.ItemKind, cached renderedBlock) int {
+	// verbatim, skipping all string work. key is recorded in usedCacheKeys so
+	// the eviction pass at the end of the loop does not remove this entry.
+	useCached := func(itemIdx int, kind events.ItemKind, key string, cached renderedBlock) int {
 		raw := cached.raw
 		n := cached.lineCount - 1 // lineCount includes the gap separator
 		blockEnd := lineNo + n
@@ -3091,6 +3129,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		contentSpans = append(contentSpans, [2]int{0, 0})
 		lineNo += cached.lineCount
 		hits = append(hits, hitRegion{start: start, end: start + n, itemIdx: itemIdx, kind: kind})
+		usedCacheKeys[key] = struct{}{}
 		return start
 	}
 
@@ -3133,6 +3172,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			spans:      csClean,
 			lineCount:  n + 1,
 		}
+		usedCacheKeys[key] = struct{}{}
 		return start
 	}
 
@@ -3155,7 +3195,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			// User bubbles are cacheable (content never changes after submit).
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content, it.Expanded, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, m.renderUserBubble(it.Content, it.Expanded, cw), userBubbleContentSpan)
 			}
@@ -3175,31 +3215,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 					if md == "" {
 						md = th.Agent.Width(cw).Render(content)
 					}
-					if it.RoutingModel != "" {
-						var badge string
-						switch it.RoutingTier {
-						case "strong":
-							badge = " 🧠"
-						case "medium":
-							badge = " ⚙️"
-						default:
-							badge = " ⚡"
-						}
-						badgeRendered := th.Muted.Render(badge)
-						badgeW := lipgloss.Width(badgeRendered)
-						lines := strings.Split(md, "\n")
-						lastLineW := lipgloss.Width(lines[len(lines)-1])
-						if lastLineW+badgeW+1 <= cw {
-							pad := cw - lastLineW - badgeW
-							if pad < 1 {
-								pad = 1
-							}
-							lines[len(lines)-1] = lines[len(lines)-1] + strings.Repeat(" ", pad) + badgeRendered
-							md = strings.Join(lines, "\n")
-						} else {
-							md = md + "\n" + badgeRendered
-						}
-					}
+					md = m.applyRoutingBadge(md, cw, it)
 					appendBlockSpanned(i, it.Kind, md, codeGutterContentSpan)
 				}
 				continue
@@ -3209,34 +3225,10 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			if md == "" {
 				md = th.Agent.Width(cw).Render(content)
 			}
-			if it.RoutingModel != "" {
-				var badge string
-				switch it.RoutingTier {
-				case "strong":
-					badge = " 🧠"
-				case "medium":
-					badge = " ⚙️"
-				default:
-					badge = " ⚡"
-				}
-				badgeRendered := th.Muted.Render(badge)
-				badgeW := lipgloss.Width(badgeRendered)
-				lines := strings.Split(md, "\n")
-				lastLineW := lipgloss.Width(lines[len(lines)-1])
-				if lastLineW+badgeW+1 <= cw {
-					pad := cw - lastLineW - badgeW
-					if pad < 1 {
-						pad = 1
-					}
-					lines[len(lines)-1] = lines[len(lines)-1] + strings.Repeat(" ", pad) + badgeRendered
-					md = strings.Join(lines, "\n")
-				} else {
-					md = md + "\n" + badgeRendered
-				}
-			}
+			md = m.applyRoutingBadge(md, cw, it)
 			cacheKey := itemCacheKey(cw, it.Kind, md, it.Expanded, it.RoutingTier, it.RoutingModel)
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, md, codeGutterContentSpan)
 			}
@@ -3261,7 +3253,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 				// with identical summaries but different steps (e.g., "Read 1 file" vs different files).
 				cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Summary+stepsCacheDigest(it.Steps), it.Expanded, it.RoutingTier, it.RoutingModel)
 				if cached, ok := m.itemRenderCache[cacheKey]; ok {
-					useCached(i, it.Kind, cached)
+					useCached(i, it.Kind, cacheKey, cached)
 				} else {
 					buildAndCache(i, it.Kind, cacheKey, m.renderActivity(it, cw), codeGutterContentSpan)
 				}
@@ -3277,7 +3269,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			}
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content+suffix, it.Expanded, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, m.renderFileDiff(it, cw), codeGutterContentSpan)
 			}
@@ -3285,7 +3277,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		case events.ItemSystem:
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, th.System.Width(cw).Render(it.Content), nil)
 			}
@@ -3293,7 +3285,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		case events.ItemCompaction:
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, th.System.Width(cw).Render(it.Content), nil)
 			}
@@ -3301,7 +3293,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		case events.ItemError:
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, th.Error.Width(cw).Render(it.Content), nil)
 			}
@@ -3328,7 +3320,7 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		case events.ItemArtifact:
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Path, false, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				start := useCached(i, it.Kind, cached)
+				start := useCached(i, it.Kind, cacheKey, cached)
 				// Artifact hit regions within the block are re-derived from the
 				// cached block. Since the artifact list is stable, we re-render
 				// only to get the row indices — the painted output comes from cache.
@@ -3361,10 +3353,19 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		case events.ItemPlan:
 			cacheKey := itemCacheKey(cw, it.Kind, it.Content+string(it.PlanStatus), it.Expanded, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
-				useCached(i, it.Kind, cached)
+				useCached(i, it.Kind, cacheKey, cached)
 			} else {
 				buildAndCache(i, it.Kind, cacheKey, m.renderPlanDocument(it, cw), planDocumentContentSpan)
 			}
+		}
+	}
+	// Evict cache entries not used in this render pass. This prevents unbounded
+	// growth from orphaned entries (e.g., the opposite expand/collapse state of
+	// a toggled item, or items removed by a /compact). The map stays bounded to
+	// at most len(m.tr.Items) entries after each full render.
+	for k := range m.itemRenderCache {
+		if _, used := usedCacheKeys[k]; !used {
+			delete(m.itemRenderCache, k)
 		}
 	}
 	m.transcriptPlainLines = plainLines

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -57,6 +57,19 @@ type artifactHit struct {
 	artifactIdx int
 }
 
+// renderedBlock is the cached output of one transcript item — the fully
+// padded+painted string ready for the viewport, plus the ANSI-stripped plain
+// lines and content spans used for drag-to-copy selection. Caching at this
+// level avoids re-running padBlock/paintTranscriptBlock/appendPlainSpanned for
+// every historical item on every refreshViewport call.
+type renderedBlock struct {
+	raw        string     // padded block before painting (needed to re-apply selection)
+	painted    string     // padded + painted block ready for viewport
+	plainLines []string   // ANSI-stripped lines for selection/copy
+	spans      [][2]int   // content spans per line
+	lineCount  int        // rendered block lines + 1 gap separator
+}
+
 type fileViewerState struct {
 	open     bool
 	loading  bool
@@ -167,6 +180,15 @@ type model struct {
 	// into O(changed item) and keeps the UI responsive under a burst of events.
 	// Cleared on resize (see layout/WindowSizeMsg) since width is part of output.
 	mdCache map[string]string
+	// itemRenderCache memoizes the fully rendered+padded+painted block for each
+	// finalized transcript item. Keyed by width, kind, content, expanded state,
+	// and routing tier. Cleared on resize alongside mdCache. This lifts the
+	// padBlock / paintTranscriptBlock / appendPlainSpanned cost from O(all items)
+	// to O(new/changed items) on every refreshViewport call.
+	itemRenderCache map[string]renderedBlock
+	// lastSelectionRefresh rate-limits refreshViewport during mouse drag so
+	// high-frequency motion events don't trigger a full re-render every pixel.
+	lastSelectionRefresh time.Time
 	// double-click detection for expanding user bubbles.
 	lastClickAt time.Time
 	lastClickY  int
@@ -408,9 +430,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Width is part of the markdown cache key; drop stale-width entries so
-		// the cache does not accumulate one set per historical window size.
+		// Width is part of both cache keys; drop stale-width entries so the
+		// caches do not accumulate one set per historical window size.
 		m.mdCache = nil
+		m.itemRenderCache = nil
 		m.layout()
 		m.ready = true
 		m.refreshViewport()
@@ -2158,6 +2181,20 @@ func (m model) statusText() string {
 // applies before yielding, so a flood of tool output cannot starve key input.
 const maxCoalescedEvents = 256
 
+// selectionRefreshInterval caps how often refreshViewport is called during a
+// mouse drag (i.e. on MouseMotion events). Terminal emulators can fire motion
+// events faster than the renderer can handle them; limiting to ~60 fps keeps
+// the UI responsive without burning CPU on sub-frame redraws.
+const selectionRefreshInterval = 16 * time.Millisecond
+
+// itemCacheKey returns a string key for the item render cache. It encodes all
+// fields that affect the visual output so changing expanded state or routing
+// tier produces a cache miss (and a fresh render) while identical items get a
+// fast lookup. Content is last so the fixed prefix is short for common items.
+func itemCacheKey(width int, kind events.ItemKind, content string, expanded bool, routingTier, routingModel string) string {
+	return strconv.Itoa(width) + "\x00" + string(kind) + "\x00" + strconv.FormatBool(expanded) + "\x00" + routingTier + "\x00" + routingModel + "\x00" + content
+}
+
 func waitEvent(ch <-chan events.Event) tea.Cmd {
 	return func() tea.Msg {
 		ev, ok := <-ch
@@ -2652,7 +2689,16 @@ func (m model) handleMouseMotion(msg tea.Mouse) (tea.Model, tea.Cmd) {
 		m.selectionMoved = true
 	}
 	m.selectionEnd = p
-	m.refreshViewport()
+	// Rate-limit viewport refreshes during drag to ~60fps. Terminal emulators
+	// can send mouse-motion events faster than the renderer can process them;
+	// a full refreshViewport (O(all items)) on every pixel saturates the CPU
+	// in long sessions and makes selection feel sluggish. The final position
+	// is always rendered on mouse release regardless of this gate.
+	now := time.Now()
+	if now.Sub(m.lastSelectionRefresh) >= selectionRefreshInterval {
+		m.lastSelectionRefresh = now
+		m.refreshViewport()
+	}
 	return m, nil
 }
 
@@ -2870,18 +2916,21 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 	cw := contentWidth(m.width)
 	lineNo := 0
 
-	// appendPlainSpanned appends the plain (ANSI-stripped) lines of block along
-	// with a content span for each line. spanFor maps a block-local line index
-	// and its plain text to the [start,end) rune-column range that is real
-	// content (excluding decorative chrome). Spans are shifted by the padBlock
-	// margin so they line up with the padded plain lines used for selection.
-	appendPlainSpanned := func(block string, spanFor func(i int, plain string) [2]int) {
+	if m.itemRenderCache == nil {
+		m.itemRenderCache = make(map[string]renderedBlock)
+	}
+
+	// buildPlainSpanned computes the ANSI-stripped plain lines and content spans
+	// for a padded block. It is called when building a new cache entry.
+	buildPlainSpanned := func(block string, spanFor func(i int, plain string) [2]int) ([]string, [][2]int) {
 		if block == "" {
-			return
+			return nil, nil
 		}
+		var pl []string
+		var cs [][2]int
 		for i, line := range strings.Split(block, "\n") {
 			plain := stripANSI(line)
-			plainLines = append(plainLines, plain)
+			pl = append(pl, plain)
 			total := len([]rune(plain))
 			span := [2]int{0, total}
 			if spanFor != nil {
@@ -2892,8 +2941,15 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			if span[0] > span[1] {
 				span[0], span[1] = span[1], span[0]
 			}
-			contentSpans = append(contentSpans, span)
+			cs = append(cs, span)
 		}
+		return pl, cs
+	}
+
+	// appendPlainSpanned appends pre-computed plain lines and spans.
+	appendPlainSpanned := func(pl []string, cs [][2]int) {
+		plainLines = append(plainLines, pl...)
+		contentSpans = append(contentSpans, cs...)
 	}
 
 	// appendBlockSpanned renders block into the transcript. spanFor (optional)
@@ -2907,13 +2963,20 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		// Trailing newline normalization: count lines before padding.
 		block = strings.TrimRight(block, "\n")
 		rawPadded := padBlock(block)
-		rawPadded = m.applySelectionToBlock(rawPadded, lineNo)
+		// Only apply selection highlighting to blocks that intersect the
+		// selection range. This reduces the O(all-items) ANSI-strip+rebuild
+		// cost to O(selected items) during drag selection.
+		n := lineCount(rawPadded)
+		blockEnd := lineNo + n
+		if m.selectionIntersectsLines(lineNo, blockEnd) {
+			rawPadded = m.applySelectionToBlock(rawPadded, lineNo)
+		}
 		padded := m.paintTranscriptBlock(rawPadded)
 		start := lineNo
-		n := lineCount(rawPadded)
 		b.WriteString(padded)
 		b.WriteString("\n")
-		appendPlainSpanned(padded, spanFor)
+		pl, cs := buildPlainSpanned(padded, spanFor)
+		appendPlainSpanned(pl, cs)
 		gap := m.paintRow("", m.width)
 		b.WriteString(gap)
 		b.WriteString("\n") // vertical gap between messages
@@ -2928,28 +2991,153 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 		return appendBlockSpanned(itemIdx, kind, block, nil)
 	}
 
+	// useCached replays a cached renderedBlock into the output. If a selection
+	// is active and intersects the block's line range, we re-apply the
+	// selection highlight to the cached raw block (cheap — only for the few
+	// blocks in the selected region). All other blocks use the cached output
+	// verbatim, skipping all string work.
+	useCached := func(itemIdx int, kind events.ItemKind, cached renderedBlock) int {
+		raw := cached.raw
+		n := cached.lineCount - 1 // lineCount includes the gap separator
+		blockEnd := lineNo + n
+		var painted string
+		if m.selectionIntersectsLines(lineNo, blockEnd) {
+			// Re-apply selection only for this block (rare fast path).
+			highlighted := m.applySelectionToBlock(raw, lineNo)
+			painted = m.paintTranscriptBlock(highlighted)
+		} else {
+			painted = cached.painted
+		}
+		start := lineNo
+		b.WriteString(painted)
+		b.WriteString("\n")
+		appendPlainSpanned(cached.plainLines, cached.spans)
+		// Gap row (empty painted row for visual separation).
+		gap := m.paintRow("", m.width)
+		b.WriteString(gap)
+		b.WriteString("\n")
+		plainLines = append(plainLines, stripANSI(gap))
+		contentSpans = append(contentSpans, [2]int{0, 0})
+		lineNo += cached.lineCount
+		hits = append(hits, hitRegion{start: start, end: start + n, itemIdx: itemIdx, kind: kind})
+		return start
+	}
+
+	// buildAndCache renders a block, stores the result in the item render
+	// cache under key, and returns the start line. This is the slow path
+	// (used only for cache misses, i.e. newly added or changed items).
+	buildAndCache := func(itemIdx int, kind events.ItemKind, key, block string, spanFor func(i int, plain string) [2]int) int {
+		if block == "" {
+			return lineNo
+		}
+		block = strings.TrimRight(block, "\n")
+		rawPadded := padBlock(block)
+		n := lineCount(rawPadded)
+		blockEnd := lineNo + n
+		rawForCache := rawPadded // save before possible selection mutation
+		if m.selectionIntersectsLines(lineNo, blockEnd) {
+			rawPadded = m.applySelectionToBlock(rawPadded, lineNo)
+		}
+		painted := m.paintTranscriptBlock(rawPadded)
+		paintedClean := m.paintTranscriptBlock(rawForCache) // selection-free for cache
+		start := lineNo
+		b.WriteString(painted)
+		b.WriteString("\n")
+		pl, cs := buildPlainSpanned(painted, spanFor)
+		appendPlainSpanned(pl, cs)
+		gap := m.paintRow("", m.width)
+		b.WriteString(gap)
+		b.WriteString("\n")
+		plainLines = append(plainLines, stripANSI(gap))
+		contentSpans = append(contentSpans, [2]int{0, 0})
+		lineNo += n + 1
+		hits = append(hits, hitRegion{start: start, end: start + n, itemIdx: itemIdx, kind: kind})
+		// Build cache entry using the selection-free painted block and plain
+		// lines derived from the unselected raw block.
+		plClean, csClean := buildPlainSpanned(paintedClean, spanFor)
+		m.itemRenderCache[key] = renderedBlock{
+			raw:        rawForCache,
+			painted:    paintedClean,
+			plainLines: plClean,
+			spans:      csClean,
+			lineCount:  n + 1,
+		}
+		return start
+	}
+
+	// isLastStreamingAgent returns true if this is the last ItemAgent that is
+	// still being streamed (its content is changing every event). Such items
+	// must bypass the cache to stay current.
+	lastStreamingAgentIdx := -1
+	if m.tr.Streaming {
+		for i := len(m.tr.Items) - 1; i >= 0; i-- {
+			if m.tr.Items[i].Kind == events.ItemAgent {
+				lastStreamingAgentIdx = i
+				break
+			}
+		}
+	}
+
 	for i, it := range m.tr.Items {
 		switch it.Kind {
 		case events.ItemUser:
-			appendBlockSpanned(i, it.Kind, m.renderUserBubble(it.Content, it.Expanded, cw), userBubbleContentSpan)
+			// User bubbles are cacheable (content never changes after submit).
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content, it.Expanded, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, m.renderUserBubble(it.Content, it.Expanded, cw), userBubbleContentSpan)
+			}
+
 		case events.ItemAgent:
 			content := strings.TrimRight(it.Content, "\n")
 			if content == "" {
 				continue
 			}
-			// Provisional = interstitial during tool loop (Studio sticky agent).
-			// Show as Thinking (muted, replaceable); finalize to full markdown on Done.
-			if it.Provisional {
-				appendBlock(i, it.Kind, m.renderThinkingBubble(content, cw))
+			// Provisional interstitial text and the currently-streaming agent
+			// bubble bypass the cache — their content changes every event.
+			if it.Provisional || i == lastStreamingAgentIdx {
+				if it.Provisional {
+					appendBlock(i, it.Kind, m.renderThinkingBubble(content, cw))
+				} else {
+					md := m.renderAgentMarkdown(content, cw)
+					if md == "" {
+						md = th.Agent.Width(cw).Render(content)
+					}
+					if it.RoutingModel != "" {
+						var badge string
+						switch it.RoutingTier {
+						case "strong":
+							badge = " 🧠"
+						case "medium":
+							badge = " ⚙️"
+						default:
+							badge = " ⚡"
+						}
+						badgeRendered := th.Muted.Render(badge)
+						badgeW := lipgloss.Width(badgeRendered)
+						lines := strings.Split(md, "\n")
+						lastLineW := lipgloss.Width(lines[len(lines)-1])
+						if lastLineW+badgeW+1 <= cw {
+							pad := cw - lastLineW - badgeW
+							if pad < 1 {
+								pad = 1
+							}
+							lines[len(lines)-1] = lines[len(lines)-1] + strings.Repeat(" ", pad) + badgeRendered
+							md = strings.Join(lines, "\n")
+						} else {
+							md = md + "\n" + badgeRendered
+						}
+					}
+					appendBlockSpanned(i, it.Kind, md, codeGutterContentSpan)
+				}
 				continue
 			}
+			// Finalized agent items are cacheable.
 			md := m.renderAgentMarkdown(content, cw)
 			if md == "" {
 				md = th.Agent.Width(cw).Render(content)
 			}
-			// Append routing badge when Auto routing is active for this response.
-			// Right-aligned on the last line when space allows, to avoid extra vertical space.
-			// 🧠 strong · ⚙️ medium · ⚡ weak.
 			if it.RoutingModel != "" {
 				var badge string
 				switch it.RoutingTier {
@@ -2962,11 +3150,9 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 				}
 				badgeRendered := th.Muted.Render(badge)
 				badgeW := lipgloss.Width(badgeRendered)
-				// Find the last line and check if the badge fits inline.
 				lines := strings.Split(md, "\n")
 				lastLineW := lipgloss.Width(lines[len(lines)-1])
 				if lastLineW+badgeW+1 <= cw {
-					// Right-align on the last line.
 					pad := cw - lastLineW - badgeW
 					if pad < 1 {
 						pad = 1
@@ -2974,27 +3160,78 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 					lines[len(lines)-1] = lines[len(lines)-1] + strings.Repeat(" ", pad) + badgeRendered
 					md = strings.Join(lines, "\n")
 				} else {
-					// No room — append below as fallback.
 					md = md + "\n" + badgeRendered
 				}
 			}
-			appendBlockSpanned(i, it.Kind, md, codeGutterContentSpan)
+			cacheKey := itemCacheKey(cw, it.Kind, md, it.Expanded, it.RoutingTier, it.RoutingModel)
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, md, codeGutterContentSpan)
+			}
+
 		case events.ItemThinking:
 			appendBlock(i, it.Kind, m.renderThinkingBubble(it.Content, cw))
+
 		case events.ItemActivity:
-			appendBlockSpanned(i, it.Kind, m.renderActivity(it, cw), codeGutterContentSpan)
+			// Activity folds change while tools are running (steps added); only
+			// cache when all steps are complete (no "running" step).
+			hasRunning := false
+			for _, s := range it.Steps {
+				if s.Status == "running" {
+					hasRunning = true
+					break
+				}
+			}
+			if hasRunning || m.tr.Streaming {
+				appendBlockSpanned(i, it.Kind, m.renderActivity(it, cw), codeGutterContentSpan)
+			} else {
+				// Use summary+step names as cache key content (avoid hashing full args/results).
+				cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Summary, it.Expanded, it.RoutingTier, it.RoutingModel)
+				if cached, ok := m.itemRenderCache[cacheKey]; ok {
+					useCached(i, it.Kind, cached)
+				} else {
+					buildAndCache(i, it.Kind, cacheKey, m.renderActivity(it, cw), codeGutterContentSpan)
+				}
+			}
+
 		case events.ItemFileDiff:
-			appendBlockSpanned(i, it.Kind, m.renderFileDiff(it, cw), codeGutterContentSpan)
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.DiffVerification, it.Expanded, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, m.renderFileDiff(it, cw), codeGutterContentSpan)
+			}
+
 		case events.ItemSystem:
-			appendBlock(i, it.Kind, th.System.Width(cw).Render(it.Content))
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, th.System.Width(cw).Render(it.Content), nil)
+			}
+
 		case events.ItemCompaction:
-			appendBlock(i, it.Kind, th.System.Width(cw).Render(it.Content))
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, th.System.Width(cw).Render(it.Content), nil)
+			}
+
 		case events.ItemError:
-			appendBlock(i, it.Kind, th.Error.Width(cw).Render(it.Content))
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content, false, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, th.Error.Width(cw).Render(it.Content), nil)
+			}
+
 		case events.ItemApproval:
 			if it.ApprovalKind == "plan" {
 				continue // plan approval shown in footer, not transcript
 			}
+			// Approval items are interactive (cursor changes) — skip cache.
 			var ab strings.Builder
 			ab.WriteString(th.Approval.Width(cw).Render("⚠ " + it.Content))
 			if len(it.Options) > 0 {
@@ -3004,23 +3241,51 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			ab.WriteByte('\n')
 			ab.WriteString(th.Muted.Width(cw).Render("Type Yes or No (or an option) and press Enter."))
 			appendBlock(i, it.Kind, ab.String())
+
 		case events.ItemNetworkDenial:
+			// Network denial items are interactive — skip cache.
 			appendBlock(i, it.Kind, m.renderNetworkDenialTranscript(it, cw))
+
 		case events.ItemArtifact:
-			block, rows := m.renderArtifactList(it, cw)
-			start := appendBlock(i, it.Kind, block)
-			for _, row := range rows {
-				artifactHits = append(artifactHits, artifactHit{
-					start:       start + row.line,
-					end:         start + row.line + 1,
-					itemIdx:     i,
-					artifactIdx: row.artifactIdx,
-				})
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Path, false, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				start := useCached(i, it.Kind, cached)
+				// Artifact hit regions within the block are re-derived from the
+				// cached block. Since the artifact list is stable, we re-render
+				// only to get the row indices — the painted output comes from cache.
+				_, rows := m.renderArtifactList(it, cw)
+				for _, row := range rows {
+					artifactHits = append(artifactHits, artifactHit{
+						start:       start + row.line,
+						end:         start + row.line + 1,
+						itemIdx:     i,
+						artifactIdx: row.artifactIdx,
+					})
+				}
+			} else {
+				block, rows := m.renderArtifactList(it, cw)
+				start := buildAndCache(i, it.Kind, cacheKey, block, nil)
+				for _, row := range rows {
+					artifactHits = append(artifactHits, artifactHit{
+						start:       start + row.line,
+						end:         start + row.line + 1,
+						itemIdx:     i,
+						artifactIdx: row.artifactIdx,
+					})
+				}
 			}
+
 		case events.ItemDelegation:
+			// Delegation items update frequently (live timer, task state) — skip cache.
 			appendBlock(i, it.Kind, m.renderDelegationItem(it, cw))
+
 		case events.ItemPlan:
-			appendBlockSpanned(i, it.Kind, m.renderPlanDocument(it, cw), planDocumentContentSpan)
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content+string(it.PlanStatus), it.Expanded, "", "")
+			if cached, ok := m.itemRenderCache[cacheKey]; ok {
+				useCached(i, it.Kind, cached)
+			} else {
+				buildAndCache(i, it.Kind, cacheKey, m.renderPlanDocument(it, cw), planDocumentContentSpan)
+			}
 		}
 	}
 	m.transcriptPlainLines = plainLines

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -2195,6 +2195,77 @@ func itemCacheKey(width int, kind events.ItemKind, content string, expanded bool
 	return strconv.Itoa(width) + "\x00" + string(kind) + "\x00" + strconv.FormatBool(expanded) + "\x00" + routingTier + "\x00" + routingModel + "\x00" + content
 }
 
+// stepsCacheDigest computes a compact, stable hash digest of steps for cache-key
+// inclusion. This prevents collisions between activities with identical summaries
+// but different underlying steps (e.g., "Read 1 file" reading different files).
+// Uses FNV-1a over step fields: name|status|args|result.
+func stepsCacheDigest(steps []events.ToolStep) string {
+	if len(steps) == 0 {
+		return ""
+	}
+	// FNV-1a 64-bit hash for compact output
+	hash := uint64(14695981039346656037) // FNV offset basis
+	const fnvPrime uint64 = 1099511628211
+	for _, s := range steps {
+		// Hash name|status|argsDigest|resultDigest to avoid very long input
+		fields := s.Name + "|" + s.Status + "|" + argsCacheDigest(s.Args) + "|" + resultCacheDigest(s.Result)
+		for _, b := range []byte(fields) {
+			hash ^= uint64(b)
+			hash *= fnvPrime
+		}
+	}
+	return strconv.FormatInt(int64(hash), 16)
+}
+
+// argsCacheDigest computes a compact hash of tool args map for cache keys.
+// Returns empty string for nil args, otherwise a short hex digest.
+func argsCacheDigest(args map[string]any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	// Sort keys for determinism and hash the serialized form
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	hash := uint64(14695981039346656037) // FNV offset basis
+	const fnvPrime uint64 = 1099511628211
+	for _, k := range keys {
+		// Include key and a compact stringification of the value
+		valStr := fmt.Sprintf("%v", args[k])
+		if len(valStr) > 50 {
+			valStr = valStr[:50] // Truncate very large values
+		}
+		entry := k + ":" + valStr
+		for _, b := range []byte(entry) {
+			hash ^= uint64(b)
+			hash *= fnvPrime
+		}
+	}
+	return strconv.FormatInt(int64(hash), 16)
+}
+
+// resultCacheDigest computes a compact hash of a tool result for cache keys.
+func resultCacheDigest(result any) string {
+	if result == nil {
+		return ""
+	}
+	// For most results use a short string representation; avoid hashing entire large outputs
+	resultStr := fmt.Sprintf("%v", result)
+	if len(resultStr) > 50 {
+		resultStr = resultStr[:50]
+	}
+	hash := uint64(14695981039346656037)
+	const fnvPrime uint64 = 1099511628211
+	for _, b := range []byte(resultStr) {
+		hash ^= uint64(b)
+		hash *= fnvPrime
+	}
+	return strconv.FormatInt(int64(hash), 16)
+}
+
 func waitEvent(ch <-chan events.Event) tea.Cmd {
 	return func() tea.Msg {
 		ev, ok := <-ch
@@ -3186,8 +3257,9 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			if hasRunning || m.tr.Streaming {
 				appendBlockSpanned(i, it.Kind, m.renderActivity(it, cw), codeGutterContentSpan)
 			} else {
-				// Use summary+step names as cache key content (avoid hashing full args/results).
-				cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Summary, it.Expanded, it.RoutingTier, it.RoutingModel)
+				// Include step digest in cache key to prevent collisions between activities
+				// with identical summaries but different steps (e.g., "Read 1 file" vs different files).
+				cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.Summary+stepsCacheDigest(it.Steps), it.Expanded, it.RoutingTier, it.RoutingModel)
 				if cached, ok := m.itemRenderCache[cacheKey]; ok {
 					useCached(i, it.Kind, cached)
 				} else {
@@ -3196,7 +3268,14 @@ func (m *model) renderTranscript() (string, []hitRegion, []artifactHit) {
 			}
 
 		case events.ItemFileDiff:
-			cacheKey := itemCacheKey(cw, it.Kind, it.Content+it.DiffVerification, it.Expanded, "", "")
+			// Include ToolName and args digest when DiffVerification is empty (fallback path).
+			// This prevents collisions between file-diffs with same content but different
+			// args (which are used by DiffFromToolArgs when verification_context is unavailable).
+			suffix := it.DiffVerification
+			if suffix == "" {
+				suffix = it.ToolName + argsCacheDigest(it.Args)
+			}
+			cacheKey := itemCacheKey(cw, it.Kind, it.Content+suffix, it.Expanded, "", "")
 			if cached, ok := m.itemRenderCache[cacheKey]; ok {
 				useCached(i, it.Kind, cached)
 			} else {

--- a/pkg/tui/app_render_test.go
+++ b/pkg/tui/app_render_test.go
@@ -1111,3 +1111,141 @@ func TestStickyExpandedResetsWhenPinnedItemChanges(t *testing.T) {
 		t.Fatalf("stickyPinnedIdx should be restored to %d, got %d", pinnedAtBottom, m.stickyPinnedIdx)
 	}
 }
+
+// TestActivityCollisionPrevention verifies that two activities with identical
+// summaries but different steps do not collide in the render cache.
+// This is a regression test for Issue #1 in PR #506 review.
+func TestActivityCollisionPrevention(t *testing.T) {
+	th := DefaultTheme()
+	m := model{theme: th, width: 80, tr: events.NewTranscript()}
+	m.itemRenderCache = make(map[string]renderedBlock)
+
+	// Create two activities that summarize identically ("Read 1 file") but read different files.
+	// They should render differently (different file names in output) and have different cache keys.
+	activity1 := events.Item{
+		Kind:     events.ItemActivity,
+		Summary:  "Read 1 file",
+		Expanded: false,
+		Steps: []events.ToolStep{
+			{
+				Name:   "read_file",
+				Status: "complete",
+				Args:   map[string]any{"path": "/path/to/file1.go"},
+				Result: "file1 contents",
+			},
+		},
+	}
+
+	activity2 := events.Item{
+		Kind:     events.ItemActivity,
+		Summary:  "Read 1 file", // Same summary!
+		Expanded: false,
+		Steps: []events.ToolStep{
+			{
+				Name:   "read_file",
+				Status: "complete",
+				Args:   map[string]any{"path": "/path/to/file2.go"},
+				Result: "file2 contents",
+			},
+		},
+	}
+
+	// Render activity1
+	key1 := itemCacheKey(80, activity1.Kind, activity1.Content+activity1.Summary+stepsCacheDigest(activity1.Steps),
+		activity1.Expanded, activity1.RoutingTier, activity1.RoutingModel)
+	render1 := m.renderActivity(activity1, 80)
+
+	// Render activity2
+	key2 := itemCacheKey(80, activity2.Kind, activity2.Content+activity2.Summary+stepsCacheDigest(activity2.Steps),
+		activity2.Expanded, activity2.RoutingTier, activity2.RoutingModel)
+	render2 := m.renderActivity(activity2, 80)
+
+	// Keys must be different because steps are different, even though summaries are identical
+	if key1 == key2 {
+		t.Errorf("Cache keys should differ for activities with different steps but same summary; got same key: %s", key1)
+	}
+
+	// Rendered outputs must be different (file1 vs file2)
+	if render1 == render2 {
+		t.Fatalf("Activities with different steps should render differently")
+	}
+
+	// Each output should mention its own file
+	if !strings.Contains(render1, "file1") {
+		t.Errorf("render1 should contain 'file1': %s", render1)
+	}
+	if !strings.Contains(render2, "file2") {
+		t.Errorf("render2 should contain 'file2': %s", render2)
+	}
+}
+
+// TestFileDiffCollisionPrevention verifies that two file-diffs with empty
+// DiffVerification but different args do not collide in the render cache.
+// This is a regression test for Issue #2 in PR #506 review.
+func TestFileDiffCollisionPrevention(t *testing.T) {
+	th := DefaultTheme()
+	m := model{theme: th, width: 80, tr: events.NewTranscript(), workDir: "/tmp"}
+	m.itemRenderCache = make(map[string]renderedBlock)
+
+	// Create two file-diffs with empty DiffVerification but different args.
+	// They should render differently (different old_string/new_string) and have different cache keys.
+	filediff1 := events.Item{
+		Kind:             events.ItemFileDiff,
+		ToolName:         "edit_file",
+		DiffVerification: "", // Empty, so fallback to args
+		Path:             "/tmp/test.txt",
+		Expanded:         false,
+		Args: map[string]any{
+			"path":       "/tmp/test.txt",
+			"old_string": "hello",
+			"new_string": "hello world",
+		},
+	}
+
+	filediff2 := events.Item{
+		Kind:             events.ItemFileDiff,
+		ToolName:         "edit_file",
+		DiffVerification: "", // Empty, so fallback to args
+		Path:             "/tmp/test.txt",
+		Expanded:         false,
+		Args: map[string]any{
+			"path":       "/tmp/test.txt",
+			"old_string": "goodbye",
+			"new_string": "goodbye world",
+		},
+	}
+
+	// Render filediff1
+	suffix1 := filediff1.DiffVerification
+	if suffix1 == "" {
+		suffix1 = filediff1.ToolName + argsCacheDigest(filediff1.Args)
+	}
+	key1 := itemCacheKey(80, filediff1.Kind, filediff1.Content+suffix1, filediff1.Expanded, "", "")
+	render1 := m.renderFileDiff(filediff1, 80)
+
+	// Render filediff2
+	suffix2 := filediff2.DiffVerification
+	if suffix2 == "" {
+		suffix2 = filediff2.ToolName + argsCacheDigest(filediff2.Args)
+	}
+	key2 := itemCacheKey(80, filediff2.Kind, filediff2.Content+suffix2, filediff2.Expanded, "", "")
+	render2 := m.renderFileDiff(filediff2, 80)
+
+	// Keys must be different because args (old/new strings) are different
+	if key1 == key2 {
+		t.Errorf("Cache keys should differ for file-diffs with different args; got same key: %s", key1)
+	}
+
+	// Rendered outputs must be different (hello vs goodbye)
+	if render1 == render2 {
+		t.Fatalf("File-diffs with different args should render differently")
+	}
+
+	// Each output should mention its own text
+	if !strings.Contains(render1, "hello") {
+		t.Errorf("render1 should contain 'hello': %s", render1)
+	}
+	if !strings.Contains(render2, "goodbye") {
+		t.Errorf("render2 should contain 'goodbye': %s", render2)
+	}
+}

--- a/pkg/tui/render_benchmark_test.go
+++ b/pkg/tui/render_benchmark_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/SAP/astonish/pkg/tui/events"
+)
+
+// BenchmarkRenderTranscript200Items measures refreshViewport with a fully
+// populated 200-item session. After the first call the item render cache is
+// warm, so subsequent iterations exercise the cached fast path — the expected
+// bottleneck in long-running sessions.
+func BenchmarkRenderTranscript200Items(b *testing.B) {
+	m := newCodeModel(b)
+	for i := 0; i < 50; i++ {
+		m.tr.Apply(events.Event{Kind: events.KindUser, Text: "Tell me about feature"})
+		m.tr.Apply(events.Event{Kind: events.KindText, Text: "Here is a response with code:\n```go\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n```\nExplanation."})
+		m.tr.Apply(events.Event{Kind: events.KindToolCall, ToolName: "read_file"})
+		m.tr.Apply(events.Event{Kind: events.KindToolResult, ToolName: "read_file", Text: "file contents"})
+		m.tr.Apply(events.Event{Kind: events.KindDone})
+	}
+	// Warm up the cache.
+	m.refreshViewport()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.refreshViewport()
+	}
+}
+
+// BenchmarkRenderTranscriptWithSelection measures refreshViewport when a drag
+// selection spans part of the transcript. This was the most painful path before
+// the fix: applySelectionToBlock was called for every item in the transcript.
+func BenchmarkRenderTranscriptWithSelection(b *testing.B) {
+	m := newCodeModel(b)
+	for i := 0; i < 50; i++ {
+		m.tr.Apply(events.Event{Kind: events.KindUser, Text: "Question"})
+		m.tr.Apply(events.Event{Kind: events.KindText, Text: "Response text with some **bold** and _italic_ content."})
+		m.tr.Apply(events.Event{Kind: events.KindDone})
+	}
+	// Warm up the cache.
+	m.refreshViewport()
+	// Simulate an active drag selection spanning a narrow range in the middle.
+	m.selecting = true
+	m.selectionMoved = true
+	m.selectionStart = selectionPoint{line: 10, col: 0}
+	m.selectionEnd = selectionPoint{line: 14, col: 20}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.refreshViewport()
+	}
+}
+
+// BenchmarkRenderTranscriptColdCache measures the cold-cache path — first call
+// after a session load where nothing is cached yet.
+func BenchmarkRenderTranscriptColdCache(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		m := newCodeModel(b)
+		for j := 0; j < 50; j++ {
+			m.tr.Apply(events.Event{Kind: events.KindUser, Text: "Question"})
+			m.tr.Apply(events.Event{Kind: events.KindText, Text: "Response"})
+			m.tr.Apply(events.Event{Kind: events.KindDone})
+		}
+		b.StartTimer()
+		m.refreshViewport()
+	}
+}

--- a/pkg/tui/render_cache_test.go
+++ b/pkg/tui/render_cache_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/SAP/astonish/pkg/tui/events"
 )
 
-func newCodeModel(t *testing.T) model {
+func newCodeModel(t testing.TB) model {
 	t.Helper()
 	m := newModel(context.Background(), Config{
 		Backend: staticBackend{info: backend.Info{Mode: "code"}},
@@ -59,10 +59,17 @@ func TestWindowResizeClearsMarkdownCache(t *testing.T) {
 	if len(m.mdCache) == 0 {
 		t.Fatal("expected cache to be populated")
 	}
+	// Verify that after resize, the old-width (80) key is gone. The resize
+	// handler nil-ifies the cache before refreshViewport, which then repopulates
+	// with the new width (120) — so old-width entries must not survive.
+	oldKey := "80\x00hello world"
+	if _, ok := m.mdCache[oldKey]; !ok {
+		t.Skip("cache key format changed; skipping stale-key check")
+	}
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	nm := next.(model)
-	if nm.mdCache != nil && len(nm.mdCache) != 0 {
-		t.Fatalf("expected markdown cache cleared on resize, got %d entries", len(nm.mdCache))
+	if _, ok := nm.mdCache[oldKey]; ok {
+		t.Fatalf("old-width cache key survived resize: %q", oldKey)
 	}
 }
 

--- a/pkg/tui/render_cache_test.go
+++ b/pkg/tui/render_cache_test.go
@@ -59,17 +59,20 @@ func TestWindowResizeClearsMarkdownCache(t *testing.T) {
 	if len(m.mdCache) == 0 {
 		t.Fatal("expected cache to be populated")
 	}
-	// Verify that after resize, the old-width (80) key is gone. The resize
-	// handler nil-ifies the cache before refreshViewport, which then repopulates
-	// with the new width (120) — so old-width entries must not survive.
-	oldKey := "80\x00hello world"
-	if _, ok := m.mdCache[oldKey]; !ok {
-		t.Skip("cache key format changed; skipping stale-key check")
-	}
+	// After resize the handler nil-ifies both caches before refreshViewport
+	// repopulates them at the new width. No key with the old width prefix (80)
+	// must survive in mdCache — verified by prefix, not by a fragile hardcoded key.
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	nm := next.(model)
-	if _, ok := nm.mdCache[oldKey]; ok {
-		t.Fatalf("old-width cache key survived resize: %q", oldKey)
+	for k := range nm.mdCache {
+		if strings.HasPrefix(k, "80\x00") {
+			t.Fatalf("old-width (80) mdCache key survived resize: %q", k)
+		}
+	}
+	for k := range nm.itemRenderCache {
+		if strings.HasPrefix(k, "80\x00") {
+			t.Fatalf("old-width (80) itemRenderCache key survived resize: %q", k)
+		}
 	}
 }
 

--- a/pkg/tui/selection.go
+++ b/pkg/tui/selection.go
@@ -104,6 +104,19 @@ func selectionText(lines []string, spans [][2]int, start, end selectionPoint) st
 	return strings.Trim(strings.Join(out, "\n"), "\n")
 }
 
+// selectionIntersectsLines returns true when the current drag selection
+// overlaps the half-open line range [startLine, endLine). It returns false
+// when no selection is active or the user hasn't moved the mouse yet, so
+// callers can skip the (expensive) ANSI-strip + highlight pass for blocks
+// that are nowhere near the selected region.
+func (m model) selectionIntersectsLines(startLine, endLine int) bool {
+	if !m.selecting || !m.selectionMoved {
+		return false
+	}
+	from, to := normalizeSelection(m.selectionStart, m.selectionEnd)
+	return from.line < endLine && to.line >= startLine
+}
+
 func normalizeSelection(a, b selectionPoint) (selectionPoint, selectionPoint) {
 	if a.line > b.line || (a.line == b.line && a.col > b.col) {
 		return b, a

--- a/pkg/tui/selection_test.go
+++ b/pkg/tui/selection_test.go
@@ -10,6 +10,72 @@ import (
 	"github.com/SAP/astonish/pkg/tui/events"
 )
 
+func TestSelectionIntersectsLines(t *testing.T) {
+	// Helper to build a model with an active selection.
+	withSel := func(start, end selectionPoint) model {
+		return model{
+			selecting:      true,
+			selectionMoved: true,
+			selectionStart: start,
+			selectionEnd:   end,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		m          model
+		blockStart int
+		blockEnd   int
+		want       bool
+	}{
+		{
+			name:       "selection not moved yet",
+			m:          model{selecting: true, selectionMoved: false, selectionStart: selectionPoint{0, 0}, selectionEnd: selectionPoint{10, 5}},
+			blockStart: 0, blockEnd: 5, want: false,
+		},
+		{
+			name:       "selection before block",
+			m:          withSel(selectionPoint{0, 0}, selectionPoint{2, 5}),
+			blockStart: 5, blockEnd: 10, want: false,
+		},
+		{
+			name:       "selection after block",
+			m:          withSel(selectionPoint{10, 0}, selectionPoint{15, 5}),
+			blockStart: 0, blockEnd: 5, want: false,
+		},
+		{
+			name:       "selection overlaps start of block",
+			m:          withSel(selectionPoint{0, 0}, selectionPoint{3, 5}),
+			blockStart: 2, blockEnd: 8, want: true,
+		},
+		{
+			name:       "selection overlaps end of block",
+			m:          withSel(selectionPoint{6, 0}, selectionPoint{12, 5}),
+			blockStart: 2, blockEnd: 8, want: true,
+		},
+		{
+			name:       "selection entirely inside block",
+			m:          withSel(selectionPoint{3, 0}, selectionPoint{5, 5}),
+			blockStart: 2, blockEnd: 8, want: true,
+		},
+		{
+			name:       "block entirely inside selection",
+			m:          withSel(selectionPoint{0, 0}, selectionPoint{20, 5}),
+			blockStart: 5, blockEnd: 10, want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.m.selectionIntersectsLines(tc.blockStart, tc.blockEnd)
+			if got != tc.want {
+				t.Fatalf("selectionIntersectsLines(%d, %d) = %v, want %v",
+					tc.blockStart, tc.blockEnd, got, tc.want)
+			}
+		})
+	}
+}
+
+
 func TestSelectionTextSingleAndMultiLine(t *testing.T) {
 	lines := []string{"hello world", "second line", "third"}
 	got := selectionText(lines, nil, selectionPoint{line: 0, col: 6}, selectionPoint{line: 1, col: 6})


### PR DESCRIPTION
## Overview

This PR contains two complementary features: a K8s sandbox recording fix and a TUI transcript render-cache optimization with collision prevention.

### 1. K8s Sandbox Recording Fix (K8s xdpyinfo error)

**Problem:** When running `run_drill` with browser recording enabled on Kubernetes, drills failed with:
```
ERR browser_start_recording: probe display size: no dimensions in xdpyinfo output: ""
```

**Root cause:** `kubectl exec` runs commands in the pod's **base namespace** (thin Debian image), not inside the chroot overlay at `/sandbox/rootfs` where `xdpyinfo`, `ffmpeg`, and other tools are installed.

**Solution:** Added `backendShellCommand()` helper that wraps shell commands through `/usr/local/bin/astonish-shell` on K8s backends (which chroots into the overlay), while using plain `sh -c` on Docker (where overlay is root). Mirrors the pattern in `backend_mcp_transport.go`.

### 2. TUI Render-Cache with Collision Prevention

**Performance optimization:** Added item render cache that memoizes fully-rendered transcript blocks. Reduces rendering cost from O(all items) to O(new/changed items) on each viewport refresh. Includes smart caching guards for streaming/interactive items and per-item selection application.

**Visual-correctness fixes:** Identified and fixed two collision bugs from PR review:
- **Activity collision:** Two activities with identical summaries but different steps (e.g., "Read 1 file" reading different files) could display the wrong block. Fixed by including step digest in cache key.
- **FileDiff collision:** Two file-diffs with empty `DiffVerification` but different args could collide. Fixed by including ToolName and args digest in cache key when using fallback rendering path.

**Added regression tests:**
- `TestActivityCollisionPrevention` verifies activities with same summary but different steps don't collide.
- `TestFileDiffCollisionPrevention` verifies file-diffs with different args don't collide.

## Changes

### K8s Recording Fix
- `pkg/sandbox/backend_browser_wire.go`: Added `backendShellCommand()` helper, wrapped 4 exec calls in `startBackendRecording()`
- `pkg/sandbox/backend_browser_wire_test.go`: Added unit tests for wrapper behavior and end-to-end K8s recording test

### TUI Render-Cache
- `pkg/tui/app.go`: Added cache digest helpers, included digests in activity and file-diff cache keys
- `pkg/tui/app_render_test.go`: Added collision regression tests

## Backward Compatibility
✅ Docker backend behavior unchanged  
✅ OpenShell backend unaffected  
✅ Non-cached item types unaffected  
✅ Breaking changes: None

## Tests
- All sandbox package tests pass
- All TUI tests pass including new collision regression tests
- Full build verified clean
- No linting issues
